### PR TITLE
adding 1d advanced indexing support to inc_subtensor and set_subtensor

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4919,7 +4919,10 @@ class AdvancedIncSubtensor1(Op):
         if x_.type.ndim == 0:
             raise TypeError('cannot index into a scalar')
         if y_.type.ndim > x_.type.ndim:
-            raise TypeError('cannot reduce dimensionality of y')
+            opname = 'increment'
+            raise TypeError('cannot %s x subtensor with ndim=%s'
+            ' by y with ndim=%s to x subtensor with ndim=%s '%(
+                opname, x_.type.ndim, y_.type.ndim ))
 
         return Apply(self, [x_, y_, ilist_], [x_.type()])
 

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -2426,6 +2426,9 @@ class TestIncSubtensor1(unittest.TestCase):
         aval = f([.4, .9, .1], [1,2])
         assert numpy.allclose(aval, [.4, 3.9, 3.1])
 
+    def test_assigning_matrix_to_vector_selection(self):
+        self.assertRaises(TypeError,
+                lambda : inc_subtensor(self.v[self.adv1q], fmatrix()))
 
 
 class T_Join_and_Split(unittest.TestCase):


### PR DESCRIPTION
The inc_subtensor and set_subtensor functions in tensor.basic used to crash if you try to do something like inc_subtensor(x[v] = y) and v was an integer vector that triggered advanced indexing on x.  This patch fixes this.
