### PR TITLE
Rop has as many outputs as f and Lop as wrt which needs to be reflected i

### DIFF
--- a/theano/tensor/tensor_grad.py
+++ b/theano/tensor/tensor_grad.py
@@ -60,7 +60,7 @@ def Rop(f, wrt, eval_points):
     if not isinstance(eval_points, (list, tuple)):
         eval_points = [eval_points]
 
-    if not (using_list or using_tuple):
+    if not isinstance(f, (list, tuple)):
         f = [f]
 
     assert len(wrt) == len(eval_points)


### PR DESCRIPTION
Rop has as many outputs as f and Lop as wrt. Therefore using_list or using_tuple should be decided based on f for Rop and based on wrt for Lop. 
