### PR TITLE
TST: refine the nose test-matching pattern.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,2 @@
-[nosetest]
-match=^test
-nocapture=1
+[nosetests]
+match=^[Tt]est(?:[\b_\.]|$)


### PR DESCRIPTION
This replaces our currently useless setup.cfg (has a [nosetest] instead
of [nosetests] section header, therefore none of the settings have any
effect) with one that replaces the pattern that nose uses to look for
tests with one that only looks for files/functions/methods that _start_
with the word test (followed by _ or . or a word boundary character, so
'testify' or something like that doesn't match).

I'm still running the buildbot script to make sure this doesn't orphan
any current tests, so **please don't merge yet** until I've made sure.
