### PR TITLE
Deprecated tensor.shared (renamed tensor._shared)

### DIFF
--- a/theano/compile/tests/test_pfunc.py
+++ b/theano/compile/tests/test_pfunc.py
@@ -645,7 +645,7 @@ class Test_aliasing_rules(unittest.TestCase):
     """
 
     def shared(self, x):
-        return tensor.shared(x)
+        return tensor._shared(x)
 
     def test_shared_constructor_copies(self):
         # shared constructor makes copy

--- a/theano/sandbox/test_neighbours.py
+++ b/theano/sandbox/test_neighbours.py
@@ -333,7 +333,7 @@ def speed_neibs_wrap_centered():
 
 def test_neibs_grad():
     shape = (2,3,4,4)
-    images = T.shared(numpy.arange(numpy.prod(shape), dtype='float32').reshape(shape))
+    images = shared(numpy.arange(numpy.prod(shape), dtype='float32').reshape(shape))
 
     cost = T.sum(T.sqr(images2neibs(images, (2,2))), axis=[0,1])
 

--- a/theano/sandbox/test_rng_mrg.py
+++ b/theano/sandbox/test_rng_mrg.py
@@ -113,7 +113,7 @@ def test_consistency_cpu_serial():
     for i in range(n_streams):
         stream_rstate = curr_rstate.copy()
         for j in range(n_substreams):
-            rstate = tensor.shared(numpy.array([stream_rstate.copy()], dtype='int32'))
+            rstate = theano.shared(numpy.array([stream_rstate.copy()], dtype='int32'))
             new_rstate, sample = rng_mrg.mrg_uniform.new(rstate, ndim=None, dtype=config.floatX, size=(1,))
             # Not really necessary, just mimicking rng_mrg.MRG_RandomStreams' behavior
             sample.rstate = rstate
@@ -152,7 +152,7 @@ def test_consistency_cpu_parallel():
         for j in range(1, n_substreams):
             rstate.append(rng_mrg.ff_2p72(rstate[-1]))
         rstate = numpy.asarray(rstate)
-        rstate = tensor.shared(rstate)
+        rstate = theano.shared(rstate)
 
         new_rstate, sample = rng_mrg.mrg_uniform.new(rstate, ndim=None,
                 dtype=config.floatX, size=(n_substreams,))

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -2597,7 +2597,7 @@ def test_speed():
     if 1:
         r = numpy.arange(10000).astype(theano.config.floatX).reshape(-1,10)
         shared_r = theano.shared(r)
-        s_i = tensor.shared(numpy.array(1))
+        s_i = theano.shared(numpy.array(1))
         s_rinc = tensor.inc_subtensor(shared_r[s_i], shared_r[s_i-1],
                 tolerate_inplace_aliasing=True)
         theano.printing.debugprint(s_rinc)

--- a/theano/tensor/__init__.py
+++ b/theano/tensor/__init__.py
@@ -1,6 +1,9 @@
 """Define the tensor toplevel"""
 __docformat__ = "restructuredtext en"
 
+
+import warnings
+
 from basic import *
 
 import opt
@@ -21,7 +24,28 @@ from elemwise import \
     DimShuffle, Elemwise, CAReduce
 
 import sharedvar # adds shared-variable constructors
-from sharedvar import tensor_constructor as shared
+
+# We import as `_shared` instead of `shared` to avoid confusion between
+# `theano.shared` and `tensor._shared`.
+from sharedvar import tensor_constructor as _shared
+
+
+def shared(*args, **kw):
+    """
+    Backward-compatibility wrapper around `tensor._shared`.
+
+    Once the deprecation warning has been around for long enough, this function
+    can be deleted.
+    """
+    # Note that we do not use the DeprecationWarning class because it is
+    # ignored by default since python 2.7.
+    warnings.warn('`tensor.shared` is deprecated. You should probably be using'
+                  ' `theano.shared` instead (if you *really* intend to call '
+                  '`tensor.shared`, you can get rid of this warning by using '
+                  '`tensor._shared`).',
+                  stacklevel=2)
+    return _shared(*args, **kw)
+
 
 import nnet # used for softmax, sigmoid, etc.
 

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -12,7 +12,7 @@ from itertools import izip
 import numpy, theano
 #from copy import copy as python_copy
 
-from theano import gof, shared
+from theano import gof
 from theano.gof import Apply, Constant, Op, Type, Value, Variable
 
 

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -10,6 +10,7 @@ from numpy.testing import dec
 from numpy.testing.noseclasses import KnownFailureTest
 
 from theano.tensor import *
+from theano.tensor import _shared
 from theano.tensor import basic as tensor # for hidden symbols
 from theano.tensor import inplace
 
@@ -1796,7 +1797,7 @@ class T_subtensor(unittest.TestCase):
     """
     This is build in a way that allow to reuse it to test the equivalent gpu op.
     """
-    def __init__(self, name, shared=shared,
+    def __init__(self, name, shared=_shared,
                  sub=theano.tensor.basic.Subtensor,
                  inc_sub=theano.tensor.basic.IncSubtensor,
                  adv_sub1=theano.tensor.basic.AdvancedSubtensor1,
@@ -2361,7 +2362,7 @@ class T_subtensor(unittest.TestCase):
 
         for idx in idxs:
             # Should stay on the cpu.
-            idx_ = shared(numpy.asarray(idx))
+            idx_ = _shared(numpy.asarray(idx))
             t = n[idx_]
             gn = grad(sum(exp(t)), n)
             f = function([], [gn, gn.shape], mode=self.mode)
@@ -5175,7 +5176,7 @@ class test_size(unittest.TestCase):
     def test_shared(self):
         # NB: we also test higher order tensors at the same time.
         y = numpy.zeros((1, 2, 3, 4), dtype=config.floatX)
-        x = tensor.shared(y)
+        x = theano.shared(y)
         assert y.size == function([], x.size)()
 
 

--- a/theano/tensor/tests/test_sharedvar.py
+++ b/theano/tensor/tests/test_sharedvar.py
@@ -622,7 +622,7 @@ def makeSharedTester(shared_constructor_,
     return SharedTester
 
 test_shared_options=makeSharedTester(
-    shared_constructor_ = tensor.shared,
+    shared_constructor_ = tensor._shared,
     dtype_ = theano.config.floatX,
     get_value_borrow_true_alias_ = True,
     shared_borrow_true_alias_ = True,


### PR DESCRIPTION
Most of the time people who use tensor.shared do it because they mix it up
with theano.shared. By renaming it with a leading underscore, this confusion
should disappear.

By the way this commit also changes a few calls in Theano code from
tensor.shared to theano.shared, when I thought calling tensor.shared was not
intentional.
