### PR TITLE
Deprecated cache entries now trigger a warning

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -577,7 +577,11 @@ class ModuleCache(object):
                             # As a result, we delete it instead (which is also
                             # simpler to implement).
                             _rmtree(root, ignore_nocleanup=True,
-                                    msg='deprecated cache entry')
+                                    msg=(
+                                        'invalid cache entry format -- this '
+                                        'should not happen unless your cache '
+                                        'was really old'),
+                                    level=logging.WARN)
                             continue
 
                         # Check the path to the module stored in the KeyData


### PR DESCRIPTION
Most people should have updated their local cache by now. Making it a
warning will ensure we notice if for some reason a bug generates new
invalid cache entries.
