### PR TITLE
Fix compilation crash on Mac OS X Lion.

### DIFF
--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -277,7 +277,8 @@ class DimShuffle(Op):
 
         # set the strides of the broadcasted dimensions
         # this algorithm is from numpy: PyArray_Newshape() in cvs/numpy/numpy/core/src/multiarraymodule.c
-        strides_statements.append('if (strides['+str(nd_out)+'-1] == 0) strides['+str(nd_out)+'-1] = %(basename)s->descr->elsize')
+        if nd_out > 0:
+            strides_statements.append('if (strides['+str(nd_out)+'-1] == 0) strides['+str(nd_out)+'-1] = %(basename)s->descr->elsize')
         for i in xrange(nd_out-2,-1, -1):
             strides_statements.append("if (strides[%(i)s] == 0) strides[%(i)s] = strides[%(i)s+1] * dimensions[%(i)s+1]"%dict(i=str(i)))
 
@@ -326,7 +327,7 @@ class DimShuffle(Op):
         return full_code % dict(locals(), **sub)
 
     def c_code_cache_version(self):
-        return (1,)
+        return (2,)
 
     def grad(self, inp, grads):
         x, = inp

--- a/theano/tensor/tests/test_elemwise.py
+++ b/theano/tensor/tests/test_elemwise.py
@@ -26,7 +26,9 @@ class test_DimShuffle(unittest.TestCase):
                                   ((2, 3, 4), (2, 1, 0), (4, 3, 2)),
                                   ((2, 3, 4), ('x', 2, 1, 0, 'x'), (1, 4, 3, 2, 1)),
                                   ((1, 4, 3, 2, 1), (3, 2, 1), (2, 3, 4)),
-                                  ((1, 1, 4), (1, 2), (1, 4))]:
+                                  ((1, 1, 4), (1, 2), (1, 4)),
+                                  ((1, 1, 1), (), ()),
+                                  ((1,), ('x','x'), (1,1)),]:
             ib = [(entry == 1) for entry in xsh]
             x = TensorType('float64', ib)('x')
             e = DimShuffle(ib, shuffle)(x)
@@ -59,6 +61,10 @@ class test_DimShuffle(unittest.TestCase):
     def test_perform(self):
         self.with_linker(gof.PerformLinker())
 
+    def test_c_or_py(self):
+        # Shape op don't have C code.
+        # But This will test DimShuffle c code
+        self.with_linker(gof.OpWiseCLinker())
 
 class test_Broadcast(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
We should not try to access C array before index 0!
