### PR TITLE
WIP: diag_dot_to_elemwise

### DIFF
--- a/theano/sandbox/linalg/ops.py
+++ b/theano/sandbox/linalg/ops.py
@@ -438,6 +438,17 @@ class ExtractDiag(Op):
 extract_diag = ExtractDiag()
 #TODO: optimization to insert ExtractDiag with view=True
 
+@register_canonicalize
+@local_optimizer([])
+def diag_dot_to_elemwise(node):
+    if node.op == extract_diag:
+        z, = node.inputs
+        if z.owner and z.owner.op == tensor.dot:
+            x, y = z.owner.inputs
+            # XXX: careful to coordinate with extract_diag re non-square z
+            return [(x * y.dimshuffle(1, 0)).sum(axis=1)]
+
+
 
 class AllocDiag(Op):
     def __eq__(self, other):
@@ -495,7 +506,6 @@ class Det(Op):
     def __str__(self):
         return "Det"
 det = Det()
-
 
 def trace(X):
     """


### PR DESCRIPTION
This is an important speed optimization. I'm not done yet with it, but since others are working on linalg stuff I wanted to advertise that I had started working on this.

This raises a question though - what is the canonical form for an outer vector product - is it outer() or is it an elemwise mul with dimshuffle?  I think the elemwise form is more canonical since there are so many things we can do with elemwise.
