### PR TITLE
add_tag_trace_on_call speeds up optimization

### DIFF
--- a/theano/compile/function_module.py
+++ b/theano/compile/function_module.py
@@ -994,6 +994,8 @@ class FunctionMaker(object):
         try:
             theano.config.compute_test_value = "off"
             start_optimizer = time.time()
+            add_stack_trace_on_call = gof.Op.add_stack_trace_on_call
+            gof.Op.add_stack_trace_on_call = False
             optimizer(env)
             end_optimizer = time.time()
 
@@ -1007,6 +1009,7 @@ class FunctionMaker(object):
             insert_deepcopy(env, inputs, outputs+additional_outputs)
         finally:
             theano.config.compute_test_value = compute_test_value_orig
+            gof.Op.add_stack_trace_on_call = add_stack_trace_on_call
 
         # initialize the linker
         if not hasattr(linker, 'accept'):

--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -310,6 +310,13 @@ class PureOp(object):
 
     """
 
+    add_stack_trace_on_call = True
+    """This class variable governs whether __call__ adds a stack trace to the node it creates.
+    
+    The tag trace is meant to connect a node to the line a user typed. It is nice for
+    debugging. It does not make as much sense during optimizations to store this information.
+    """
+
     #############
     # make_node #
     #############
@@ -367,7 +374,8 @@ class PureOp(object):
 
         """
         node = self.make_node(*inputs, **kwargs)
-        self.add_tag_trace(node)
+        if self.add_stack_trace_on_call:
+            self.add_tag_trace(node)
 
         if config.compute_test_value != 'off':
             run_perform = True


### PR DESCRIPTION
Adding tag traces is expensive. This PR disables adding tag traces during the
optimization process itself, which is anyway not the point of tag traces. This
saves 10 seconds of compilation on a graph I'm working with that ends up with
about 240 nodes, which is about a third of the overall compilation time.
