### PR TITLE
In the shape feature, return to the old priority when we update the shape

### DIFF
--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -929,10 +929,9 @@ class ShapeFeature(object):
             # update_shape suppose that r and new_r are in shape_of.
             self.init_r(new_r)
 
-        # This tells us that r and new_r must have the same shape
-        # if we didn't know that the shapes are related, now we do.
-        # We should give priority to new_r, so we put it last.
-        self.update_shape(r, new_r)
+        # This tells us that r and new_r must have the same shape if
+        # we didn't know that the shapes are related, now we do.
+        self.update_shape(new_r, r)
 
         # change_input happens in two cases:
         # 1) we are trying to get rid of r, or


### PR DESCRIPTION
In the shape feature, return to the old priority when we update the shape info.

Otherwise it create cycle in the graph. I'm tired of debugging, so I just let the old version that was working but I don't understand why we want this priority and there is no doc about this.
