### PR TITLE
Better error message when compilation fails

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1392,12 +1392,12 @@ def gcc_module_compile_str(module_name, src_code, location=None, include_dirs=[]
 
     try:
         p = subprocess.Popen(cmd, stderr=subprocess.PIPE)
+        compile_stderr = p.communicate()[1]
     except Exception:
-        # An exception can occur here e.g. if `g++` is not found.
+        # An exception can occur e.g. if `g++` is not found.
         print_command_line_error()
         raise
 
-    compile_stderr = p.communicate()[1]
     status = p.returncode
 
     if status:


### PR DESCRIPTION
1. The g++ error message is now displayed in the exception text rather
   than hidden before the file content is printed (which made it very hard
   to notice).
2. If the call to Popen fails for some reason (e.g. because g++ is not
   found), the command line is printed to stderr so that the user has a
   better idea of what the problem may be.
