### PR TITLE
Fixed tests when on_shape_error = 'raise'

### DIFF
--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -785,8 +785,8 @@ class ShapeFeature(object):
         if s is None:
             self.shape_of[r] = s
         else:
-            if  r.ndim != len(s):
-                raise ShapeError(
+            if r.ndim != len(s):
+                raise AssertionError(
                         "Something inferred a shape with %d dimensions "
                         "for a variable with %d dimensions." % (
                         len(s), r.ndim))
@@ -908,8 +908,6 @@ class ShapeFeature(object):
             o_shapes = shape_infer(node,
                                    [self.shape_of[r] for r in node.inputs])
         except ShapeError:
-            if config.on_shape_error == "raise":
-                raise
             o_shapes = self.default_infer_shape(node, [self.shape_of[r] for
                                                        r in node.inputs])
         except NotImplementedError, e:


### PR DESCRIPTION
It is expected that some implementations of 'infer_shape' raise a ShapeError to
indicate that they do not know how to compute the shape. In such a situation,
we should silently fall back to the default implementation, regardless of the
value of 'on_shape_error' (whose name may be misleading for developers, since
we want to catch all exceptions _except_ ShapeError).

Also, when a bad shape was inferred, we should not raise a ShapeError (which
may be caught silently), but rather something that indicates that there is a
serious bug somewhere, like an AssertionError.
