### PR TITLE
Include the theano version in the compiledir.

### DIFF
--- a/theano/gof/compiledir.py
+++ b/theano/gof/compiledir.py
@@ -6,6 +6,7 @@ import re
 import sys
 
 import theano
+import theano.version
 from theano.configparser import config, AddConfigVar, ConfigParam, StrParam
 
 
@@ -13,7 +14,8 @@ def default_compiledirname():
     platform_id = '-'.join([
         platform.platform(),
         platform.processor(),
-        platform.python_version()])
+        platform.python_version(),
+        theano.version.version])
     platform_id = re.sub("[\(\)\s,]+", "_", platform_id)
     return 'compiledir_' + platform_id
 


### PR DESCRIPTION
- No more forgetting to clear the cache!
- No more collisions when running multiple theano versions at once!

I've been bitten by this too many times, and it's driving me crazy. I'm sure there will be concerns about this (disk space being an obvious one), but a pull request seems as good a place as any to hash them out, so: Let the discussion begin. :)
