### PR TITLE
fixed a bug where get_debug_values returns tuple(val) rather than val in

### DIFF
--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -664,4 +664,7 @@ def get_debug_values(*args):
                                      " has no test value")
             return []
 
+    if len(rval) == 1:
+        return rval
+
     return [tuple(rval)]


### PR DESCRIPTION
the case where it is fetching the value of only one variable
