### PR TITLE
Fixed crash when theano.version does not exist

### DIFF
--- a/theano/__init__.py
+++ b/theano/__init__.py
@@ -41,6 +41,15 @@ import configparser, configdefaults
 
 config = configparser.TheanoConfigParser()
 
+# Version information.
+# Note that the version must be defined before imports below as it is used by
+# some of these imports.
+try:
+    import theano.version
+    __version__ = theano.version.version
+except ImportError:
+    __version__ = "unknown"
+
 import gof
 
 from gof import \
@@ -142,11 +151,3 @@ def dot(l, r):
     if rval == NotImplemented:
         raise NotImplementedError("Dot failed for the following reasons:", (e0, e1))
     return rval
-
-
-# Version information
-try:
-    import theano.version
-    __version__ = theano.version.version
-except ImportError:
-    __version__ = "unknown"

--- a/theano/gof/compiledir.py
+++ b/theano/gof/compiledir.py
@@ -6,7 +6,6 @@ import re
 import sys
 
 import theano
-import theano.version
 from theano.configparser import config, AddConfigVar, ConfigParam, StrParam
 
 
@@ -15,7 +14,7 @@ def default_compiledirname():
         platform.platform(),
         platform.processor(),
         platform.python_version(),
-        theano.version.version])
+        theano.__version__])
     platform_id = re.sub("[\(\)\s,]+", "_", platform_id)
     return 'compiledir_' + platform_id
 


### PR DESCRIPTION
This is the case for instance when someone directly uses the git
repository without running setup.py.
