### PR TITLE
Make mlp_test test a more sensible case.

### DIFF
--- a/theano/tensor/tests/mlp_test.py
+++ b/theano/tensor/tests/mlp_test.py
@@ -306,27 +306,15 @@ def test_mlp():
     theano.printing.debugprint(train_model, print_type=True)
     assert any([isinstance(i.op,T.nnet.CrossentropySoftmax1HotWithBiasDx) for i in train_model.maker.env.toposort()])
 
-    # Now, this case works, too!
+    # Even without FeatureShape
     train_model =theano.function( inputs = [index],
             updates = updates2,
-            mode=mode.excluding('local_track_shape_i'),
+            mode=mode.excluding('ShapeOpt'),
             givens={
                 x:train_set_x[index*batch_size:(index+1)*batch_size],
                 y:train_set_y[index*batch_size:(index+1)*batch_size]})
     print
     print 'MODEL 2'
-    theano.printing.debugprint(train_model, print_type=True)
-    assert any([isinstance(i.op,T.nnet.CrossentropySoftmax1HotWithBiasDx) for i in train_model.maker.env.toposort()])
-
-    # Even without FeatureShape
-    train_model =theano.function( inputs = [index],
-            updates = updates2,
-            mode=mode.excluding('local_shape_to_shape_i'),
-            givens={
-                x:train_set_x[index*batch_size:(index+1)*batch_size],
-                y:train_set_y[index*batch_size:(index+1)*batch_size]})
-    print
-    print 'MODEL 3'
     theano.printing.debugprint(train_model, print_type=True)
     assert any([isinstance(i.op,T.nnet.CrossentropySoftmax1HotWithBiasDx) for i in train_model.maker.env.toposort()])
 


### PR DESCRIPTION
Previous test was testing settings where we removed either the
"local_track_shape_i" or "local_shape_to_shape_i" optimizations.
These are unlikely settings, what we test now is the complete
removal of the "ShapeOpt" optimization.

The name of the branch is misleading, since the CrossEntropy... optimization is fine, the test itself had to be fixed.
