### PR TITLE
Add warning for bug in Numpy <= 1.6.1.

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4916,6 +4916,14 @@ class PermuteRowElements(Op):
                 out[y] = x[:]
             else:
                 out[:] = x[y]
+            if (numpy.__version__ <= '1.6.1' and
+                    out.size != numpy.uint32(out.size)):
+                warnings.warn(
+                        'Numpy versions 1.6.1 and below have a bug preventing '
+                        'advanced indexing from correctly filling arrays that '
+                        'are too big (>= 2^32 elements). It is possible that '
+                        'out (%s), with shape %s, is not correctly filled.'
+                        % (out, out.shape))
         else:
             xs0 = x.shape[0]
             ys0 = y.shape[0]
@@ -5209,6 +5217,14 @@ class AdvancedSubtensor(Op):
         # TODO: in general, we need to re-pack the inputs into a valid index, just like
         # subtensor
         out[0] = inputs[0].__getitem__(inputs[1:])
+        if (numpy.__version__ <= '1.6.1' and
+                out[0].size != numpy.uint32(out[0].size)):
+            warnings.warn(
+                    'Numpy versions 1.6.1 and below have a bug preventing '
+                    'advanced indexing from correctly filling arrays that '
+                    'are too big (>= 2^32 elements). It is possible that '
+                    'out[0] (%s), with shape %s, is not correctly filled.'
+                    % (out[0], out[0].shape))
         #return
         #raise NotImplementedError()
 
@@ -5247,6 +5263,14 @@ class AdvancedIncSubtensor(Op):
         # TODO: same thing as in AdvancedSubtensor's perform TODO
         out[0] = inputs[0].copy()
         out[0][inputs[2:]] += inputs[1]
+        if (numpy.__version__ <= '1.6.1' and
+                out[0].size != numpy.uint32(out[0].size)):
+            warnings.warn(
+                    'Numpy versions 1.6.1 and below have a bug preventing '
+                    'advanced indexing from correctly filling arrays that '
+                    'are too big (>= 2^32 elements). It is possible that '
+                    'out[0] (%s), with shape %s, is not correctly filled.'
+                    % (out[0], out[0].shape))
 
     def grad(self, inpt, output_gradients):
         x, y = inpt[:2]


### PR DESCRIPTION
When using numpy's advanced indexing on huge arrays (2**32 elements or
more), Numpy <= 1.6.1 has a bug where the resulting array is not
properly filled. We emit a warning in those cases.
