### PR TITLE
Fixed crash with Composite support code and GPU

### DIFF
--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -2422,10 +2422,11 @@ class Composite(ScalarOp):
         rval = []
         for subnode, subnodename in zip(self.env.toposort(), self.nodenames):
             try:
-                rval.append(
-                        subnode.op.c_support_code_apply(
+                subnode_support_code = subnode.op.c_support_code_apply(
                             subnode,
-                            subnodename % dict(nodename=name)))
+                            subnodename % dict(nodename=name))
+                if subnode_support_code:
+                    rval.append(subnode_support_code)
             except gof.utils.MethodNotDefined:
                 pass
         # there should be no need to remove duplicate code blocks because


### PR DESCRIPTION
The problem was that when a Composite Op had a Composite subnode, having
the subnode return an empty support code would cause the parent node to
return '\n' as support code. As a result, GPU code generation would
crash due to non-empty support code.

NB: I don't know how to write GPU tests, so I didn't add a test for this. An example showing this bug was posted on the mailing list if you someone wants to add one (subject: "SupportCodeError compiling gradient in certain circumstances").
