### PR TITLE
Fix when forcing cuda to be disabled

### DIFF
--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -162,6 +162,30 @@ from theano.sandbox.cuda.var import (CudaNdarrayVariable,
                                      float32_shared_constructor)
 from theano.sandbox.cuda.type import CudaNdarrayType
 
+
+class GpuOp(theano.gof.Op):
+
+    """
+    Parent class for all GPU Ops.
+
+    This class ensures we verify the GPU is working properly when a GPU Op is
+    used for the first time.
+
+    It is defined in __init__.py so that it exists even when `cuda_available`
+    is False (this is necessary to avoid breaking the test suite).
+    """
+
+    def make_thunk(self, node, storage_map, compute_map, no_recycling):
+        if theano.sandbox.cuda.use.device_number is None:
+            theano.sandbox.cuda.use("gpu",
+                                    force=True,
+                                    default_to_move_computation_to_gpu=False,
+                                    move_shared_float32_to_gpu=False,
+                                    enable_cuda=False)
+        return super(GpuOp, self).make_thunk(node, storage_map,
+                                             compute_map, no_recycling)
+
+
 if cuda_available:
     # check if their is an old cuda_ndarray that was loading instead of the one
     # we compiled!
@@ -178,7 +202,7 @@ if cuda_available:
     shared_constructor = float32_shared_constructor
 
     import basic_ops
-    from basic_ops import (GpuOp, GpuFromHost, HostFromGpu, GpuElemwise,
+    from basic_ops import (GpuFromHost, HostFromGpu, GpuElemwise,
                            GpuDimShuffle, GpuSum, GpuReshape, GpuContiguous,
                            GpuSubtensor, GpuIncSubtensor,
                            GpuAdvancedSubtensor1, GpuAdvancedIncSubtensor1,

--- a/theano/sandbox/cuda/basic_ops.py
+++ b/theano/sandbox/cuda/basic_ops.py
@@ -34,18 +34,6 @@ def as_cuda_array(obj):
         raise TypeError("Don't know how to cast to a CudaNdarray object")
 
 
-class GpuOp(Op):
-    def make_thunk(self, node, storage_map, compute_map, no_recycling):
-        if theano.sandbox.cuda.use.device_number is None:
-            theano.sandbox.cuda.use("gpu",
-                                    force=True,
-                                    default_to_move_computation_to_gpu=False,
-                                    move_shared_float32_to_gpu=False,
-                                    enable_cuda=False)
-        return super(GpuOp, self).make_thunk(node, storage_map,
-                                             compute_map, no_recycling)
-
-
 class HostFromGpu(GpuOp):
     """
     Implement the transfer from gpu to the cpu.

--- a/theano/sandbox/multinomial.py
+++ b/theano/sandbox/multinomial.py
@@ -3,9 +3,9 @@ from theano import Op, Apply
 import theano.tensor as T
 from theano.gof import local_optimizer
 
-from theano.sandbox.cuda import cuda_available
+from theano.sandbox.cuda import cuda_available, GpuOp
 if cuda_available:
-    from theano.sandbox.cuda import CudaNdarrayType, GpuOp
+    from theano.sandbox.cuda import CudaNdarrayType
     from theano.sandbox.cuda.basic_ops import host_from_gpu, gpu_from_host
     from theano.sandbox.cuda.opt import register_opt
 

--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -18,11 +18,10 @@ from theano.gof.python25 import all
 
 import multinomial
 
-from theano.sandbox.cuda import cuda_available, cuda_enabled
+from theano.sandbox.cuda import cuda_available, cuda_enabled, GpuOp
 if cuda_available:
     from theano.sandbox.cuda import (CudaNdarrayType,
-                                     float32_shared_constructor,
-                                     GpuOp)
+                                     float32_shared_constructor)
 
 
 def mulmod(a, b, c, m):


### PR DESCRIPTION
The GpuOp class must be available even when Cuda is disabled (e.g. by
forcing cuda_available = False). Otherwise some tests fail.

This commit moves the definition of GpuOp directly into cuda/**init**.py
so that it works.
