### PR TITLE
Fixes for Python 2.4

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1312,7 +1312,7 @@ def gcc_version():
     return gcc_version_str
 
 
-class GCC_compiler():
+class GCC_compiler(object):
     @staticmethod
     def compile_args():
         cxxflags = [flag for flag in config.gcc.cxxflags.split(' ') if flag]

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -74,7 +74,7 @@ def add_standard_rpath(rpath):
     rpath_defaults.append(rpath)
 
 
-class NVCC_compiler():
+class NVCC_compiler(object):
     @staticmethod
     def compile_args():
         """


### PR DESCRIPTION
Using
    class X():
triggers a SyntaxError with Python 2.4
