### PR TITLE
Fixed a test on 32-bit platforms

### DIFF
--- a/theano/sparse/tests/test_basic.py
+++ b/theano/sparse/tests/test_basic.py
@@ -784,8 +784,14 @@ class test_structureddot(unittest.TestCase):
 
 class DotTests(unittest.TestCase):
     def setUp(self):
-        x_size = (10, 1000)
-        y_size = (1000, 10000)
+        # On 32-bit platforms we use smaller matrices to avoid running out of
+        # memory during tests.
+        if theano.gof.cmodule.local_bitwidth() <= 32:
+            x_size = (10, 100)
+            y_size = (100, 1000)
+        else:
+            x_size = (10, 1000)
+            y_size = (1000, 10000)
 
         self.x_csr = scipy.sparse.csr_matrix(
             numpy.random.binomial(1, 0.5, x_size), dtype=theano.config.floatX)


### PR DESCRIPTION
This fix existed before, but was accidentally removed in 495aa9d3.
