### PR TITLE
Use sys.executable instead of 'python'

### DIFF
--- a/theano/tests/run_tests_in_batch.py
+++ b/theano/tests/run_tests_in_batch.py
@@ -94,8 +94,10 @@ def run(stdout, stderr, argv, theano_nose, batch_size):
     dummy_in = open(os.devnull)
     # We need to call 'python' on Windows, because theano-nose is not a
     # native Windows app; and it does not hurt to call it on Unix.
+    # Using sys.executable, so that the same Python version is used.
+    python = sys.executable
     rval = subprocess.call(
-            (['python', theano_nose, '--collect-only', '--with-id']
+            ([python, theano_nose, '--collect-only', '--with-id']
                 + other_args),
             stdin=dummy_in.fileno(),
             stdout=stdout.fileno(),
@@ -122,7 +124,7 @@ def run(stdout, stderr, argv, theano_nose, batch_size):
         # failed tests, which are re-run (with output) below.
         dummy_out = open(os.devnull, 'w')
         rval = subprocess.call(
-                (['python', theano_nose, '-q', '--with-id']
+                ([python, theano_nose, '-q', '--with-id']
                     + map(str, test_range)
                     + other_args),
                 stdout=dummy_out.fileno(),
@@ -146,7 +148,7 @@ def run(stdout, stderr, argv, theano_nose, batch_size):
         stdout.flush()
         stderr.flush()
         subprocess.call(
-                (['python', theano_nose, '-v', '--with-id']
+                ([python, theano_nose, '-v', '--with-id']
                     + failed
                     + other_args),
                 stdin=dummy_in.fileno(),


### PR DESCRIPTION
This way, the same executable will be used.
