### PR TITLE
failing GpuConv unittest

### DIFF
--- a/theano/sandbox/cuda/tests/test_conv_cuda_ndarray.py
+++ b/theano/sandbox/cuda/tests/test_conv_cuda_ndarray.py
@@ -705,3 +705,19 @@ def benchmark():
 
     exec_conv(version, shapes_valid, verbose, random, 'valid', print_=None, rtol=1e-3)
     exec_conv(version, shapes_full, verbose, random, 'full')
+
+
+def test_stack_rows_segfault_070312():
+    # 07/03/2012
+    # Running this unittest with cuda-memcheck exposes an illegal read.
+    # THEANO_FLAGS=device=gpu cuda-memcheck nosetests \
+    # test_conv_cuda_ndarray.py:test_stack_rows_segfault_070312
+    img = theano.shared(numpy.random.rand(1, 80, 96, 96).astype('float32'))
+    kern = theano.shared(numpy.random.rand(1, 80, 9, 9).astype('float32'))
+    out = theano.shared(numpy.random.rand(1, 2, 2, 3).astype('float32'))
+    op = theano.tensor.nnet.conv.ConvOp(imshp=(80, 96, 96), kshp=(9, 9),
+            nkern=1, bsize=1)
+    f = theano.function([], [], updates={out: op(img, kern)})
+    f()
+
+


### PR DESCRIPTION
This unittest exploses an illegal read in the conv_rows_stack kernel.  @nouiz, would you let me know if/when you might be able to look at it?
