### PR TITLE
Fix scan pushout

### DIFF
--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -222,6 +222,8 @@ class PushOutNonSeqScan(gof.Optimizer):
                                  'to move some computation fron scan '
                                  'which is not allowed to move. Report '
                                  'this on theano-users list'), x)
+                    outside_ins = [x.type.filter_variable(y) for x,y in
+                                   zip(nd.inputs, outside_ins)]
                     nw_outer_node = nd.op.make_node(*outside_ins)
                     # Step 2. Create variables for replacements
                     for idx, y in enumerate(nd.outputs):


### PR DESCRIPTION
I'm just making sure that inputs to a node (when I'm reconstructing it) are on the same device as the original ones.
