### PR TITLE
Do not wrap in as_tensor_variable unless needed

### DIFF
--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -295,12 +295,20 @@ def Rop(f, wrt, eval_points):
                     _traverse(inp.owner)
                     local_eval_points.append(
                         seen_nodes[inp.owner][inp.owner.outputs.index(inp)])
+            same_type_eval_points = []
             for x, y in zip(inputs, local_eval_points):
                 if y is not None:
-                    assert (as_tensor_variable(x).type ==
-                            as_tensor_variable(y).type)
+                    if not isinstance(x, gof.Variable):
+                        x = as_tensor_variable(x)
+                    if not isinstance(y, gof.Variable):
+                        y = as_tensor_variable(y)
+                    y = x.type.filter_variable(y)
+                    assert x.type == y.type
+                    same_type_eval_points.append(y)
+                else:
+                    same_type_eval_points.append(y)
 
-            seen_nodes[node] = op.R_op(node.inputs, local_eval_points)
+            seen_nodes[node] = op.R_op(node.inputs, same_type_eval_points)
             return None
 
     # Populate the dictionary


### PR DESCRIPTION
The automatic wrapping in as_tensor_variable is incorrect and it was there just to check that arguments are on the same device. 
