### PR TITLE
Fix for CUDA 4.1 on OS X, prevent -no_pie flag

### DIFF
--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -243,6 +243,13 @@ class NVCC_compiler(object):
 
         # Fix for MacOS X.
         cmd = remove_python_framework_dir(cmd)
+        # CUDA Toolkit v4.1 Known Issues:
+        # Host linker on Mac OS 10.7 (and 10.6 for me) passes -no_pie option to nvcc
+        # this option is not recognized and generates an error
+        # http://stackoverflow.com/questions/9327265/nvcc-unknown-option-no-pie
+        # Passing -Xlinker -pie stops -no_pie from getting passed
+        if sys.platform == 'darwin' and nvcc_version >= '4.1':
+            cmd.extend(['-Xlinker', '-pie'])
 
         #cmd.append("--ptxas-options=-v")  #uncomment this to see register and shared-mem requirements
         _logger.debug('Running cmd %s', ' '.join(cmd))


### PR DESCRIPTION
I updated to CUDA 4.1 today on OSX and found that Theano would no longer compile with nvcc.

I get an error like this:

```
ld: unknown option: -no_pie
collect2: ld returned 1 exit status
```

 It turns out that the host linker on Mac 10.7 (and 10.6 I guess, because I haven't upgraded to 10.6) passes the -no_pie option to the linker by default. This is a known issue reported in the [NVIDIA CUDA Toolkit Release notes](http://developer.download.nvidia.com/compute/cuda/4_1/rel/toolkit/docs/CUDA_Toolkit_Release_Notes_And_Errata.txt).

Apparently the solution is to pass the option `-Xlinker -pie` to nvcc. This patch does just that (only on the darwin platform and when CUDA version is >= 4.1). 

It would be good if another Mac user (perhaps on a different CUDA version) tries this and makes sure it doesn't break compiling with nvcc.
