### PR TITLE
Disable ConvOp grad when subsampling is not 1 or 2

### DIFF
--- a/theano/tensor/nnet/conv.py
+++ b/theano/tensor/nnet/conv.py
@@ -707,10 +707,9 @@ class ConvOp(Op):
         if self.imshp != self.imshp_logical or self.kshp != self.kshp_logical:
             raise NotImplementedError('todo')
 
-        #if self.dx!=1 or self.dy!=1:
-            #raise Exception("ERROR: We disable ConvOp.grad now when dx!=1 or "\
-                    #"dy!=1 as we think their is a high probability of bug in it."\
-                    #"We need to raise the error on the gradient to .1!")
+        if self.dx not in (1, 2) or self.dy not in (1, 2):
+            raise Exception("ERROR: We disable ConvOp.grad now when dx or "\
+                    "dy are different from 1 and 2, as there is a bug in it.")
 
         all_shape = self.imshp is not None and self.kshp is not None and \
                     self.nkern is not None and self.bsize is not None

--- a/theano/tensor/nnet/tests/test_conv.py
+++ b/theano/tensor/nnet/tests/test_conv.py
@@ -203,6 +203,10 @@ class TestConv2D(unittest.TestCase):
         self.validate((3,2,7,5), (5,2,2,3), 'full', subsample=(2,2))
         self.validate((3,2,7,5), (5,2,2,3), 'valid', subsample=(2,1))
 
+        # Fails as of 2012-04-12
+        self.validate((1,1,6,6), (1,1,3,3), 'valid', subsample=(3,3))
+
+
     def test_shape_Constant_tensor(self):
         """
         Tests convolution where the {image,filter}_shape is a Constant tensor.


### PR DESCRIPTION
Subsampling seems to work with 1 and 2, but gives incorrect
results for (3, 3) and (1, 3).
