### PR TITLE
in {zeros,ones}_like, don't insert fill for scalar.

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2650,6 +2650,8 @@ def ones_like(model, dtype=None):
     """equivalent of numpy.ones_like"""
     if dtype is None:
         dtype = model.type.dtype
+    if model.ndim == 0 and isinstance(model.type, TensorType):
+        return constant(1.0, dtype=dtype)
     ret = fill(model, constant(1.0, dtype=dtype))
     return ret
 
@@ -2659,6 +2661,8 @@ def zeros_like(model, dtype=None):
     """equivalent of numpy.zeros_like"""
     if dtype is None:
         dtype = model.type.dtype
+    if model.ndim == 0 and isinstance(model.type, TensorType):
+        return constant(0.0, dtype=dtype)
     return fill(model, constant(0.0, dtype=dtype))
 
 


### PR DESCRIPTION
This  make  the  graph  before  compilation  and  when  compiled  with
FAST_COMPILE   more    readable.   This   was    optimized   away   to
local_fill_to_alloc, but if  we enable it in fast_compile,  it also do
more optimisation that make the  graph not readable without enabling even
more optimization in fast_compile.s
