### PR TITLE
Vm allow gc and conditionals

### DIFF
--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -401,6 +401,7 @@ class Stack(VM):
                                         break
                                 if empty_storage_map:
                                     storage_map[i][0] = None
+                                    compute_map[i][0] = None
 
         # Hacky coarse gc final pass
         # This is required until we have a proper gc algorithm for graphs with


### PR DESCRIPTION
This PR follows from theano-dev thread "State of CVM close to enable by default" June 2012.

Mainly it's comments and readability improvements, but it also clears out the storage_map after `Stack.__call__` so that intermediate values can be reclaimed by the Python gc.

There was discussion in the email thread about how to allow fine-grained on-the-fly gc with conditionals in the graph, but that is not implemented here.
