### PR TITLE
fixed gradient name bug

### DIFF
--- a/theano/tests/test_gradient.py
+++ b/theano/tests/test_gradient.py
@@ -261,5 +261,13 @@ def test_unimplemented_grad():
     except NotImplementedError:
         pass
 
+def test_grad_name():
+    A = theano.tensor.matrix('A')
+    x = theano.tensor.vector('x')
+    f = theano.tensor.dot(x,theano.tensor.dot(A,x))
+    f.name = 'f'
+    g = theano.tensor.grad(f,x)
+    assert g.name == '(df/dx)'
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There was a bug where T.grad would return variables with misleading names. I found a section in gradient.py that gives variables names. Since this is not necessary for theano's main functionality and the names were sometimes wrong, I commented out this section and added a note explaining in what case the logic is wrong. I don't actually know what the correct logic is, so I didn't fix the bug in that section. However, I added functionality to insert the correct name in the grad method itself.
