### PR TITLE
ENH: modify mrg to not allocate so many streams when computing large ran...

### DIFF
--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -618,7 +618,7 @@ def guess_n_streams(size, warn=True):
             r *= s
         if r > 6:
             r = r/6 # chosen as fastest for rbm_benchmark
-        return r
+        return min(r, 30 * 256)
     else:
         if warn:
             warnings.warn((


### PR DESCRIPTION
...dom tensors

This (a) wastes memory and (b) wastes a lot of time, because the code for initializing the random state is in Python and sometimes takes for freaking ever.
