### PR TITLE
Remove reference to non-existing variable

### DIFF
--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -374,8 +374,7 @@ def default_blas_ldflags():
                         # we just pass the whole ldflags as the -l
                         # options part.
                         ['-L%s' % l for l in blas_info['library_dirs']] +
-                        ['-l%s' % l for l in blas_info['libraries']] +
-                        extra)
+                        ['-l%s' % l for l in blas_info['libraries']])
 #                       ['-I%s' % l for l in blas_info['include_dirs']])
     except KeyError:
         return "-lblas"


### PR DESCRIPTION
This seems to be a leftover from a previous attempt at making EPD
work on Mac.
Should fix gh-750.
