### PR TITLE
Dump the module code before showing the nvcc errors.

### DIFF
--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -317,6 +317,9 @@ class NVCC_compiler(object):
             _logger.info("NVCC: %s", eline)
 
         if p.returncode:
+            for i, l in enumerate(src_code.split('\n')):
+                print >> sys.stderr,  i + 1, l
+            print >> sys.stderr, '==============================='
             # filter the output from the compiler
             for l in nvcc_stderr.split('\n'):
                 if not l:
@@ -331,9 +334,6 @@ class NVCC_compiler(object):
                 except Exception:
                     pass
                 print >> sys.stderr, l
-            print >> sys.stderr, '==============================='
-            for i, l in enumerate(src_code.split('\n')):
-                print >> sys.stderr,  i + 1, l
             raise Exception('nvcc return status', p.returncode,
                             'for cmd', ' '.join(cmd))
         elif config.cmodule.compilation_warning and nvcc_stdout:


### PR DESCRIPTION
In my experience 99% of the time, the error message from nvcc if way more useful to find the source of the problem than the code of the module that was compiled.  But this error message is lost at the top of a giant code dump and nobody reports it when they create new issues, creating back and forth just to get the message and try to fix the problem.

This change just prints the code first make the error message much more visible.
