### PR TITLE
Make unimplemented images2neibs gradient handled the same as other unimplemented grads

### DIFF
--- a/theano/sandbox/neighbours.py
+++ b/theano/sandbox/neighbours.py
@@ -95,7 +95,7 @@ class Images2Neibs(Op):
         if self.mode in ['valid', 'ignore_borders']:
             warnings.warn("The Images2Neibs grad is not implemented."+\
                     "It was in the past but returned the wrong answer!")
-            return None
+            return [ None, None, None ]
 
             #raise BadOldCode("The Images2Neibs grad is not implemented."
             #                " It was in the past, but returned the wrong"


### PR DESCRIPTION
images2neibs was raising an exception saying that its gradient was unimplemented. This is not how other ops with unimplemented grads are treated--they just return None--and it causes problems where no gradients can be computed in a graph that contains this op anywhere, because of the way T.grad is implemented. This pull request changes it to issue a warning and return None.
