### PR TITLE
initialize the destroy map to empty 

### DIFF
--- a/theano/sandbox/scan.py
+++ b/theano/sandbox/scan.py
@@ -607,6 +607,7 @@ def scan(fn,
     info['truncate_gradient'] = -1
     info['name'] = name
     info['mode'] = mode
+    info['destroy_map'] = {}
     info['inplace'] = False
     info['gpu'] = False
     info['as_while'] = as_while


### PR DESCRIPTION
This bug was detected by Fred by having a test failing. The fix is to initialize the destroy map to empty, 
and let the inplace optimization to populate it. 
