### PR TITLE
fix destroy_map bug in scan

### DIFF
--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -798,6 +798,8 @@ class Scan(PureOp):
 
         pos = [(-self.mintaps[idx]) % store_steps[idx] for idx
                          in xrange(self.n_outs + self.n_nit_sot)]
+        if not getattr(self, 'destroy_map', None):
+            self.destroy_map = {}
         # 2.1 Create storage space for outputs
         for idx in xrange(self.n_outs):
             if idx in self.destroy_map:


### PR DESCRIPTION
Scan op used to assume that the destroy map is always defined (and is empty if nothing is to be run inplace). Unfortunately several places where the Scan op is generated do not initialize the destroy_map. 
I've fixed this for the scan function, grad method and R_op method, but another source of error is the ops generated by optimizations. 

Instead of fixing it in all possible places, I opted for the easier version where I removed the assumption that the destroy_map should exist before we run the node (assumption that exist only for the python version of the code)
