### PR TITLE
add print_active_device flag

### DIFF
--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -75,6 +75,11 @@ AddConfigVar('force_device',
         BoolParam(False, allow_override=False),
         in_c_key=False)
 
+AddConfigVar('print_active_device',
+        "Print active device at startup",
+        BoolParam(True, allow_override=False),
+        in_c_key=False)
+
 # Do not add FAST_RUN_NOGC to this list (nor any other ALL CAPS shortcut).
 # The way to get FAST_RUN_NOGC is with the flag 'linker=c|py_nogc'.
 # The old all capital letter way of working is deprecated as it is not

--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -379,8 +379,10 @@ def use(device,
 
             if enable_cuda:
                 cuda_enabled = True
-            print >> sys.stderr, "Using gpu device %d: %s" % (
-                use.device_number, active_device_name())
+
+            if config.print_active_device:
+                print >> sys.stderr, "Using gpu device %d: %s" %(
+                        active_device_number(), active_device_name())
             if device_properties(use.device_number)['regsPerBlock'] < 16384:
                 # We will try to use too much register per bloc at many places
                 # when there is only 8k register per multi-processor.


### PR DESCRIPTION
Adds a new config flag `print_active_device` that defaults to True

If it is set to False then the greeting "Using gpu device <GPU device>" does not appear at import. 

https://groups.google.com/forum/?fromgroups=#!topic/theano-dev/UHGfvmiAoyM
