### PR TITLE
Make sure the output of perform has the exact right dtype

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2298,7 +2298,8 @@ class MaxAndArgmax(Op):
         max, max_idx = outs
         if python_all(axis == range(x.ndim)):
             axis = None
-        max[0] = numpy.asarray(numpy.max(x, axis))
+        max[0] = theano._asarray(numpy.max(x, axis),
+                                 dtype=node.outputs[0].dtype)
         max_idx[0] = theano._asarray(numpy.argmax(x, axis), dtype='int64')
 
     def infer_shape(self, node, shapes):

--- a/theano/tensor/extra_ops.py
+++ b/theano/tensor/extra_ops.py
@@ -151,11 +151,14 @@ class BinCountOp(theano.Op):
 
         if weights is not None and weights.shape != x.shape:
             raise TypeError("All inputs must have the same shape.")
+
         #Needed for numpy 1.4.1 compatibility
         if self.minlength:
-            z[0] = np.bincount(x, weights=weights, minlength=self.minlength)
+            out = np.bincount(x, weights=weights, minlength=self.minlength)
         else:
-            z[0] = np.bincount(x, weights=weights)
+            out = np.bincount(x, weights=weights)
+
+        z[0] = theano._asarray(out, dtype=node.outputs[0].dtype)
 
     def grad(self, inputs, outputs_gradients):
         output = self(*inputs)

--- a/theano/tensor/sort.py
+++ b/theano/tensor/sort.py
@@ -128,7 +128,9 @@ class ArgSortOp(theano.Op):
         a = inputs[0]
         axis = inputs[1]
         z = output_storage[0]
-        z[0] = np.argsort(a, axis, self.kind, self.order)
+        z[0] = theano._asarray(
+                np.argsort(a, axis, self.kind, self.order),
+                dtype=node.outputs[0].dtype)
 
     def infer_shape(self, node, inputs_shapes):
         if (isinstance(node.inputs[1], theano.Constant) and


### PR DESCRIPTION
It fixes tests on platforms where integers are 32-bit.
