### PR TITLE
Use defaultdict instead of dict in memodict.

### DIFF
--- a/theano/gof/graph.py
+++ b/theano/gof/graph.py
@@ -14,7 +14,7 @@ from copy import copy
 import theano
 import warnings
 from theano.gof import utils
-from theano.gof.python25 import deque
+from theano.gof.python25 import any, deque
 
 # Lazy imports to avoid circular dependencies.
 is_same_graph_with_merge = None

--- a/theano/gof/sched.py
+++ b/theano/gof/sched.py
@@ -1,9 +1,11 @@
 from graph import list_of_nodes
+from theano.gof.python25 import any, defaultdict
+
 
 ## {{{ http://code.activestate.com/recipes/578231/ (r1)
 def memodict(f):
     """ Memoization decorator for a function taking a single argument """
-    class memodict(dict):
+    class memodict(defaultdict):
         def __missing__(self, key):
             ret = self[key] = f(key)
             return ret


### PR DESCRIPTION
Python 2.4's dict ignores the **missing** method, but we already
had an implementation of defaultdict in Python 2.4 that does not.
