### PR TITLE
Check the graphviz executable are there.

### DIFF
--- a/theano/printing.py
+++ b/theano/printing.py
@@ -13,7 +13,10 @@ import numpy
 
 try:
     import pydot as pd
-    pydot_imported = True
+    if pd.find_graphviz():
+        pydot_imported = True
+    else:
+        pydot_imported = False
 except ImportError:
     pydot_imported = False
 


### PR DESCRIPTION
Even if the pydot Python package is installed, it is not certain that
the graphviz executable are (that is the case with EPD for instance).
In that case, we do not want to use it.
