### PR TITLE
make compiled function's fgraphs have same name as function

### DIFF
--- a/theano/compile/function_module.py
+++ b/theano/compile/function_module.py
@@ -1337,6 +1337,7 @@ def orig_function(inputs, outputs, mode=None, accept_inplace=False,
         profile.compile_time += t2 - t1
 
     fn.name = name
+    fn.maker.fgraph.name = name
     return fn
 
 


### PR DESCRIPTION
This allows wraplinkers to know print which function they are executing by looking at node.fgraph.
