### PR TITLE
Always define the name attribute to a default value.

### DIFF
--- a/theano/compile/function_module.py
+++ b/theano/compile/function_module.py
@@ -281,6 +281,7 @@ class Function(object):
         self.maker = maker
         self.profile = None  # reassigned in FunctionMaker.create
         self.trust_input = False  # If True, we don't check the input parameter
+        self.name = None
 
         # We will be popping stuff off this `containers` object.  It is a copy.
         containers = list(self.input_storage)


### PR DESCRIPTION
This fix an error in error handling code. This will allow the real error to show up.
