### PR TITLE
Issue #783: python3 compatible - remove unnecessary imports.

### DIFF
--- a/theano/compile/debugmode.py
+++ b/theano/compile/debugmode.py
@@ -5,7 +5,7 @@
 """
 __docformat__ = "restructuredtext en"
 
-import time, copy, sys, copy_reg, gc, os
+import copy, sys, copy_reg, gc
 from itertools import izip
 from StringIO import StringIO
 

--- a/theano/compile/function.py
+++ b/theano/compile/function.py
@@ -3,13 +3,10 @@
 __docformat__ = "restructuredtext en"
 
 import logging
-import sys
-import traceback
 _logger = logging.getLogger('theano.compile.function')
 
 from io import In
 from function_module import orig_function
-from profiling import ProfileStats
 from pfunc import pfunc
 from numpy import any  # to work in python 2.4
 import warnings

--- a/theano/compile/pfunc.py
+++ b/theano/compile/pfunc.py
@@ -9,7 +9,7 @@ from theano import config
 from theano.compile import orig_function, In, Out
 from theano.compile import UnusedInputError
 from theano.compile.sharedvalue import SharedVariable, shared
-from theano.gof import Container, Variable, generic, graph, Constant
+from theano.gof import Variable, Constant
 from theano.gof.python25 import any
 
 import logging

--- a/theano/gof/callcache.py
+++ b/theano/gof/callcache.py
@@ -1,4 +1,4 @@
-import cPickle, logging, sys
+import cPickle, logging
 
 _logger=logging.getLogger("theano.gof.callcache")
 

--- a/theano/gof/compilelock.py
+++ b/theano/gof/compilelock.py
@@ -2,7 +2,6 @@
 # same compilation directory (which can cause crashes).
 
 from theano import config
-import compiledir
 import os, random, time, atexit
 import socket # only used for gethostname()
 import logging

--- a/theano/gof/destroyhandler.py
+++ b/theano/gof/destroyhandler.py
@@ -2,12 +2,6 @@
 Classes and functions for validating graphs that contain view
 and inplace operations.
 """
-import sys
-if sys.version_info[:2] >= (2,5):
-    from collections import defaultdict
-
-# otherwise it's implemented in python25.py
-
 import theano
 import toolbox
 import graph

--- a/theano/gof/fg.py
+++ b/theano/gof/fg.py
@@ -12,7 +12,6 @@ from python25 import all
 from theano import config
 import warnings
 NullType = None
-import theano
 from python25 import OrderedDict
 from theano.misc.ordered_set import OrderedSet
 

--- a/theano/gof/type.py
+++ b/theano/gof/type.py
@@ -2,11 +2,9 @@
 
 __docformat__ = "restructuredtext en"
 
-import copy
 import utils
 from utils import MethodNotDefined, object2
 import graph
-from theano import config
 
 ########
 # Type #

--- a/theano/gof/utils.py
+++ b/theano/gof/utils.py
@@ -3,7 +3,7 @@
 # import variable
 
 from theano import config
-import re, os, traceback
+import re, traceback
 
 def add_tag_trace(thing):
     """Add tag.trace to an node or variable.

--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -21,10 +21,8 @@ from itertools import izip
 from theano import gof
 from theano.gof import Variable
 from theano.gof.python25 import OrderedDict
-from theano.gof.python25 import all
-import theano.gof.utils
 from theano.gof.null_type import NullType
-from theano.printing import min_informative_str
+
 # we can't do "import theano.tensor"
 # tensor depends on theano.compile
 # theano.compile depends on theano.gradient (this file)

--- a/theano/sandbox/cuda/neighbours.py
+++ b/theano/sandbox/cuda/neighbours.py
@@ -1,7 +1,5 @@
 # This is work in progress
-import theano
 from theano import Op, Apply
-import theano.tensor as T
 from theano.gof import local_optimizer
 from theano.sandbox.cuda import cuda_available, GpuOp
 

--- a/theano/sandbox/linalg/kron.py
+++ b/theano/sandbox/linalg/kron.py
@@ -1,4 +1,3 @@
-import numpy
 import theano
 from theano.gof import Op, Apply
 from theano import tensor

--- a/theano/sandbox/linalg/ops.py
+++ b/theano/sandbox/linalg/ops.py
@@ -12,7 +12,7 @@ from theano.tensor.opt import (register_stabilize,
         register_specialize, register_canonicalize)
 from theano.gof import local_optimizer
 from theano.gof.opt import Optimizer
-from theano.gradient import grad_not_implemented, DisconnectedType
+from theano.gradient import DisconnectedType
 
 try:
     import scipy.linalg

--- a/theano/sandbox/scan_module/scan_op.py
+++ b/theano/sandbox/scan_module/scan_op.py
@@ -12,27 +12,18 @@ __authors__ = ("Razvan Pascanu "
 __copyright__ = "(c) 2010, Universite de Montreal"
 __contact__ = "Razvan Pascanu <r.pascanu@gmail>"
 
-import itertools
 import logging
-import time
 from itertools import izip
 
 import numpy
 
 import theano
-from theano.compile import function, Param, Out
 from theano import compile
-from theano import gradient
 from theano.gof.python25 import any
 from theano.gof import PureOp, Apply
 from theano import gof
 from theano.tensor import TensorType
-from theano import tensor
 from theano.tensor.opt import Shape_i
-#from theano.sandbox import cuda
-from theano.compile.profiling import ScanProfileStats
-
-import scan_utils
 
 # Logging function for sending warning or info
 _logger = logging.getLogger('theano.scan_module.scan_op')

--- a/theano/scalar/sharedvar.py
+++ b/theano/scalar/sharedvar.py
@@ -22,7 +22,7 @@ __contact__   = "theano-dev <theano-dev@googlegroups.com>"
 __docformat__ = "restructuredtext en"
 
 import numpy
-from theano.compile import shared_constructor, SharedVariable
+from theano.compile import SharedVariable
 from basic import Scalar, _scalar_py_operators
 
 class ScalarSharedVariable(_scalar_py_operators, SharedVariable):

--- a/theano/tensor/fourier.py
+++ b/theano/tensor/fourier.py
@@ -1,8 +1,6 @@
-import theano
 import numpy
 import math
-from theano import gof, tensor, function, scalar
-from theano.sandbox.linalg.ops import diag
+from theano import gof, tensor
 
 
 class Fourier(gof.Op):

--- a/theano/tensor/inplace.py
+++ b/theano/tensor/inplace.py
@@ -1,9 +1,7 @@
-from basic import _scal_elemwise #, _transpose_inplace
 from theano import scalar as scal
 import elemwise
 from theano import printing
 from theano.printing import pprint
-from theano.gof.python25 import any
 
 def _scal_inplace(symbol):
     """Replace a symbol definition with an elementwise version of the corresponding scalar Op"""

--- a/theano/tensor/opt_uncanonicalize.py
+++ b/theano/tensor/opt_uncanonicalize.py
@@ -28,16 +28,10 @@ Also, we should make the fgraph refuse optimization that break the canonization 
 import logging
 _logger = logging.getLogger('theano.tensor.opt')
 
-import operator
-import itertools
-import sys
-
-import theano
 from theano import gof
 from elemwise import CAReduce
 import basic as T
 
-from theano.gof.python25 import any, all
 from theano.gof.opt import Optimizer
 from theano.gof import InconsistencyError, toolbox
 

--- a/theano/tensor/shared_randomstreams.py
+++ b/theano/tensor/shared_randomstreams.py
@@ -4,11 +4,8 @@ graphs.
 __docformat__ = "restructuredtext en"
 
 import copy
-import sys
-
 import numpy
 
-from theano.gof import Container
 from theano.compile.sharedvalue import (SharedVariable, shared_constructor,
                                         shared)
 import raw_random

--- a/theano/tensor/signal/conv.py
+++ b/theano/tensor/signal/conv.py
@@ -5,11 +5,7 @@ generic 2D convolution.
 
 __docformat__ = "restructuredtext en"
 
-import numpy
-import theano
 import theano.tensor as tensor
-import theano.tensor.nnet as nnet
-from theano import gof, Op, tensor, config
 from theano.tensor.nnet import conv
 
 import logging

--- a/theano/tensor/xlogx.py
+++ b/theano/tensor/xlogx.py
@@ -1,5 +1,3 @@
-
-import theano
 import numpy
 
 from elemwise import Elemwise


### PR DESCRIPTION
This commit is the first step of the plan to make Theano imports compatible with 3.x:
1. Remove unnecessary imports.
2. Convert relative imports to absolute.
3. Fix circular dependency issues by either eliminating "from xyz" imports or moving them inside functions.
