### PR TITLE
BUG: unreferenced variable.

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -944,7 +944,7 @@ class ModuleCache(object):
                     if not os.path.exists(location):
                         # Temporary fix, we should make sure it don't
                         # get deleted by the clear*() fct.
-                        os.makedirs(path)
+                        os.makedirs(location)
 
                     if module_hash in self.module_hash_to_key_data:
                         _logger.debug("Duplicated module! Will re-use the "


### PR DESCRIPTION
```
5754e615 (Frederic Bastien  2013-02-06 17:08:51 -0500  944)                     if not os.path.exists(location):
5754e615 (Frederic Bastien  2013-02-06 17:08:51 -0500  945)                         # Temporary fix, we should make sure it don't
5754e615 (Frederic Bastien  2013-02-06 17:08:51 -0500  946)                         # get deleted by the clear*() fct.
5754e615 (Frederic Bastien  2013-02-06 17:08:51 -0500  947)                         os.makedirs(path)
```

@nouiz :)

This is something that was unlikely to be caught by a test, but something that is easily detected with pyflakes. @nouiz you use emacs; maybe [these instructions](http://reinout.vanrees.org/weblog/2010/05/11/pep8-pyflakes-emacs.html) would help you set it up to catch it automatically in your editor?
