### PR TITLE
Install scipy in travis-ci buildbot.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 #  - "3.2"
 # command to install dependencies
 before_install:
-  - sudo apt-get install -qq libatlas3gf-base libatlas-dev liblapack-dev
+  - sudo apt-get install -qq libatlas3gf-base libatlas-dev liblapack-dev gfortran
 #  - sudo apt-get install -qq libopenblas-dev
 install:
 # If we don't install numpy before SciPy 0.10.1, the SciPy installations fails.


### PR DESCRIPTION
There is now change on how travis compute the time allocated per projects.

This could mean maybe we have enough time to compile scipy now.

This PR is to try this.
