### PR TITLE
Travis ci scipy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   - PART="theano/tensor/tests/test_basic.py"
   - PART="-e test_basic.py theano/tensor/tests"
 script:
-  - 'if [ `expr "$PART" : '.*sparse'` -gt "0" ]; then pip install scipy==0.8 --use-mirrors; fi'
+  - "if [ `expr \"$PART\" : '.*sparse'` -gt \"0\" ]; then pip install scipy==0.8 --use-mirrors; fi"
   - export THEANO_FLAGS=warn.ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise
   - python --version
   - uname -a


### PR DESCRIPTION
Make the travis test faster by installing scipy only for the part needed.

scipy is very long to compile and install.
