### PR TITLE
Initial version of the compatibility guide.

### DIFF
--- a/doc/developer/compat.txt
+++ b/doc/developer/compat.txt
@@ -11,8 +11,12 @@ Installation (2to3 and setup.py)
 --------------------------------
 
 
-Compatibility package (theano.compat)
+Python code compatibility
 -------------------------------------
+
+
+Compatibility package (theano.compat)
+.....................................
 
 Compatibility between 2.x and 3.x is implemented using six_, a Python
 2 and 3 compatibility library by Benjamin Peterson.  A copy of six_
@@ -33,7 +37,21 @@ Incorrect:
 
 ::
 
-   from six import b 
+   from six import b
+
+Strings, bytes and unicode
+..........................
+
+
+
+C code compatibility
+--------------------
+
+Module initialization
+.....................
+
+PyCapsule and PyCObject
+.......................
 
 
 


### PR DESCRIPTION
@delallea> I was wondering, do you think you could write a short documentation on coding guidelines (both Python & C) to make it less likely for future development to break Python 3 compatibility?

I am submitting a very preliminary version of the guide mostly to establish the right place and format for it.  I don't think we need a Py3k only guide.  IMO, maintaining compatibility with 2.4 is much harder these days than compatibility between 2.7 and 3.2.  I intend to make this guide a one-stop reference for all backward and forward compatibility issues.
