### PR TITLE
fix bug reported by Nicolas

### DIFF
--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -1268,6 +1268,8 @@ class Scan(PureOp):
                     # It means the gradient is undefined (which implies
                     # is connected)
                     gmp[x] = x
+                except gradient.DisconnectedInputError:
+                    gmp[x] = None
             return [gmp.get(p, None) for p in diff_inputs]
 
         def _get_inner_outs(oidx):

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -3427,6 +3427,15 @@ class T_Scan(unittest.TestCase):
         assert numpy.allclose(outs[2], v_w + 3)
         assert numpy.allclose(sh.get_value(), v_w + 4)
 
+    def test_grad_bug_disconnected_input(self):
+        W = theano.shared(numpy.zeros((3, 3)), name='W')
+        v = theano.tensor.ivector(name='v')
+        y, _ = theano.scan(lambda i, W: W[i], sequences=v, outputs_info=None, non_sequences=W)
+
+        #This used to raise an exception
+        f = theano.function([v], theano.tensor.grad(y.sum(), W))
+        assert numpy.allclose(f([1,2]), [[0,0,0],[1,1,1],[1,1,1]])
+
     def test_clone(self):
         def test(x, y, mention_y):
             if mention_y:


### PR DESCRIPTION
The problem was that the new version of compute_gradient does not return None for a disconnected gradient anymore, but it raises a DisconnectedError. I've changed the code to catch that error and replace it with None, so the rest of the logic in scan_op.grad works as it used to. 

I've added a test (the sample send by Nicolas). 
