### PR TITLE
Typo in try_compile_tmp in op.py

### DIFF
--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -793,7 +793,7 @@ int main( int argc, const char* argv[] )
 }
         """
         default_openmp = GCC_compiler.try_compile_tmp(
-                code=code,
+                src_code=code,
                 tmp_prefix='test_omp_',
                 flags=['-fopenmp'],
                 try_run=False)


### PR DESCRIPTION
This may be a typo in `try_compile_tmp` in `OpenMPOp` where the `code` should be `src_code`.
