### PR TITLE
scan_utils.py: Make traversal routines remember visited nodes

### DIFF
--- a/theano/scan_module/scan_utils.py
+++ b/theano/scan_module/scan_utils.py
@@ -114,8 +114,8 @@ def traverse(out, x, x_copy, d, visited=None):
     This happens because initially shared variables are on GPU .. which is
     fine for the main computational graph but confuses things a bit for the
     inner graph of scan '''
-    # ``visited`` is a set of nodes that are already known and do not need
-    # to be checked again, speeding up the traversal of interconnected graphs.
+    # ``visited`` is a set of nodes that are already known and don't need to be
+    # checked again, speeding up the traversal of multiply-connected graphs.
     # if a ``visited`` set is given, it will be updated in-place so the callee
     # knows which nodes we have seen.
     if visited is None:
@@ -997,8 +997,8 @@ def forced_replace(out, x, y):
     if out is None:
         return None
 
-    # ``visited`` is a set of nodes that are already known and do not need
-    # to be checked again, speeding up the traversal of interconnected graphs.
+    # ``visited`` is a set of nodes that are already known and don't need to be
+    # checked again, speeding up the traversal of multiply-connected graphs.
     visited = set()
     def local_traverse(graph, x):
         if graph in visited:


### PR DESCRIPTION
As discussed on [theano-dev](https://groups.google.com/forum/?fromgroups=#!topic/theano-dev/yMJMZxGpd4Y), a particular graph I was working with took extraordinarily long to be traversed within scan_utils.py:traverse and scan_utils.py:forced_replace.traverse -- so long that I actually never saw it finish. The reason was that large parts of the graph were reachable via multiple paths and thus where traversed again and again, without producing any new findings. The attached pull request makes the traversal routines visit each node at most once, cutting down the computation time from >80 minutes to 2 seconds in my case without changing the result.

NEWS.txt:
- Speed up compilation with Scan (Jan Schlüter)
  - This fix a slow down introduced in one of Theano 0.6rc? version.
