### PR TITLE
Removed a misleading comment.

### DIFF
--- a/theano/sandbox/cuda/cuda_ndarray.cu
+++ b/theano/sandbox/cuda/cuda_ndarray.cu
@@ -260,7 +260,6 @@ __global__ void name (unsigned int numEls,  \
         for (unsigned int _d = 0; _d < nd; ++_d) \
         { \
             unsigned int d = nd - _d-1;  \
-            /* i_d used to be unsigned, but their is a bug in nvcc 3.0. making it signed fix the bug.*/\
             int i_d = ii % dim[d]; /* i_d is our position in the d'th dimension   */ \
             ii = ii / dim[d]; \
             a_i += i_d * a_str[d]; /* increment our a and z pointers by i_d elements */ \


### PR DESCRIPTION
The value added to a_i (result of multiplication i_d*a_str[d]) was unsigned int, which broke when strides were negative.
This is not a bug in nvcc 3.0, it is correct behavior according to the C99 standard:

"Otherwise, if the operand that has unsigned integer type has rank greater or equal to the rank of the type of the other operand, then the operand with signed integer type is converted to the type of the operand with unsigned integer type."
