### PR TITLE
Added 'on_opt_error=pdb' to fall into pdb on error

### DIFF
--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -310,13 +310,13 @@ import theano and print the config variable, as in:
 
 .. attribute:: on_opt_error
 
-    String value: 'warn' or 'raise'
+    String value: 'warn', 'raise' or 'pdb'
 
     Default: 'warn'
 
     When a crash occurs while trying to apply some optimization, either warn
-    the user and skip this optimization ('warn'), or raise the exception
-    ('raise').
+    the user and skip this optimization ('warn'), raise the exception
+    ('raise'), or fall into the pdb debugger ('pdb').
 
 .. attribute:: on_shape_error
 

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -157,9 +157,9 @@ AddConfigVar('optimizer',
         in_c_key=False)
 
 AddConfigVar('on_opt_error',
-        ("What to do when an optimization crashes: warn and skip it, or raise "
-         "the exception"),
-        EnumStr('warn', 'raise'),
+        ("What to do when an optimization crashes: warn and skip it, raise "
+         "the exception, or fall into the pdb debugger."),
+        EnumStr('warn', 'raise', 'pdb'),
         in_c_key=False)
 
 

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -5,6 +5,7 @@ amount of useful generic optimization tools.
 
 import copy
 import logging
+import pdb
 import sys
 import time
 
@@ -147,6 +148,8 @@ class SeqOptimizer(Optimizer, list):
         _logger.error(traceback.format_exc())
         if config.on_opt_error == 'raise':
             raise exc
+        elif config.on_opt_error == 'pdb':
+            pdb.post_mortem(sys.exc_info()[2])
 
     def __init__(self, *opts, **kw):
         """WRITEME"""
@@ -1084,7 +1087,11 @@ class NavigatorOptimizer(Optimizer):
         _logger.error("Optimization failure due to: %s" % str(local_opt))
         _logger.error("TRACEBACK:")
         _logger.error(traceback.format_exc())
-        if isinstance(exc, AssertionError) or config.on_opt_error == 'raise':
+        if config.on_opt_error == 'pdb':
+            pdb.post_mortem(sys.exc_info()[2])
+        elif isinstance(exc, AssertionError) or config.on_opt_error == 'raise':
+            # We always crash on AssertionError because something may be
+            # seriously wrong if such an exception is raised.
             raise exc
 
     @staticmethod


### PR DESCRIPTION
This makes it easier to debug crashes in optimizations.

I don't see how this could be tested automatically, but I manually tested it by adding dummy crashes in `MergeOptimizer.apply` and `local_lift_transpose_through_dot`, and both broke into pdb in the correct place.
