### PR TITLE
Revert "msvc doesn't understand -Wl,-rpath option"

### DIFF
--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -456,8 +456,7 @@ def ldflags(libs=True, flags=False, libs_dir=False, include_dir=False):
         elif flags and t1 == 'L':
             #to find it when we load the compiled op if the env of the
             #used is not well configured.
-            if sys.platform != 'win32':
-                rval.append('-Wl,-rpath,' + t[2:])
+            rval.append('-Wl,-rpath,' + t[2:])
     return rval
 
 


### PR DESCRIPTION
This reverts commit cc639be5d0cad72a4da3fd9f667a83d939fc4d1c.

This shouldn't be done on the platform, but on the compiler. Anyway,
we won't make GPU op link to BLAS in Pylearn2 for now, so I just
remove this.
