### PR TITLE
MAINT: Remove unnecessary check from before swapaxes (API change)

### DIFF
--- a/theano/gof/cutils.py
+++ b/theano/gof/cutils.py
@@ -117,11 +117,9 @@ map_increment(PyArrayMapIterObject *mit, PyObject *op, inplace_map_binop add_inp
         return -1;
     }
     if ((mit->subspace != NULL) && (mit->consec)) {
-        if (mit->iteraxes[0] > 0) {
-            PyArray_MapIterSwapAxes(mit, (PyArrayObject **)&arr, 0);
-            if (arr == NULL) {
-                return -1;
-            }
+        PyArray_MapIterSwapAxes(mit, (PyArrayObject **)&arr, 0);
+        if (arr == NULL) {
+            return -1;
         }
     }
     it = (PyArrayIterObject*)


### PR DESCRIPTION
This check was a speed optimization in the numpy code. Due to
a small change in the MapIter API, the check is now wrong in
corner cases and becomes fully unnecessary.
The previous API had not been public in any release numpy
version.
