### PR TITLE
FIX: Do not explicitly link against libpython2.x on OS X.

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1448,14 +1448,10 @@ def std_lib_dirs_and_libs():
         python_lib_dir = os.path.join(os.path.dirname(python_inc), 'libs')
         return [libname], [python_lib_dir]
 
-    # DSE Patch 2 for supporting OSX frameworks.
-    # Suppress -lpython2.x when frameworks are present
+    # Suppress -lpython2.x on OS X since the `-undefined dynamic_lookup`
+    # makes it unnecessary.
     elif sys.platform == 'darwin':
-        if python_inc.count('Python.framework'):
-            return [], []
-        else:
-            libname = os.path.basename(python_inc)
-            return [libname], []
+        return [], []
     else:
         # Typical include directory: /usr/include/python2.6
         libname = os.path.basename(python_inc)


### PR DESCRIPTION
On OS X, for both framework and non-framework builds of Python, the correct way to link extension modules is to use the link flag `-undefined dynamic_lookup` instead of specifying `-framework Python` or `-lpython2.x`. With either of the latter, it is very easy to accidentally link against Python distributions that are on the system but are not the Python being used to build Theano. This is a _very_ common case on OS X since Python is provided by the OS, but users should be using third party builds of Python.

I believe this addresses issue #1319. I have not been able to test how this affects GPU-using extension modules with nvcc, so I would appreciate if someone else could test that.
