### PR TITLE
[FIX] fix gh-1344. Scan opt error/warning.

### DIFF
--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -506,7 +506,7 @@ class PushOutSeqScan(gof.Optimizer):
                     replace_with[x] = y
 
             # We need to add one extra dimension to the outputs
-            if replace_with:
+            if replace_with and len(replace_with) == len(node.outputs):
                 fgraph.replace_all_validate_remove(
                     replace_with.items(),
                     remove=[node],


### PR DESCRIPTION
@razvan, can you review this?

Do you think we can optimize this case easily? In fact, in this case, we pushout nothing, do you see a way to remove only the first output? To remove both output?
