### PR TITLE
Backport new exception to python 2.4

### DIFF
--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -1494,6 +1494,7 @@ def verify_grad(fun, pt, n_tests=2, rng=None, eps=None,
 class GradientError(Exception):
     """This error is raised when a gradient is calculated, but incorrect."""
     def __init__(self, arg, err_pos, abs_err, rel_err, abs_tol, rel_tol):
+        Exception.__init__(self)  # to be compatible with python2.4
         self.arg = arg
         self.err_pos = err_pos
         self.abs_err = abs_err

--- a/theano/tests/unittest_tools.py
+++ b/theano/tests/unittest_tools.py
@@ -318,6 +318,7 @@ def str_diagnostic(expected, value, rtol, atol):
 
 class WrongValue(Exception):
     def __init__(self, expected_val, val, rtol, atol):
+        Exception.__init__(self)  # to be compatible with python2.4
         self.val1 = expected_val
         self.val2 = val
         self.rtol = rtol


### PR DESCRIPTION
We use the e.args field elsewhere and it is set only if we call Exception.**init** in python 2.4
