### PR TITLE
Fix a crash on Mac OS when sys.prefix is different from its realpath

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1684,6 +1684,7 @@ class GCC_compiler(object):
                 cxxflags.extend(['-framework', 'Python'])
             if 'Anaconda' in sys.version:
                 new_path = os.path.join(sys.prefix, "lib")
+                new_path = os.path.realpath(new_path)
                 v = os.getenv("DYLD_FALLBACK_LIBRARY_PATH", None)
                 if v is not None:
                     # This will resolve symbolic links


### PR DESCRIPTION
The problem was that new_path was actually in the environment variable,
but when realpath(v) was called, it became a different string (starting
with a single backslash instead of two).
