### PR TITLE
add missing import

### DIFF
--- a/theano/tensor/type_other.py
+++ b/theano/tensor/type_other.py
@@ -1,6 +1,7 @@
 #
 # Slice type and Op. None Type and NoneConst.
 #
+import theano
 from theano.gof import Apply, Constant, Op, Type
 from theano.gradient import DisconnectedType
 


### PR DESCRIPTION
I'm not diving too deep into why this was missing.  Presumably test coverage here is poor.

Line 12 of `theano/tensor/type_other.py`

```
x = theano.tensor.as_tensor_variable(x, ndim=0) 
```

Yet `theano` has not been directly imported.
