### PR TITLE
FIX: Example code from tutorial page fails with conversion error

### DIFF
--- a/doc/tutorial/examples.txt
+++ b/doc/tutorial/examples.txt
@@ -254,7 +254,7 @@ for the purpose of one particular function.
 .. theano/tests/test_tutorial.py:T_examples.test_examples_8
 
 >>> fn_of_state = state * 2 + inc
->>> foo = T.lscalar()  # the type (lscalar) must match the shared variable we
+>>> foo = T.iscalar()  # the type (lscalar) must match the shared variable we
 >>>                    # are replacing with the ``givens`` list
 >>> skip_shared = function([inc, foo], fn_of_state,
         givens=[(state, foo)])


### PR DESCRIPTION
Example code from tutorial page http://deeplearning.net/software/theano/tutorial/examples.html fails with
conversion error, this change fix the problem.

NEWS.txt
- fix tutorial on python with 32 bit int (Ilya Dyachenko)
