### PR TITLE
BUGFIX: tutorial -> Derivatives in Theano -> Jacobian times a Vector -> L-operator.

### DIFF
--- a/doc/tutorial/gradients.txt
+++ b/doc/tutorial/gradients.txt
@@ -221,8 +221,8 @@ f(x)}{\partial x}`. The *L-operator* is also supported for generic tensors
 >>> x = T.dvector('x')
 >>> y = T.dot(x, W)
 >>> VJ = T.Lop(y, W, v)
->>> f = theano.function([W,v,x], JV)
->>> f([[1, 1], [1, 1]], [2, 2], [0, 1])
+>>> f = theano.function([v,x], VJ)
+>>> f([2, 2], [0, 1])
 array([[ 0.,  0.],
        [ 2.,  2.]])
 


### PR DESCRIPTION
I've fixed a bug in tutorial described here https://groups.google.com/forum/#!topic/theano-users/nC2l8e-WL3c/discussion
Error text: "UnusedInputError: theano.function was asked to create a function computing outputs given certain inputs, but the provided input variable at index 0 is not part of the computational graph needed to compute the outputs: W. To make this error into a warning, you can pass the parameter on_unused_input='warn' to theano.function. To disable it completely, use on_unused_input='ignore'." 
