### PR TITLE
Use compat.python2x.all instead of numpy.all on generator

### DIFF
--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -2,6 +2,7 @@ import numpy
 
 import theano
 from theano.compat import PY3
+from theano.compat.python2x import all
 from theano.scalar import ComplexError, IntegerDivisionError
 from theano.gof import Constant, Variable
 from theano.gof.utils import hashtype
@@ -366,8 +367,8 @@ class _tensor_py_operators:
 
         if advanced:
             if (axis is not None
-                and numpy.all(a == slice(None) for a in args[:axis])
-                and numpy.all(a == slice(None) for a in args[axis + 1:])
+                and all(a == slice(None) for a in args[:axis])
+                and all(a == slice(None) for a in args[axis + 1:])
                 and isinstance(args[axis], (
                         numpy.ndarray,
                         list,


### PR DESCRIPTION
Otherwise, the generator evaluates to "True", because numpy.all does not
actually iterate through it.

Also add test case to check that m[0, idx_list] triggers full
advanced indexing, not "take".

This should fix gh-1499.
