### PR TITLE
Fix command not returning with recent mingw64

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1570,7 +1570,7 @@ class GCC_compiler(object):
                 if p.returncode != 0:
                     return None
 
-                lines = StringIO.StringIO(stdout + stderr).readlines()
+                lines = StringIO(stdout + stderr).readlines()
                 lines = decode_iter(lines)
                 if parse:
                     selected_lines = []


### PR DESCRIPTION
This should address both problems reported at gh-1544

NEWS.txt:
- Fix command not returning with recent mingw64 on Windows (Pascal L., reported by many people)
