### PR TITLE
Use empty lists as default args where appropriate  (cosmetics)

### DIFF
--- a/theano/compile/debugmode.py
+++ b/theano/compile/debugmode.py
@@ -492,9 +492,9 @@ def char_from_number(number):
     return rval
 
 
-def debugprint(r, prefix='', depth=-1, done=None, print_type=False,
+def debugprint(r, prefix='', depth=-1, done={}, print_type=False,
                file=sys.stdout, print_destroy_map=False,
-               print_view_map=False, order=None, ids='CHAR',
+               print_view_map=False, order=[], ids='CHAR',
                stop_on_name=False, prefix_child=None):
     """Print the graph leading to `r` to given depth.
 
@@ -519,12 +519,6 @@ def debugprint(r, prefix='', depth=-1, done=None, print_type=False,
     """
     if depth == 0:
         return
-
-    if order is None:
-        order = []
-
-    if done is None:
-        done = dict()
 
     if print_type:
         type_str = ' <%s>' % r.type
@@ -1537,9 +1531,7 @@ class _Linker(gof.link.LocalLinker):
         if schedule:
             self.schedule = schedule
 
-    def accept(self, fgraph, no_recycling=None):
-        if no_recycling is None:
-            no_recycling = []
+    def accept(self, fgraph, no_recycling=[]):
         if self.fgraph is not None and self.fgraph is not fgraph:
             assert type(self) is _Linker
             return type(self)(maker=self.maker).accept(fgraph, no_recycling)

--- a/theano/compile/function.py
+++ b/theano/compile/function.py
@@ -12,7 +12,7 @@ from numpy import any  # to work in python 2.4
 import warnings
 from theano import gof
 
-def function(inputs, outputs=None, mode=None, updates=None, givens=None,
+def function(inputs, outputs=None, mode=None, updates=[], givens=[],
              no_default_updates=False, accept_inplace=False, name=None,
              rebuild_strict=True, allow_input_downcast=None, profile=None,
              on_unused_input=None):
@@ -159,9 +159,6 @@ def function(inputs, outputs=None, mode=None, updates=None, givens=None,
 
 
     """
-    if updates is None:
-        updates = []
-
     if (isinstance(updates, dict) and
             not isinstance(updates, gof.python25.OrderedDict) and
             len(updates) > 1):
@@ -177,8 +174,6 @@ def function(inputs, outputs=None, mode=None, updates=None, givens=None,
             " the call as the conversion will still be non-deterministic.",
             stacklevel=2)
 
-    if givens is None:
-        givens = []
     if not isinstance(inputs, (list, tuple)):
         raise Exception("Input variables of a Theano function should be"
                         " contained in a list, even when there is a single input.")

--- a/theano/compile/pfunc.py
+++ b/theano/compile/pfunc.py
@@ -16,9 +16,9 @@ _logger = logging.getLogger("theano.compile.pfunc")
 
 
 def rebuild_collect_shared(outputs,
-                           inputs=None,
-                           replace=None,
-                           updates=None,
+                           inputs=[],
+                           replace=[],
+                           updates=[],
                            rebuild_strict=True,
                            copy_inputs_over=True,
                            no_default_updates=False,
@@ -138,8 +138,6 @@ def rebuild_collect_shared(outputs,
         return clone_d[a]
 
     # intialize the clone_d mapping with the replace dictionary
-    if replace is None:
-        replace = []
     try:
         replace_pairs = replace.items()
     except Exception:
@@ -163,9 +161,6 @@ def rebuild_collect_shared(outputs,
         clone_d[v_orig] = clone_v_get_shared_updates(v_repl,
                                                      copy_inputs_over)
 
-    if inputs is None:
-        inputs = []
-
     def clone_inputs(i):
         if not copy_inputs_over:
             return clone_d.setdefault(i, i.clone())
@@ -186,8 +181,6 @@ def rebuild_collect_shared(outputs,
                              ' variable via the `givens` parameter') % v)
 
     # Fill update_d and update_expr with provided updates
-    if updates is None:
-        updates = []
     for (store_into, update_val) in iter_over_pairs(updates):
         if not isinstance(store_into, SharedVariable):
             raise TypeError('update target must be a SharedVariable',
@@ -333,7 +326,7 @@ class Param(object):
         self.implicit = implicit
 
 
-def pfunc(params, outputs=None, mode=None, updates=None, givens=None,
+def pfunc(params, outputs=None, mode=None, updates=[], givens=[],
         no_default_updates=False, accept_inplace=False, name=None,
         rebuild_strict=True, allow_input_downcast=None,
         profile=None, on_unused_input=None):
@@ -416,10 +409,6 @@ def pfunc(params, outputs=None, mode=None, updates=None, givens=None,
     # Then it clones the outputs and the update expressions.  This rebuilds a computation graph
     # from the inputs and the givens.
     #
-    if updates is None:
-        updates = []
-    if givens is None:
-        givens = []
     if profile is None:
         profile = config.profile
         # profile -> True or False


### PR DESCRIPTION
Is there a reason why you chose to use arg=None as default value and then do "if arg is None: arg=[]"? \
I think the methods signature is more clear and the functions are slightly shorter when "arg=[]" is 
directly used as default value.

If you think this is a reasonable change, I would look for more instances of this.
