### PR TITLE
mod derivative

### DIFF
--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -1655,8 +1655,14 @@ class Mod(BinaryScalarOp):
             """) % locals()
 
     def grad(self, (x, y), (gz, )):
+        z = self(x, y)
+        if z.type.dtype in discrete_types:
+            # The gradient does not flow in if the output is discrete
+            return [x.zeros_like(dtype=theano.config.floatX),
+                    y.zeros_like(dtype=theano.config.floatX)]
         return [gz,
-                -(x//y) * gz ]
+                -(x // y) * gz]
+
 mod = Mod(upcast_out, name='mod')
 
 

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -876,6 +876,7 @@ ModTester = makeBroadcastTester(
         x % y, dtype=theano.scalar.basic.upcast(x.dtype, y.dtype)),
     good=copymod(_good_broadcast_div_mod_normal_float,
                  ['complex1', 'complex2']),
+    grad=_grad_broadcast_div_mod_normal,
     )
 
 
@@ -885,6 +886,7 @@ ModInplaceTester = makeBroadcastTester(
         x % y, dtype=theano.scalar.basic.upcast(x.dtype, y.dtype)),
     good=copymod(_good_broadcast_div_mod_normal_float_inplace,
                  ["complex1", "complex2"]),
+    grad=_grad_broadcast_div_mod_normal,
     inplace=True)
 
 _good_broadcast_pow_normal_float = dict(same_shapes = (rand_ranged(1, 5, (2, 3)), rand_ranged(-3, 3, (2, 3))),


### PR DESCRIPTION
It's sometimes useful to take the derivative of the mod operator, e.g. when the first argument is an angle variable.

It wasn't obvious to me how to add a proper unit test, but here's a test script:
https://gist.github.com/joschu/7443684
