### PR TITLE
Make Theano (or at least DenseDesignMatrix) work with numpy.memmap arrays

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -370,7 +370,7 @@ def constant_or_value(x, rtype, name=None, ndim=None, dtype=None):
             # it will work if the long fits in int64 or uint64.
             x_ = numpy.asarray(x)
 
-    assert type(x_) == numpy.ndarray
+    assert isinstance(x_, numpy.ndarray)
 
     bcastable = [d == 1 for d in x_.shape]
     if ndim is not None:


### PR DESCRIPTION
The numpy.memmap array is a subclass of numpy.ndarray. The assert
prevents DenseDesignMatrix from working with a numpy.memmap array.
Making said assert less specific makes it work.
