### PR TITLE
Add ARM architecture check for Raspberry Pi

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1711,10 +1711,13 @@ class GCC_compiler(object):
         # in the key of the compiled module, avoiding potential conflicts.
 
         # Figure out whether the current Python executable is 32
-        # or 64 bit and compile accordingly.
-        n_bits = local_bitwidth()
-        cxxflags.append('-m%d' % n_bits)
-        _logger.debug("Compiling for %s bit architecture", n_bits)
+        # or 64 bit and compile accordingly. This step is ignored for ARM
+        # architectures in order to make Theano compatible with the Raspberry
+        # Pi.
+        if any([not 'arm' in flag for flag in GCC_compiler.march_flags]):
+            n_bits = local_bitwidth()
+            cxxflags.append('-m%d' % n_bits)
+            _logger.debug("Compiling for %s bit architecture", n_bits)
 
         if sys.platform != 'win32':
             # Under Windows it looks like fPIC is useless. Compiler warning:


### PR DESCRIPTION
Hopefully the check is not too restrictive. If it is, I could check for `armv6` instead of just `arm` in order to target only the RPi's specific ARM architecture.
