### PR TITLE
Make tensor.{constant,as_tensor_variable} work with memmap.

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -370,7 +370,7 @@ def constant_or_value(x, rtype, name=None, ndim=None, dtype=None):
             # it will work if the long fits in int64 or uint64.
             x_ = numpy.asarray(x)
 
-    assert type(x_) == numpy.ndarray
+    assert type(x_) in [numpy.ndarray, numpy.memmap]
 
     bcastable = [d == 1 for d in x_.shape]
     if ndim is not None:

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -5929,6 +5929,14 @@ class T_as_tensor_variable(unittest.TestCase):
         ten = as_tensor_variable(numpy.array([True, False, False, True, True]))
         assert ten.type.dtype == 'uint8'
 
+    def test_memmap(self):
+        inp = numpy.random.rand(4, 3)
+        f, fname = mkstemp()
+        new_inp = numpy.memmap(fname, dtype=inp.dtype,
+                               mode='w+', shape=inp.shape)
+        new_inp[...] = inp
+        x = as_tensor_variable(new_inp)
+
 
 class test_complex_mod(unittest.TestCase):
     """Make sure % fails on complex numbers."""


### PR DESCRIPTION
close gh-1610
- Make tensor.{constant,as_tensor_variable} work with memmap. (Christian Hudon, Frédéric Bastien)
