### PR TITLE
GpuEye compyte

### DIFF
--- a/theano/sandbox/gpuarray/basic_ops.py
+++ b/theano/sandbox/gpuarray/basic_ops.py
@@ -683,7 +683,7 @@ class GpuEye(GpuKernelBase, Op):
     def c_kernel_code(self):
         return """
 KERNEL void k(GLOBAL_MEM %(ctype)s *a, ga_size n, ga_size m) {
-    ga_size nb = (ga_size)min((ga_ulong)n, (ga_ulong)m);
+    ga_size nb = n < m ? n : m;
     for (ga_size i = LID_0; i < nb; i += LDIM_0) {
         a[i*m + i] = 1;
     }


### PR DESCRIPTION
The first commit adds a helper for dealing with kernels in c_code().

The second commit makes GpuEye more compyte-like to show how to convert an op to the compyte style.
