### PR TITLE
[MRG] Fix crash when specifing march in cxxflags.

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1714,7 +1714,7 @@ class GCC_compiler(object):
         # or 64 bit and compile accordingly. This step is ignored for ARM
         # architectures in order to make Theano compatible with the Raspberry
         # Pi.
-        if any([not 'arm' in flag for flag in GCC_compiler.march_flags]):
+        if any([not 'arm' in flag for flag in cxxflags]):
             n_bits = local_bitwidth()
             cxxflags.append('-m%d' % n_bits)
             _logger.debug("Compiling for %s bit architecture", n_bits)


### PR DESCRIPTION
This should also make the warning printed only once.
