### PR TITLE
Add config option to specifiy cublas library name.

### DIFF
--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -29,6 +29,10 @@ AddConfigVar('pycuda.init',
         BoolParam(False),
         in_c_key=False)
 
+AddConfigVar('cublas.lib',
+        """Name of the cuda blas library for the linker.""",
+        StrParam('cublas'))
+
 
 #is_nvcc_available called here to initialize global vars in
 #nvcc_compiler module
@@ -152,7 +156,7 @@ if compile_cuda_ndarray and cuda_available:
                             'cuda_ndarray',
                             code,
                             location=cuda_ndarray_loc,
-                            include_dirs=[cuda_path], libs=['cublas'],
+                            include_dirs=[cuda_path], libs=[config.cublas.lib],
                             preargs=['-O3'] + compiler.compile_args())
                     from cuda_ndarray.cuda_ndarray import *
             except Exception, e:

--- a/theano/sandbox/cuda/type.py
+++ b/theano/sandbox/cuda/type.py
@@ -400,7 +400,7 @@ class CudaNdarrayType(Type):
     def c_libraries(self):
         # returning cublas because the cuda_ndarray.cuh header
         # includes calls to SetVector and cublasGetError
-        return ['cudart', 'cublas', 'cuda_ndarray']
+        return ['cudart', config.cublas.lib, 'cuda_ndarray']
 
     def c_support_code(cls):
         return ""


### PR DESCRIPTION
Adds an optional section [cublas] to .theanorc that lets you specify a non-default name for libcublas.so.  You can also force linking against a specific version of the library with ,e.g.

[cublas]
lib = :libcublas.so.4

The config section is optional and the standard name is used by default, so this change should be invisible to anyone who doesn't explicitly change the library name.
