### PR TITLE
Compile the inner fct in scan only once per instance.

### DIFF
--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -566,12 +566,15 @@ class Scan(PureOp):
                 profile = ScanProfileStats(name=self.name)
         elif self.profile:
             profile = self.profile
-        self.fn = function(wrapped_inputs,
-                           wrapped_outputs,
-                           mode=self.mode_instance,
-                           name=self.name,
-                           profile=profile,
-                           on_unused_input='ignore')
+        # make_thunk can be called many times on the same op
+        # we do not want to recompile the inner fct every time.
+        if not getattr(self, 'fn', None):
+            self.fn = function(wrapped_inputs,
+                               wrapped_outputs,
+                               mode=self.mode_instance,
+                               name=self.name,
+                               profile=profile,
+                               on_unused_input='ignore')
 
         try:
             cython_mintaps = numpy.asarray(self.mintaps, dtype='int32')


### PR DESCRIPTION
This make the new test run in DebugMode in 1500s instead of 2ks.
