### PR TITLE
c.data + 1 return numpy.float64 when c.data is float32. But we compute i...

### DIFF
--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -5960,15 +5960,15 @@ class T_get_scalar_constant_value(unittest.TestCase):
         # elemwise are in the fct.
         c = theano.tensor.constant(numpy.random.rand())
         s = c + 1
-        assert get_scalar_constant_value(s) == c.data + 1
+        assert numpy.allclose(get_scalar_constant_value(s), c.data + 1)
         s = c - 1
-        assert get_scalar_constant_value(s) == c.data - 1
+        assert numpy.allclose(get_scalar_constant_value(s), c.data - 1)
         s = c * 1.2
-        assert get_scalar_constant_value(s) == c.data * 1.2
+        assert numpy.allclose(get_scalar_constant_value(s), c.data * 1.2)
         s = c < 0.5
-        assert get_scalar_constant_value(s) == int(c.data < 0.5)
+        assert numpy.allclose(get_scalar_constant_value(s), int(c.data < 0.5))
         s = tensor.second(c, .4)
-        assert get_scalar_constant_value(s) == .4
+        assert numpy.allclose(get_scalar_constant_value(s), .4)
 
     def test_second(self):
         #Second should apply when the value is constant but not the shape


### PR DESCRIPTION
...t in float32 in Theano.

So when the test have floatX=float32, we have an error.
