### PR TITLE
Fix for string substitution / implicity tuple bug.

### DIFF
--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -792,14 +792,14 @@ class ScalarOp(Op):
             if not callable(output_types_preference):
                 raise TypeError(
                     "Expected a callable for the 'output_types_preference' argument to %s. (got: %s)" %
-                    self.__class__, output_types_preference)
+                    (self.__class__, output_types_preference))
             self.output_types_preference = output_types_preference
 
     def make_node(self, *inputs):
         if self.nin >= 0:
             if len(inputs) != self.nin:
                 raise TypeError("Wrong number of inputs for %s.make_node (got %i(%s), expected %i)" %
-                                self, len(inputs), str(inputs), self.nin)
+                                (self, len(inputs), str(inputs), self.nin))
         inputs = [as_scalar(input) for input in inputs]
         outputs = [t() for t in self.output_types([input.type
                                                    for input in inputs])]


### PR DESCRIPTION
The current code produces an error on reaching lines 795 or 802, because of incorrect assumptions about the relative priority of string substitution and implicit tuple creation (string substitution happens first).

/s/Theano/theano/scalar/basic.pyc in make_node(self, *inputs)
    800             if len(inputs) != self.nin:
    801                 raise TypeError("Wrong number of inputs for
%s.make_node (got %i(%s), expected %i)" %
--> 802                                 self, len(inputs),
str(inputs), self.nin)
    803         inputs = [as_scalar(input) for input in inputs]
    804         outputs = [t() for t in self.output_types([input.type

TypeError: not enough arguments for format string

The fix was simply to enclose the intended implicit tuple in a set of parentheses.
