### PR TITLE
Uniformize the typedef name of Scalar's dtype.

### DIFF
--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -245,7 +245,8 @@ class Scalar(Type):
     def c_declare(self, name, sub):
         return """
         %(dtype)s %(name)s;
-        typedef %(dtype)s %(name)s_dtype;
+        typedef %(dtype)s %(name)s_dtype; // Deprecated use dtype_%(name)s instead.
+        typedef %(dtype)s dtype_%(name)s;
         """ % dict(name=name, dtype=self.dtype_specs()[1])
 
     def c_init(self, name, sub):


### PR DESCRIPTION
Related to this discussion: https://groups.google.com/forum/#!topic/theano-dev/7tUwqrVauFk
