### PR TITLE
Assertion failure when there are multiple versions of Enthought Canopy

### DIFF
--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -239,6 +239,9 @@ SOMEPATH/Canopy_64bit/User/lib/python2.7/site-packages/numpy/distutils/system_in
             for sub in p2:
                 if not os.path.exists(os.path.join(p, sub, subsub)):
                     p2.remove(sub)
+            assert len(p2) >= 1, ("Canopy changed the location of MKL",
+                                   p, p2, [os.listdir(os.path.join(p, sub))
+                                           for sub in p2])
             if sys.platform == "linux2":
                 p2 = os.path.join(p, p2[0], "lib")
                 assert os.path.exists(p2), "Canopy changed the location of MKL"


### PR DESCRIPTION
...nopy installed. For example, on my system, I get p2 like this:

['canopy-1.3.0.1715.rh5-x86_64', 'canopy-1.2.0.1610.rh5-x86_64', 'updates']

The for loop on Ln 239 will only remove the 'updates' in p2, which leads to the failure in the assert statement on Ln 242.
