### PR TITLE
Python3 compatibility in test program compilation

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1800,6 +1800,11 @@ class GCC_compiler(object):
             fd, path = tempfile.mkstemp(suffix='.c', prefix=tmp_prefix)
             exe_path = path[:-2]
             try:
+                # Python3 compatibility: try to cast Py3 strings as Py2 strings
+                try:
+                    src_code = b(src_code)
+                except:
+                    pass
                 os.write(fd, src_code)
                 os.close(fd)
                 fd = None


### PR DESCRIPTION
Similar fix to #1660.

Without this fix, a `'str' does not support the buffer interface` error is raised in Python 3.3 on Mac OSX 10.9. One place it occurs is during testing for the Mac OS sdot bug (line 73, blas_headers.py)

NEWS:
- Crash fix for python3 on Mac. (Jeremiah Lowin)
