### PR TITLE
Speed up matVecModM function.

### DIFF
--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -26,18 +26,8 @@ if cuda_available:
     from theano.sandbox.cuda import (CudaNdarrayType,
                                      float32_shared_constructor)
 
-
 def matVecModM(A, s, m):
-    # return (A * s) % m
-    x = numpy.zeros_like(s)
-    for i in xrange(len(x)):
-        for j in xrange(len(s)):
-            r = numpy.int32((numpy.int64(A[i][j]) * s[j] + x[i]) % m)
-            if r >= 0:
-                x[i] = r
-            else:
-                x[i] = r + m
-    return x
+    return numpy.int32(numpy.sum((A*s) % m, 1) % m)
 
 
 def multMatVect(v, A, m1, B, m2):


### PR DESCRIPTION
I'm using a lot of random streams like `uniform(...,nstreams=100000)` and as I increase the number of `nstreams`, the compilation time was also increasing. So, I took a look around and found the initialization part of the MRG_RandomStreams uses the `matVecModM` function a lot.

What I found is the following line will always be positive (for explanation see below), which means the if-else is wasting cpu time:
https://github.com/Theano/Theano/blob/master/theano/sandbox/rng_mrg.py#L35

I got a 2x speed up when removing the if-else. But, I though it could be faster if we could remove those two for loops. I used some numpy magic and now, on my computer it is 3.2x faster.

The reason line 35 will always produce positive number has to do with the modulo operator: `x1 % x2 == x1 - floor(x1 / x2) * x2` (http://docs.scipy.org/doc/numpy/reference/generated/numpy.mod.html) So, as long as the divider (`x2` in the example, or `m` in the `matVecModM` function) is positive (which is the case in ours), the remainder will be positive.

That being said, since we are casting the remainder as a int32, the only way `r` could be negative is if the remainder was greater than `2^31-1` before the cast, which is not the case here because `m` is either `2^31-1` or `2^31 - 21069`.
