### PR TITLE
Speed up random number seeding

### DIFF
--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -27,7 +27,7 @@ if cuda_available:
                                      float32_shared_constructor)
 
 def matVecModM(A, s, m):
-    return numpy.int32(numpy.sum((A*s) % m, 1) % m)
+    return numpy.int32(numpy.dot(A, s) % m)
 
 
 def multMatVect(v, A, m1, B, m2):


### PR DESCRIPTION
This PR deals with speeding up random number seeding (https://github.com/lisa-lab/pylearn2/issues/298). It's basically a faster implementation of matVecModM.
