### PR TITLE
bugfix, for a case that don't happen right now.

### DIFF
--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -587,7 +587,7 @@ class MakeVector(T.Op):
             out[0][...] = inputs
 
     def c_code_cache_version(self):
-        return (1,)
+        return (2,)
 
     def c_code(self, node, name, inp, out_, sub):
         out, = out_
@@ -604,7 +604,7 @@ class MakeVector(T.Op):
         ret = """
         npy_intp dims[1];
         dims[0] = %(out_shape)s;
-        if(!%(out)s || PyArray_DIMS(%(out)s)[0] == %(out_shape)s){
+        if(!%(out)s || PyArray_DIMS(%(out)s)[0] != %(out_shape)s){
             Py_XDECREF(%(out)s);
             %(out)s = (PyArrayObject*)PyArray_EMPTY(1, dims, %(out_dtype)s, 0);
         }


### PR DESCRIPTION
The preallocated output size for make_vector should ALWAYS be the good
shape right now as it only depend on the ndim and that is constant in
the graph and we only give preallocated output of the same node.

This fix will be useful in the futur if we make other type of
preallocated output that could be of the wrong size.

NO NEWS.txt as this don't affect current code.
