### PR TITLE
Add python platform-dependent C include files to the include directories

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1438,8 +1438,12 @@ def get_gcc_shared_library_arg():
 
 
 def std_include_dirs():
-    return (numpy.distutils.misc_util.get_numpy_include_dirs()
-            + [distutils.sysconfig.get_python_inc()])
+    numpy_inc_dirs = numpy.distutils.misc_util.get_numpy_include_dirs()
+    py_inc = distutils.sysconfig.get_python_inc()
+    py_plat_spec_inc = distutils.sysconfig.get_python_inc(plat_specific=True)
+    python_inc_dirs = ([py_inc] if py_inc == py_plat_spec_inc
+                       else [py_inc, py_plat_spec_inc])
+    return numpy_inc_dirs + python_inc_dirs
 
 
 def std_lib_dirs_and_libs():


### PR DESCRIPTION
pyconfig.h is required for lazy_linker. It maybe located in the platform-dependent include directory instead of the general include directory. For example, python 3.3m on Linux Mint 14 x64 version has pyconfig.h in /usr/include/x86_64-linux-gnu/python3.3m instead of /usr/include/python3.3m.

Fail to include the platform-dependent include directory would cause this error:
Compilation failed (return status=1): In file included from /home/hei/.theano/compiledir_Linux-3.5.0-17-generic-x86_64-with-LinuxMint-14-nadia-x86_64-3.3.0-64/lazylinker_ext/mod.cpp:1:0:. /usr/include/python3.3m/Python.h:8:22: fatal error: pyconfig.h: No such file or directory. compilation terminated..
