### PR TITLE
BUGFIX introduced in 4cf0f055b418544e9f6090728466d9f70c04ca07 and merged...

### DIFF
--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -880,6 +880,9 @@ class Elemwise(OpenMPOp):
                   variable.dtype != nout.dtype):
                 variable = numpy.asarray(variable, nout.dtype)
                 storage[0] = variable
+            # numpy.real return a view!
+            elif not variable.flags.owndata:
+                storage[0] = variable.copy()
             else:
                 storage[0] = variable
             i += 1


### PR DESCRIPTION
... the 7 april.

That commit removed copy in Elemwise.perform(), but numpy.real return a view. This is bad if the op isn't inplace!
