### PR TITLE
The -ccbin argument to nvcc has to be a direct argument to nvcc

### DIFF
--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -290,7 +290,7 @@ class NVCC_compiler(object):
         #nvcc argument
         preargs1 = []
         for pa in preargs:
-            for pattern in ['-O', '-arch=',
+            for pattern in ['-O', '-arch=', '-ccbin='
                             '--fmad', '--ftz', '--maxrregcount',
                             '--prec-div', '--prec-sqrt',  '--use_fast_math',
                             '-fmad', '-ftz', '-maxrregcount',


### PR DESCRIPTION
Currently the -ccbin argument gets placed in the list of arguments in -Xcompiler instead of being an argument directly to `nvcc`

Using CUDA6.0 on OSX 10.8.5 with clang `import theano` fails. After some googling I found the recommendation to add:

```
[nvcc]
flags=-ccbin=/usr/bin/clang
```

to my `.theanorc`. However this add the `ccbin=...` command line option in the wrong place.

Starting up a new python instance with `THEANO_FLAGS='floatX=float32,device=gpu'  ipython` and typing `import theano` leads to the following:

```
nvcc warning : The 'compute_10' and 'sm_10' architectures are deprecated, and may be removed in a future release.
clang: error: unsupported option '-dumpspecs'
clang: error: no input files

['nvcc', '-shared', '-g', '-O3', '-m64', '-Xcompiler', '-ccbin=/usr/bin/clang,-DCUDA_NDARRAY_CUH=d67f7c8a21306c67152a70a88a837011,-fPIC', '-Xlinker', '-rpath,/Users/thead/.theano/compiledir_Darwin-12.5.0-x86_64-i386-64bit-i386-2.7.5-64/cuda_ndarray', '-I/Users/thead/virtualenvs/default2/lib/python2.7/site-packages/theano/sandbox/cuda', '-I/Users/thead/virtualenvs/default2/lib/python2.7/site-packages/numpy/core/include', '-I/usr/local/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/include/python2.7', '-o', '/Users/thead/.theano/compiledir_Darwin-12.5.0-x86_64-i386-64bit-i386-2.7.5-64/cuda_ndarray/cuda_ndarray.so', 'mod.cu', '-LNone/lib', '-lcublas', '-lcudart', '-L/usr/local/Cellar/python/2.7.6_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/config', '-ldl', '-lpython2.7', '-Xcompiler', '-framework,CoreFoundation', '-Xlinker', '-pie']
ERROR (theano.sandbox.cuda): Failed to compile cuda_ndarray.cu: ('nvcc return status', 1, 'for cmd', 'nvcc -shared -g -O3 -m64 -Xcompiler -ccbin=/usr/bin/clang,-DCUDA_NDARRAY_CUH=d67f7c8a21306c67152a70a88a837011,-fPIC -Xlinker -rpath,/Users/thead/.theano/compiledir_Darwin-12.5.0-x86_64-i386-64bit-i386-2.7.5-64/cuda_ndarray -I/Users/thead/virtualenvs/default2/lib/python2.7/site-packages/theano/sandbox/cuda -I/Users/thead/virtualenvs/default2/lib/python2.7/site-packages/numpy/core/include -I/usr/local/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/include/python2.7 -o /Users/thead/.theano/compiledir_Darwin-12.5.0-x86_64-i386-64bit-i386-2.7.5-64/cuda_ndarray/cuda_ndarray.so mod.cu -LNone/lib -lcublas -lcudart -L/usr/local/Cellar/python/2.7.6_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/config -ldl -lpython2.7 -Xcompiler -framework,CoreFoundation -Xlinker -pie')
WARNING (theano.sandbox.cuda): CUDA is installed, but device gpu is not available
```

This PR fixes that by recognising -ccbin= as something that should be a preargs1. After this `import theano` works.
