### PR TITLE
inserting missing comma when adding '-ccbin' to direct argument flags

### DIFF
--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -290,7 +290,7 @@ class NVCC_compiler(object):
         #nvcc argument
         preargs1 = []
         for pa in preargs:
-            for pattern in ['-O', '-arch=', '-ccbin='
+            for pattern in ['-O', '-arch=', '-ccbin=',
                             '--fmad', '--ftz', '--maxrregcount',
                             '--prec-div', '--prec-sqrt',  '--use_fast_math',
                             '-fmad', '-ftz', '-maxrregcount',


### PR DESCRIPTION
@betatim provided a fix to Theano/Theano#1912 in commit Theano/Theano@bb4b1a5.  However, that fix did not include a comma on the end of the line, causing the `'-ccflags'` to be merged with the next string `'--fmad'`.  Here's the missing comma.
