### PR TITLE
Stop adding -L/usr/local/cuda/lib{,64} as argument to nvcc.

### DIFF
--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -254,13 +254,6 @@ class NVCC_compiler(object):
             libs.append('cudart')
 
         lib_dirs = std_lib_dirs() + lib_dirs
-        if cuda_root:
-            lib_dirs.append(os.path.join(cuda_root, 'lib'))
-
-            # from Benjamin Schrauwen April 14 2010
-            if sys.platform != 'darwin':
-                # OS X uses universal libraries
-                lib_dirs.append(os.path.join(cuda_root, 'lib64'))
 
         if sys.platform != 'darwin':
             # sometimes, the linker cannot find -lpython so we need to tell it

--- a/theano/sandbox/cuda/type.py
+++ b/theano/sandbox/cuda/type.py
@@ -408,9 +408,6 @@ class CudaNdarrayType(Type):
 
     def c_lib_dirs(self):
         ret = [os.path.dirname(cuda_ndarray.__file__)]
-        cuda_root = config.cuda.root
-        if cuda_root:
-            ret.append(os.path.join(cuda_root, 'lib'))
         return ret
 
     def c_libraries(self):


### PR DESCRIPTION
This was never needed and also causes the errors with fatbinwrap_65.
