### PR TITLE
fix crash of profiling atexit when it clashes with pycuda atexit handler

### DIFF
--- a/theano/compile/profiling.py
+++ b/theano/compile/profiling.py
@@ -31,6 +31,7 @@ config = theano.config
 
 _atexit_print_list = []
 _atexit_print_file = sys.stderr
+_atexit_registered = False
 
 AddConfigVar('profiling.time_thunks',
              """Time individual thunks when profiling""",
@@ -99,7 +100,7 @@ def _atexit_print_fn():
                     n_apply_to_print=config.profiling.n_apply)
 
 
-atexit.register(_atexit_print_fn)
+
 
 
 class ProfileStats(object):
@@ -208,6 +209,10 @@ class ProfileStats(object):
         if atexit_print:
             global _atexit_print_list
             _atexit_print_list.append(self)
+            global _atexit_registered
+            if not _atexit_registered:
+                atexit.register(_atexit_print_fn)
+                _atexit_registered = True
 
     def class_time(self):
         """dict op -> total time on thunks"""


### PR DESCRIPTION
This was the error earlier when using profiling. @abergeron  made the following changes which worked.

```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/u/lisa/local/install_package.fc14_v3/Canopy1.4/appdata/canopy-1.4.0.1938.rh5-x86_64/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/u/huilgolr/Theano/theano/compile/profiling.py", line 65, in _atexit_print_fn
    n_apply_to_print=config.profiling.n_apply)
  File "/u/huilgolr/Theano/theano/compile/profiling.py", line 842, in summary
    self.summary_nodes(file, n_apply_to_print)
  File "/u/huilgolr/Theano/theano/compile/profiling.py", line 550, in summary_nodes
    str(a)[:maxlen])
  File "/u/huilgolr/Theano/theano/gof/graph.py", line 165, in __str__
    return op_as_string(self.inputs, self)
  File "/u/huilgolr/Theano/theano/gof/graph.py", line 937, in op_as_string
    strs = as_string(i, op.inputs, leaf_formatter, node_formatter)
  File "/u/huilgolr/Theano/theano/gof/graph.py", line 1013, in as_string
    return [describe(output) for output in o]
  File "/u/huilgolr/Theano/theano/gof/graph.py", line 1011, in describe
    return leaf_formatter(r)
  File "/u/huilgolr/Theano/theano/sandbox/cuda/var.py", line 52, in __str__
    return "CudaNdarrayConstant{"+str(numpy.asarray(self.data))+"}"
  File "/Tmp/lisa/os_v3/canopy/lib/python2.7/site-packages/numpy/core/numeric.py", line 460, in asarray
    return array(a, dtype, copy=False, order=order)
RuntimeError: error copying data to host
Error in sys.exitfunc:
Traceback (most recent call last):
  File "/u/lisa/local/install_package.fc14_v3/Canopy1.4/appdata/canopy-1.4.0.1938.rh5-x86_64/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/u/huilgolr/Theano/theano/compile/profiling.py", line 65, in _atexit_print_fn
    n_apply_to_print=config.profiling.n_apply)
  File "/u/huilgolr/Theano/theano/compile/profiling.py", line 842, in summary
    self.summary_nodes(file, n_apply_to_print)
  File "/u/huilgolr/Theano/theano/compile/profiling.py", line 550, in summary_nodes
    str(a)[:maxlen])
  File "/u/huilgolr/Theano/theano/gof/graph.py", line 165, in __str__
    return op_as_string(self.inputs, self)
  File "/u/huilgolr/Theano/theano/gof/graph.py", line 937, in op_as_string
    strs = as_string(i, op.inputs, leaf_formatter, node_formatter)
  File "/u/huilgolr/Theano/theano/gof/graph.py", line 1013, in as_string
    return [describe(output) for output in o]
  File "/u/huilgolr/Theano/theano/gof/graph.py", line 1011, in describe
    return leaf_formatter(r)
  File "/u/huilgolr/Theano/theano/sandbox/cuda/var.py", line 52, in __str__
    return "CudaNdarrayConstant{"+str(numpy.asarray(self.data))+"}"
  File "/Tmp/lisa/os_v3/canopy/lib/python2.7/site-packages/numpy/core/numeric.py", line 460, in asarray
    return array(a, dtype, copy=False, order=order)
RuntimeError: error copying data to host
```
