### PR TITLE
[CRASH] Be more resistent to NumPy bad strides for shapes of 1.

### DIFF
--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -721,9 +721,9 @@ class GemmRelated(Op):
         /*
         encode the stride structure of _x,_y,_zout into a single integer
         */
-        unit |= ((Sx[1] == type_size) ? 0x0 : (Sx[0] == type_size) ? 0x1 : 0x2) << 8;
-        unit |= ((Sy[1] == type_size) ? 0x0 : (Sy[0] == type_size) ? 0x1 : 0x2) << 4;
-        unit |= ((Sz[1] == type_size) ? 0x0 : (Sz[0] == type_size) ? 0x1 : 0x2) << 0;
+        unit |= ((Sx[1] == type_size || Nx[1]==1) ? 0x0 : (Sx[0] == type_size || Nx[0]==1) ? 0x1 : 0x2) << 8;
+        unit |= ((Sy[1] == type_size || Ny[1]==1) ? 0x0 : (Sy[0] == type_size || Ny[0]==1) ? 0x1 : 0x2) << 4;
+        unit |= ((Sz[1] == type_size || Nz[1]==1) ? 0x0 : (Sz[0] == type_size || Nz[0]==1) ? 0x1 : 0x2) << 0;
         """
 
     compute_strides = """
@@ -856,7 +856,7 @@ class GemmRelated(Op):
             self.end_switch_typenum), '')
 
     def build_gemm_version(self):
-        return (12, blas_header_version())
+        return (13, blas_header_version())
 
 
 class Gemm(GemmRelated):


### PR DESCRIPTION
NEWS.txt
- Be more tolerant to bad strides in dot/gemm op. (Frederic B., reported by Madison May)

https://stackoverflow.com/questions/25046108/theano-valueerror-some-matrix-has-no-unit-stride
