### PR TITLE
Fixed "cublasHandle_t handle" declaration in cuda_ndarray.cuh.

### DIFF
--- a/theano/sandbox/cuda/cuda_ndarray.cuh
+++ b/theano/sandbox/cuda/cuda_ndarray.cuh
@@ -82,7 +82,7 @@ typedef float real;
 #define NO_VERBOSE_DEVICE_MALLOC 0
 
 /* Use this handle to make cublas calls */
-extern cublasHandle_t handle;
+extern DllExport cublasHandle_t handle;
 
 /**
  * Allocation and freeing of device memory should go through these functions so that the lib can track memory usage.


### PR DESCRIPTION
Required for cuda_convnet compilation in pylearn2 in Windows. Wasn't checked in Linux

Proposed by Pascal Lamblin:
https://groups.google.com/forum/#!topic/pylearn-users/hWKPFMs_OTw
