### PR TITLE
Less verbose error message.

### DIFF
--- a/theano/gof/link.py
+++ b/theano/gof/link.py
@@ -161,7 +161,7 @@ def raise_with_op(node, thunk=None, exc_info=None):
     if theano.config.exception_verbosity == 'high':
         f = StringIO.StringIO()
         theano.printing.debugprint(node, file=f, stop_on_name=True,
-                                   print_type=True)
+                                   print_type=True, stop_on_name=True)
         detailed_err_msg += "\nDebugprint of the apply node: \n"
         detailed_err_msg += f.getvalue()
 


### PR DESCRIPTION
exception_verbosity use min_informative_str at many place that at like
the option I added.
