### PR TITLE
Fixed the compilation errors in mod.cu

### DIFF
--- a/theano/sandbox/cuda/cuda_ndarray.cuh
+++ b/theano/sandbox/cuda/cuda_ndarray.cuh
@@ -6,6 +6,7 @@
 // Py3k treats all ints as longs. This one is not caught by npy_3kcompat.h.
 #define PyNumber_Int PyNumber_Long
 
+#include <algorithm>
 #include "numpy/npy_3kcompat.h"
 
 // Py3k strings are unicode, these mimic old functionality.


### PR DESCRIPTION
The generated mod.cu contains a number of std::min and std::max. Including <algorithm> will remove the not-found errors from these two functions.
