### PR TITLE
Fixed the compilation errors in mod.cu

### DIFF
--- a/theano/sandbox/cuda/cuda_ndarray.cuh
+++ b/theano/sandbox/cuda/cuda_ndarray.cuh
@@ -1,12 +1,13 @@
 #ifndef _CUDA_NDARRAY_H
 #define _CUDA_NDARRAY_H
 
+#include <algorithm>
+
 // Defines for Python 2/3 compatibility.
 #if PY_MAJOR_VERSION >= 3
 // Py3k treats all ints as longs. This one is not caught by npy_3kcompat.h.
 #define PyNumber_Int PyNumber_Long
 
-#include <algorithm>
 #include "numpy/npy_3kcompat.h"
 
 // Py3k strings are unicode, these mimic old functionality.


### PR DESCRIPTION
The generated mod.cu contains a number of `std::min` and `std::max`. `#including <algorithm>` will remove the not-found errors from these two functions.
