### PR TITLE
Resolved issue #2055

### DIFF
--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -313,6 +313,10 @@ class NVCC_compiler(object):
             # add flags for Microsoft compiler to create .pdb files
             preargs2.extend(['/Zi', '/MD'])
             cmd.extend(['-Xlinker', '/DEBUG'])
+            # remove the complaints for the duplication of `double round(double)`
+            # in both math_functions.h and pymath.h,
+            # by not including the one in pymath.h
+            cmd.extend(['-D HAVE_ROUND'])
 
         if local_bitwidth() == 64:
             cmd.append('-m64')


### PR DESCRIPTION
The `double round(double x)` is present in CUDA 6.5.13/6.0.37/5.5.22/5.5.11/4.1.28/4.0.17, so I think it's safe to remove the one in `pymath.h`
