### PR TITLE
Added option to not print inner scan graphs in printing.debugprint()

### DIFF
--- a/theano/compile/debugmode.py
+++ b/theano/compile/debugmode.py
@@ -495,7 +495,8 @@ def char_from_number(number):
 def debugprint(r, prefix='', depth=-1, done=None, print_type=False,
                file=sys.stdout, print_destroy_map=False,
                print_view_map=False, order=None, ids='CHAR',
-               stop_on_name=False, prefix_child=None):
+               stop_on_name=False, prefix_child=None,
+               stop_on_scan=False):
     """Print the graph leading to `r` to given depth.
 
     :param r: Variable instance
@@ -515,6 +516,8 @@ def debugprint(r, prefix='', depth=-1, done=None, print_type=False,
                 "" - don't print an identifier
     :param stop_on_name: When True, if a node in the graph has a name,
                          we don't print anything below it.
+    :param stop_on_scan: When True, if a node in the graph corresponds
+                         to a scan Op, we don't print anything below it.
 
     """
     if depth == 0:
@@ -594,9 +597,14 @@ def debugprint(r, prefix='', depth=-1, done=None, print_type=False,
                                                             destroy_map_str,
                                                             view_map_str,
                                                             o)
+
         if not already_printed:
-            if (not stop_on_name or
-                not (hasattr(r, 'name') and r.name is not None)):
+            stop_because_scan = (stop_on_scan and 
+                isinstance(a.op, theano.scan_module.scan_op.Scan))
+            stop_because_name = (stop_on_name and
+                (hasattr(r, 'name') and r.name is not None))
+
+            if not (stop_because_name or stop_because_scan):
                 new_prefix = prefix_child + ' |'
                 new_prefix_child = prefix_child + ' |'
                 for idx, i in enumerate(a.inputs):
@@ -606,7 +614,8 @@ def debugprint(r, prefix='', depth=-1, done=None, print_type=False,
                     debugprint(i, new_prefix, depth=depth - 1, done=done,
                                print_type=print_type, file=file, order=order,
                                ids=ids, stop_on_name=stop_on_name,
-                               prefix_child=new_prefix_child)
+                               prefix_child=new_prefix_child,
+                               stop_on_scan=stop_on_scan)
     else:
         #this is an input variable
         id_str = get_id_str(r)

--- a/theano/printing.py
+++ b/theano/printing.py
@@ -35,7 +35,8 @@ _logger = logging.getLogger("theano.printing")
 
 
 def debugprint(obj, depth=-1, print_type=False,
-               file=None, ids='CHAR', stop_on_name=False):
+               file=None, ids='CHAR', stop_on_name=False,
+               scan_graphs=True):
     """Print a computation graph as text to stdout or a file.
 
     :type obj: Variable, Apply, or Function instance
@@ -54,6 +55,8 @@ def debugprint(obj, depth=-1, print_type=False,
                 "" - don't print an identifier
     :param stop_on_name: When True, if a node in the graph has a name,
                          we don't print anything below it.
+    :param scan_graphs: When True, will print the inner graphs of scan ops.
+                When false, the inner graphs of scan ops will not be printed.
 
     :returns: string if `file` == 'str', else file arg
 
@@ -79,6 +82,7 @@ def debugprint(obj, depth=-1, print_type=False,
         _file = sys.stdout
     else:
         _file = file
+    stop_on_scan = not scan_graphs
     done = dict()
     results_to_print = []
     order = []
@@ -101,7 +105,8 @@ def debugprint(obj, depth=-1, print_type=False,
     for r in results_to_print:
         debugmode.debugprint(r, depth=depth, done=done, print_type=print_type,
                              file=_file, order=order, ids=ids,
-                             stop_on_name=stop_on_name)
+                             stop_on_name=stop_on_name,
+                             stop_on_scan=stop_on_scan)
     if file is _file:
         return file
     elif file == 'str':


### PR DESCRIPTION
Here's a first stab at the issue. Fixes #2079

For now, I set the default values for the new parameters of printing.debugprint() and debugmode.debugprint() so that the default behavior is the same as right now (which is printing the inner graphs). This is, however, inconsistent with printing.pydotprint() where the default behavior is to not print the inner graphs.  This is mostly a consistent interface vs coherent interface question and if anyone has a strong opinion on this, I'm listening.
