### PR TITLE
 Add new flag for theano profiling output cropping

### DIFF
--- a/theano/compile/profiling.py
+++ b/theano/compile/profiling.py
@@ -50,6 +50,11 @@ AddConfigVar('profiling.n_ops',
              IntParam(20, lambda i: i > 0),
              in_c_key=False)
 
+AddConfigVar('profiling.output_line_width',
+             "Max line width for the profiling output",
+             IntParam(512, lambda i: i > 0),
+             in_c_key=False)
+
 AddConfigVar('profiling.min_memory_size',
              """For the memory profile, do not print Apply nodes if the size
              of their outputs (in bytes) is lower than this threshold""",
@@ -175,7 +180,7 @@ class ProfileStats(object):
     linker_time = 0.0
     # time spent linking graph (FunctionMaker.create)
 
-    line_width = 140
+    line_width = config.profiling.output_line_width
 
     optimizer_profile = None
     # None or tuple (the optimizer, the profile it returned)
@@ -360,7 +365,7 @@ class ProfileStats(object):
         es += [' %4d  ']
 
         upto_length = numpy.sum([len(x) for x in hs]) + len(hs)
-        maxlen = self.line_width - upto_length
+        maxlen = max(self.line_width - upto_length, 0)
         hs += ['<Class name>']
         es += ['%s']
         header_str = ' '.join(hs)
@@ -443,7 +448,7 @@ class ProfileStats(object):
         es += ['  %4d  ']
 
         upto_length = numpy.sum([len(x) for x in hs]) + len(hs)
-        maxlen = self.line_width - upto_length
+        maxlen = max(self.line_width - upto_length, 0)
         hs += ['<Op name>']
         es += ['%s']
         header_str = ' '.join(hs)
@@ -510,7 +515,7 @@ class ProfileStats(object):
             hs += ['<Mflops>', '<Gflops/s>']
 
         upto_length = numpy.sum([len(x) for x in hs]) + len(hs)
-        maxlen = self.line_width - upto_length
+        maxlen = max(self.line_width - upto_length, 0)
         hs += ['<Apply name>']
         es += ['%s']
 


### PR DESCRIPTION
Fixes #2080 . This pull requests adds a new flag, profiling.output_line_width, which can be set to limit the line length of the profiling output. Its default value is 512.

The change is the way the variables maxlen are computed is to avoid an invalid behavior when line_width is smaller than upto_length.
