### PR TITLE
Fix dnn handle init.

### DIFF
--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -49,6 +49,11 @@ cudnnConvolutionDescriptor_t op%(id)d;
 
     def c_init_code_struct(self, node, struct_id, sub):
         return """
+handle%(id)d = NULL;
+input%(id)d = NULL;
+output%(id)d = NULL;
+kerns%(id)d = NULL;
+op%(id)d = NULL;
 cudnnStatus_t err%(id)d;
 if ((err%(id)d = cudnnCreate(&handle%(id)d)) != CUDNN_STATUS_SUCCESS) {
   PyErr_Format(PyExc_RuntimeError, "could not create cudnn handle: %%s",
@@ -210,7 +215,7 @@ if (err%(name)s != CUDNN_STATUS_SUCCESS) {
            fail=sub['fail'], id=sub['struct_id'], name=name)
 
     def c_code_cache_version(self):
-        return (3,)
+        return (4,)
 
 
 from theano.sandbox.cuda.opt import (local_optimizer, gpu_contiguous,


### PR DESCRIPTION
C++03 changed the rules, so we actually need the NULL inits.
