### PR TITLE
add support for border_mode='half' to cudnn

### DIFF
--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -83,7 +83,9 @@ class GpuDnnConvDesc(GpuOp):
         img_shape, kern_shape = inputs
         desc, = outputs
 
-        if self.border_mode == "valid":
+        if self.border_mode == "half":
+            bmode = 2
+        elif self.border_mode == "valid":
             bmode = 1
         else:
             assert self.border_mode == "full"
@@ -106,7 +108,10 @@ class GpuDnnConvDesc(GpuOp):
     %(fail)s
   }
 
-  if (%(bmode)d == 1) {
+  if (%(bmode)d == 2) {
+    pad_h%(name)s = *(npy_int64 *)PyArray_GETPTR1(%(kern_shape)s, 2) / 2;
+    pad_w%(name)s = *(npy_int64 *)PyArray_GETPTR1(%(kern_shape)s, 3) / 2;
+  } else if (%(bmode)d == 1) {
     pad_h%(name)s = 0;
     pad_w%(name)s = 0;
   } else if (%(bmode)d == 0) {
@@ -142,7 +147,7 @@ class GpuDnnConvDesc(GpuOp):
            subsx=self.subsample[0], subsy=self.subsample[1])
 
     def c_code_cache_version(self):
-        return (1,)
+        return (2,)
 
 
 class GpuDnnConvBase(DnnBase):


### PR DESCRIPTION
Following up on #2118, I added support for a 'half' `border_mode` to the cudnn convolution implementation. I didn't want to call it 'same' because it only gives the same output feature map dimensionality if the filter sizes are odd. If they are even, the output feature map dimensionality is one larger than the input.

For example:
input shape (64, 128, 32, 32), filter shape (256, 128, **5**, **5**) will result in an output shape of (64, 256, **32**, **32**)
input shape (64, 128, 32, 32), filter shape (256, 128, **6**, **6**) will result in an output shape of (64, 256, **33**, **33**)

Unfortunately implementing a true 'same' convolution is a bit more involved and the definition is a bit ambiguous.

I also had a look into adding some tests for this, but it seems that tests for convolutions with different border modes are a bit involved, so I haven't attempted this yet. It looks like I'd have to add a `_test_half` function in `test_conv_cuda_ndarray.py`?
