### PR TITLE
Include and library flags in nvcc.flags in config not passed to nvcc correctly

### DIFF
--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -293,8 +293,8 @@ class NVCC_compiler(object):
         #nvcc argument
         preargs1 = []
         for pa in preargs:
-            for pattern in ['-O', '-arch=', '-ccbin=', '-G', '-g',
-                            '--fmad', '--ftz', '--maxrregcount',
+            for pattern in ['-O', '-arch=', '-ccbin=', '-G', '-g', '-I',
+                            '-L', '--fmad', '--ftz', '--maxrregcount',
                             '--prec-div', '--prec-sqrt',  '--use_fast_math',
                             '-fmad', '-ftz', '-maxrregcount',
                             '-prec-div', '-prec-sqrt', '-use_fast_math']:


### PR DESCRIPTION
Note: I am working on the win32 platform.
Include and library flags given to nvcc.flags in the theano.rc config file are not passed to nvcc correctly; they come through separated by commas instead of spaces. (e.g. '-LC:\packages\cudnn,-IC:\packages\cudnn' instead of '-LC:\packages\cudnn -IC:\packages\cudnn').
I have made a small fix that adds '-I' and '-L' to the list of patterns that are filtered into the 'preargs1' list in the NVCC_compiler.compile_str() method.
