### PR TITLE
Fix blocksparse optimization that could give bad results in some cases

### DIFF
--- a/theano/sandbox/cuda/blocksparse.py
+++ b/theano/sandbox/cuda/blocksparse.py
@@ -684,7 +684,7 @@ GpuElemwise{mul}(lr, SparseBlockOuterSS) -> SparseBlockOuterSS(..., alpha=lr)
     def local_merge_blocksparse_output(node):
         if (isinstance(node.op, GpuElemwise) and
             (node.op.scalar_op == scalar.sub or
-             node.scalar_op == scalar.add) and
+             node.op.scalar_op == scalar.add) and
             node.nin == 2):
             ger = grab_ger(node.inputs[0])
             W = node.inputs[1]


### PR DESCRIPTION
This changes the way "inplace" optimization for SparseBlock{Gemv,Outer}SS works.  It makes it much safer for unusual graphs and add support for add along with sub.

However due to these changes, it makes avoiding the Alloc the responsability of other optimizations (local_alloc_elemwise), which are not enabled by default and are highly recommended.  Use the flag `optimizer_including=local_alloc_elemwise` to enable it.
