### PR TITLE
setup.py: replaced calls to open() with codecs.open() to read non-ASCII characters...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@
 import os
 import sys
 import subprocess
+import codecs
 from fnmatch import fnmatchcase
 from distutils.util import convert_path
 try:
@@ -43,8 +44,8 @@ MAINTAINER          = "LISA laboratory, University of Montreal"
 MAINTAINER_EMAIL    = "theano-dev@googlegroups.com"
 DESCRIPTION         = ('Optimizing compiler for evaluating mathematical ' +
                        'expressions on CPUs and GPUs.')
-LONG_DESCRIPTION    = (open("DESCRIPTION.txt").read() + "\n\n" +
-                       open("NEWS.txt").read())
+LONG_DESCRIPTION    = (codecs.open("DESCRIPTION.txt",encoding='utf-8').read() + "\n\n" +
+                       codecs.open("NEWS.txt",encoding='utf-8').read())
 URL                 = "http://deeplearning.net/software/theano/"
 DOWNLOAD_URL        = ""
 LICENSE             = 'BSD'


### PR DESCRIPTION
... when building LONG_DESCRIPTION string from the contents of NEWS.txt, DESCRIPTION.txt.  It helps fix an exception being thrown when building from master in python 3.3.4.  See [this](https://groups.google.com/forum/#!topic/theano-users/a0obHkVaRmo) thread in theano-users for details.
