### PR TITLE
stdint should not be imported into OpenCL kernels

### DIFF
--- a/theano/sandbox/gpuarray/elemwise.py
+++ b/theano/sandbox/gpuarray/elemwise.py
@@ -124,7 +124,8 @@ class GpuElemwise(HideC, Elemwise):
                                     scal_out,
                                     dict(fail='return;'))
 
-        # OpenCL implicitly has 'stdint' defs at the kernel compilation stage
+        # Translate types for scalar composite ops (except complex).
+        # NB: OpenCL implicitly has 'stdint' defs at the kernel compilation stage
         support_code = "" if pygpu.get_default_context().kind == 'opencl' else """
 #ifdef _MSC_VER
 #define signed __int8 int8_t
@@ -139,8 +140,7 @@ class GpuElemwise(HideC, Elemwise):
 #include <stdint.h>
 #endif
 """
-
-        # Translate types for scalar composite ops (except complex).
+        # Translate ga_ pseudo-types into their specific realizations
         support_code += """
 #define ga_bool uint8_t
 #define ga_byte int8_t


### PR DESCRIPTION
Key change : OpenCL doesn't need the same type information to be included in kernels (in particular, including files _at all_ is somewhat deprecated : http://devgurus.amd.com/message/1296050)

This PR should cure the failure of the opencl test script shown on http://deeplearning.net/software/theano/tutorial/using_gpu.html

The code has been before/after tested on my Linux OpenCL system (with an Nvidia graphics card, but no CUDA libraries installed).  For non-OpenCL systems, the gpuarray output should be unchanged.

The PR also solves the central issue behind "Theano fails when device=opencl #2189" (where the bug is correctly identified, and a PR is asked for, but the issue was closed because it wasn't clear that libgpuarray hadn't been 'messed with').

Also this should fix:
"stdint.h not found error on MacOS Mavericks when running theano test on OpenCL using libgpuarray" found at https://groups.google.com/forum/#!topic/theano-users/4HrFKsL5c2w

If this is acceptable, I'd be happy to continue ploughing ahead with OpenCL/gpuarray fixes (since, FWIW, OpenCL is more appealing to this Linux user than CUDA...)
