### PR TITLE
Change default platform to something that don't change when it isn't nee...

### DIFF
--- a/theano/gof/compiledir.py
+++ b/theano/gof/compiledir.py
@@ -64,8 +64,69 @@ compiledir_format_dict = {
         "gxx_version": gcc_version_str.replace(" ", "_"),
         "hostname": socket.gethostname(),
         }
+
+
+def short_platform():
+    """Return a safe shorter version of platform.platform().
+
+    The old default Theano compiledir used platform.platform in
+    it. This use the platform.version() as a substring. This is too
+    specific as it contain the full kernel number and package
+    version. This cause the compiledir to change each time there is a
+    new linux kernel update. This function remove the part of platform
+    that are too precise.
+
+    If we have something else then expected, we do nothing. So this
+    should be safe on other OS.
+
+    Some example if we use platform.platform() direction. On the same
+    OS, with just some kernel updates.
+
+    compiledir_Linux-2.6.32-504.el6.x86_64-x86_64-with-redhat-6.6-Santiago-x86_64-2.6.6-64
+    compiledir_Linux-2.6.32-431.29.2.el6.x86_64-x86_64-with-redhat-6.5-Santiago-x86_64-2.6.6-64
+    compiledir_Linux-2.6.32-431.23.3.el6.x86_64-x86_64-with-redhat-6.5-Santiago-x86_64-2.6.6-64
+    compiledir_Linux-2.6.32-431.20.3.el6.x86_64-x86_64-with-redhat-6.5-Santiago-x86_64-2.6.6-64
+    compiledir_Linux-2.6.32-431.17.1.el6.x86_64-x86_64-with-redhat-6.5-Santiago-x86_64-2.6.6-64
+    compiledir_Linux-2.6.32-431.11.2.el6.x86_64-x86_64-with-redhat-6.5-Santiago-x86_64-2.6.6-64
+    compiledir_Linux-2.6.32-431.el6.x86_64-x86_64-with-redhat-6.5-Santiago-x86_64-2.6.6-64
+    compiledir_Linux-2.6.32-358.23.2.el6.x86_64-x86_64-with-redhat-6.4-Santiago-x86_64-2.6.6-64
+    compiledir_Linux-2.6.32-358.6.2.el6.x86_64-x86_64-with-redhat-6.4-Santiago-x86_64-2.6.6-64
+    compiledir_Linux-2.6.32-358.6.1.el6.x86_64-x86_64-with-redhat-6.4-Santiago-x86_64-2.6.6-64
+    compiledir_Linux-2.6.32-358.2.1.el6.x86_64-x86_64-with-redhat-6.4-Santiago-x86_64-2.6.6-64
+    compiledir_Linux-2.6.32-358.el6.x86_64-x86_64-with-redhat-6.4-Santiago-x86_64-2.6.6-64
+    compiledir_Linux-2.6.32-358.el6.x86_64-x86_64-with-redhat-6.4-Santiago-x86_64-2.6.6
+    compiledir_Linux-2.6.32-279.14.1.el6.x86_64-x86_64-with-redhat-6.4-Santiago-x86_64-2.6.6
+    compiledir_Linux-2.6.32-279.14.1.el6.x86_64-x86_64-with-redhat-6.3-Santiago-x86_64-2.6.6
+    compiledir_Linux-2.6.32-279.5.2.el6.x86_64-x86_64-with-redhat-6.3-Santiago-x86_64-2.6.6
+    compiledir_Linux-2.6.32-220.13.1.el6.x86_64-x86_64-with-redhat-6.3-Santiago-x86_64-2.6.6
+    compiledir_Linux-2.6.32-220.13.1.el6.x86_64-x86_64-with-redhat-6.2-Santiago-x86_64-2.6.6
+    compiledir_Linux-2.6.32-220.7.1.el6.x86_64-x86_64-with-redhat-6.2-Santiago-x86_64-2.6.6
+    compiledir_Linux-2.6.32-220.4.1.el6.x86_64-x86_64-with-redhat-6.2-Santiago-x86_64-2.6.6
+
+    """
+    r = platform.release()
+    sp = r.split('-')
+    if len(sp) != 2:
+        return r
+    kernel_version = sp[0].split('.')
+    if len(kernel_version) <= 2:
+        return r
+    sp[0] = '.'.join(kernel_version[:2])
+    rest = sp[1].split('.')
+    while len(rest) > 2:
+        if rest[0].isdigit():
+            del rest[0]
+        else:
+            break
+    sp[1] = '.'.join(rest)
+    sr = '-'.join(sp)
+    p = platform.platform()
+    p = p.replace(r, sr)
+
+    return p
+compiledir_format_dict['short_platform'] = short_platform()
 compiledir_format_keys = ", ".join(sorted(compiledir_format_dict.keys()))
-default_compiledir_format = ("compiledir_%(platform)s-%(processor)s-"
+default_compiledir_format = ("compiledir_%(short_platform)s-%(processor)s-"
                              "%(python_version)s-%(python_bitwidth)s")
 
 AddConfigVar("compiledir_format",

--- a/theano/gof/tests/test_compiledir.py
+++ b/theano/gof/tests/test_compiledir.py
@@ -1,0 +1,20 @@
+from theano.gof.compiledir import short_platform
+
+
+def test_short_platform():
+    for r, p, a in [  # (release, platform, answer)
+        ('3.2.0-70-generic',
+         'Linux-3.2.0-70-generic-x86_64-with-debian-wheezy-sid',
+         "Linux-3.2--generic-x86_64-with-debian-wheezy-sid"),
+        ('3.2.0-70.1-generic',
+         'Linux-3.2.0-70.1-generic-x86_64-with-debian-wheezy-sid',
+         "Linux-3.2--generic-x86_64-with-debian-wheezy-sid"),
+        ('3.2.0-70.1.2-generic',
+         'Linux-3.2.0-70.1.2-generic-x86_64-with-debian-wheezy-sid',
+         "Linux-3.2--generic-x86_64-with-debian-wheezy-sid"),
+        ('2.6.35.14-106.fc14.x86_64',
+         'Linux-2.6.35.14-106.fc14.x86_64-x86_64-with-fedora-14-Laughlin',
+         'Linux-2.6-fc14.x86_64-x86_64-with-fedora-14-Laughlin'),
+    ]:
+        o = short_platform(r, p)
+        assert o == a, (o, a)


### PR DESCRIPTION
...ded.

News.txt
- Better default compiledir name

@lamblin and @abergeron can both of you review comment on this before? Currently the compiledir change too often. I think that this version would work on windows and mac. I'll test on windows. @abergeron can you test on mac?