### PR TITLE
Fix cuDNN detection

### DIFF
--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -44,7 +44,9 @@ if ((err = cudnnCreate(&_handle)) != CUDNN_STATUS_SUCCESS) {
 """
 
             comp, run, out, err = gof.cmodule.GCC_compiler.try_flags(
-                ["-l", "cudnn", "-I" + os.path.dirname(__file__)],
+                ["-l", "cudnn", "-I" + os.path.dirname(__file__),
+                 "-I" + os.path.join(theano.config.cuda.root, 'include'),
+                 "-L" + os.path.join(theano.config.cuda.root, 'lib64')],
                 preambule=preambule, body=body,
                 try_run=True, output=True)
 


### PR DESCRIPTION
The cuDNN detection code in `theano.sandbox.cuda.dnn.dnn_available()` is slightly broken. It assumes that cuda.h, cudnn.h and cudnn.so are available in standard system-wide include and library directories, while during the compilation of the cuDNN ops, it is enough if they are available in CUDA's include and library directories.
This PR includes cuda.h before cudnn.h to not give a "cudnn.h is not found" error if even cuda.h cannot be found (to avoid pointing the user in the wrong direction on what to fix). In addition, it adds the CUDA include and lib directories to the GCC call via -I and -L, respectively.

Alternatively, the check could just use nvcc instead of gcc, but I don't know if that's easy to accomplish.
