### PR TITLE
Fixes a crash of casting bytes to Python string

### DIFF
--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -56,7 +56,7 @@ if ((err = cudnnCreate(&_handle)) != CUDNN_STATUS_SUCCESS) {
             else:
                 dnn_available.msg = (
                     "Theano is not able to use cuDNN. We got this error: \n" +
-                    err)
+                    str(err))
     return dnn_available.avail
 
 


### PR DESCRIPTION
The crash happened when cuDNN isn't used and the error message was raised. However, the message was a 'bytes' object, not a string. Casting the bytes to string solves the issue.
