### PR TITLE
Fixed dependencies for theano.sandbox.cuda import

### DIFF
--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -7,7 +7,9 @@ from theano.gof.type import CDataType
 from theano.compat import PY3
 from theano.tensor.nnet import SoftmaxGrad
 from theano.sandbox.cuda.type import CudaNdarrayType
-from theano.sandbox.cuda import (GpuOp, cuda_available)
+from theano.sandbox.cuda import (GpuOp, cuda_available,
+                                 active_device_number,
+                                 device_properties)
 from theano.sandbox.cuda.basic_ops import (as_cuda_ndarray_variable,
                                            gpu_contiguous, HostFromGpu)
 from theano.sandbox.cuda.blas import (GpuConv, GpuDownsampleFactorMax,
@@ -20,8 +22,8 @@ from theano.sandbox.cuda.nvcc_compiler import NVCC_compiler
 
 def dnn_available():
     if dnn_available.avail is None:
-        dev = theano.sandbox.cuda.active_device_number()
-        if theano.sandbox.cuda.device_properties(dev)['major'] < 3:
+        dev = active_device_number()
+        if device_properties(dev)['major'] < 3:
             dnn_available.msg = "Device not supported by cuDNN"
             dnn_available.avail = False
         else:


### PR DESCRIPTION
When importing theano, I get the following error:

```
In [1]: import theano
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-3397704bd624> in <module>()
----> 1 import theano

/raid/user/karen/devtools/Theano_git/Theano/theano/__init__.pyc in <module>()
     83 
     84 if config.device.startswith('gpu') or config.init_gpu_device.startswith('gpu'):
---> 85     import theano.sandbox.cuda
     86     # We can't test the driver during import of theano.sandbox.cuda as
     87     # this cause circular import dependency. So we also test it manually

/raid/user/karen/devtools/Theano_git/Theano/theano/sandbox/cuda/__init__.py in <module>()
    279             as_cuda_array, as_cuda_ndarray_variable)
    280     import cuda_ndarray
--> 281     from . import opt, dnn
    282     from .rng_curand import CURAND_RandomStreams
    283 

/raid/user/karen/devtools/Theano_git/Theano/theano/sandbox/cuda/opt.py in <module>()
   1338 # It can be disabled by excluding 'conv_dnn' or 'cudnn'.
   1339 from . import dnn
-> 1340 if dnn.dnn_available():
   1341     conv_groupopt.register('local_conv_dnn', dnn.local_conv_dnn, 20,
   1342                            'conv_dnn',

/raid/user/karen/devtools/Theano_git/Theano/theano/sandbox/cuda/dnn.py in dnn_available()
     21 def dnn_available():
     22     if dnn_available.avail is None:
---> 23         dev = theano.sandbox.cuda.active_device_number()
     24         if theano.sandbox.cuda.device_properties(dev)['major'] < 3:
     25             dnn_available.msg = "Device not supported by cuDNN"

AttributeError: 'module' object has no attribute 'cuda'

```

The PR fixes it.
