### PR TITLE
Fix scan_args for the 'as_while' case properly.

### DIFF
--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -1453,10 +1453,7 @@ def scan_merge_inouts(node):
         inner_inputs = a.inner_inputs
         outer_inputs = a.outer_inputs
         info = a.info
-        if info['as_while']:
-            a_inner_outs = a.inner_outputs + a.cond
-        else:
-            a_inner_outs = a.inner_outputs
+        a_inner_outs = a.inner_outputs
         inner_outputs = scan_utils.clone(a_inner_outs, replace=inp_equiv)
 
         op = scan_op.Scan(inner_inputs, inner_outputs, info)

--- a/theano/scan_module/scan_utils.py
+++ b/theano/scan_module/scan_utils.py
@@ -818,6 +818,7 @@ class scan_args(object):
             self.cond = [rval[1][-1]]
             inner_outputs = rval[1][:-1]
         else:
+            self.cond = []
             inner_outputs = rval[1]
         inner_inputs = rval[0]
 
@@ -942,7 +943,8 @@ class scan_args(object):
                                            self.inner_out_mit_sot +
                                            self.inner_out_sit_sot +
                                            self.inner_out_nit_sot +
-                                           self.inner_out_shared))
+                                           self.inner_out_shared +
+                                           self.cond))
 
     outer_outputs = property(lambda self: (self.outer_out_mit_mot +
                                            self.outer_out_mit_sot +


### PR DESCRIPTION
Somebody else changed the code to add support for as_while, but this was done in a way that forces all users to think about this flags and is error prone.

Do it the simpler way by handling the distinction in scan_args itself.
