### PR TITLE
now pretty print works for scaler variables too.

### DIFF
--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -3108,7 +3108,8 @@ class Composite(ScalarOp):
                 for i, r in enumerate(self.fgraph.variables):
                     if r not in io and len(r.clients) > 1:
                         r.name = 't%i' % i
-                rval = "Composite{%s}" % pprint(self.fgraph.outputs[0])
+                rval = "Composite{%s}" % ', '.join([pprint(output) for output
+                                                    in self.fgraph.outputs])
         self.name = rval
 
     def init_fgraph(self):

--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -22,7 +22,7 @@ import numpy
 
 import theano
 from theano.compat import PY3
-from theano import gof
+from theano import gof, printing
 from theano.gof import (Op, utils, Variable, Constant, Type, Apply,
                         FunctionGraph)
 from theano.gof.python25 import partial, all, any
@@ -30,6 +30,8 @@ from theano.configparser import config
 
 from theano.gradient import DisconnectedType
 from theano.gradient import grad_undefined
+
+from theano.printing import pprint
 
 builtin_complex = complex
 builtin_int = int
@@ -2166,6 +2168,13 @@ class Neg(UnaryScalarOp):
         return "%(z)s = -%(x)s;" % locals()
 neg = Neg(same_out, name='neg')
 
+pprint.assign(add, printing.OperatorPrinter('+', -2, 'either'))
+pprint.assign(mul, printing.OperatorPrinter('*', -1, 'either'))
+pprint.assign(sub, printing.OperatorPrinter('-', -2, 'left'))
+pprint.assign(neg, printing.OperatorPrinter('-', 0, 'either'))
+pprint.assign(true_div, printing.OperatorPrinter('/', -1, 'left'))
+pprint.assign(int_div, printing.OperatorPrinter('//', -1, 'left'))
+pprint.assign(pow, printing.OperatorPrinter('**', 1, 'right'))
 
 class Inv(UnaryScalarOp):
     """ multiplicative inverse. Also called reciprocal"""
@@ -3099,7 +3108,7 @@ class Composite(ScalarOp):
                 for i, r in enumerate(self.fgraph.variables):
                     if r not in io and len(r.clients) > 1:
                         r.name = 't%i' % i
-                rval = "Composite{%s}" % str(self.fgraph)
+                rval = "Composite{%s}" % pprint(self.fgraph.outputs[0])
         self.name = rval
 
     def init_fgraph(self):

--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -2175,6 +2175,7 @@ pprint.assign(neg, printing.OperatorPrinter('-', 0, 'either'))
 pprint.assign(true_div, printing.OperatorPrinter('/', -1, 'left'))
 pprint.assign(int_div, printing.OperatorPrinter('//', -1, 'left'))
 pprint.assign(pow, printing.OperatorPrinter('**', 1, 'right'))
+pprint.assign(mod, printing.OperatorPrinter('%', -1, 'lef'))
 
 class Inv(UnaryScalarOp):
     """ multiplicative inverse. Also called reciprocal"""

--- a/theano/scalar/tests/test_basic.py
+++ b/theano/scalar/tests/test_basic.py
@@ -151,11 +151,22 @@ class test_composite(unittest.TestCase):
         e0 = x + y + z
         e1 = x + y * z
         e2 = x / y
-        C = Composite([x, y, z], [e0, e1, e2])
+        e3 = x // 5
+        e4 = -x
+        e5 = x - y
+        e6 = x ** y + (-z)
+        e7 = x % 3
+        C = Composite([x, y, z], [e0, e1, e2, e3, e4, e5, e6, e7])
         c = C.make_node(x, y, z)
         g = FunctionGraph([x, y, z], c.outputs)
         fn = gof.DualLinker().accept(g).make_function()
-        assert str(g) == '[*1 -> Composite{((i0 + i1) + i2), (i0 + (i1 * i2)), (i0 / i1)}(x, y, z), *1::1, *1::2]'
+
+        assert str(g) == ('[*1 -> Composite{((i0 + i1) + i2),'
+                          ' (i0 + (i1 * i2)), (i0 / i1), '
+                          '(i0 // Constant{5}), '
+                          '(-i0), (i0 - i1), ((i0 ** i1) + (-i2)),'
+                          ' (i0 % Constant{3})}(x, y, z), '
+                          '*1::1, *1::2, *1::3, *1::4, *1::5, *1::6, *1::7]')
 
     def test_make_node_continue_graph(self):
         # This is a test for a bug (now fixed) that disabled the

--- a/theano/scalar/tests/test_basic.py
+++ b/theano/scalar/tests/test_basic.py
@@ -146,6 +146,17 @@ class test_composite(unittest.TestCase):
         fn = gof.DualLinker().accept(g).make_function()
         assert fn(1.0, 2.0, 3.0) == [6.0, 7.0, 0.5]
 
+    def test_composite_printing(self):
+        x, y, z = floats('xyz')
+        e0 = x + y + z
+        e1 = x + y * z
+        e2 = x / y
+        C = Composite([x, y, z], [e0, e1, e2])
+        c = C.make_node(x, y, z)
+        g = FunctionGraph([x, y, z], c.outputs)
+        fn = gof.DualLinker().accept(g).make_function()
+        assert str(g) == '[*1 -> Composite{((i0 + i1) + i2), (i0 + (i1 * i2)), (i0 / i1)}(x, y, z), *1::1, *1::2]'
+
     def test_make_node_continue_graph(self):
         # This is a test for a bug (now fixed) that disabled the
         # local_gpu_elemwise_0 optimization and printed an


### PR DESCRIPTION
Hi @dwf ,
Here I just handle output[0] of a FunctionGraph in a Composite.
I'm now sure how should I print multiple outputs.
I'm still struggling with a good test file. The only thing I found is this test:

import numpy
import theano

def detect_nan(i, node, fn):
    for output in fn.outputs:
        if numpy.isnan(output[0]).any():
            print '*** NaN detected ***'
            theano.printing.debugprint(node)
            print 'Inputs : %s' % [input[0] for input in fn.inputs]
            print 'Outputs: %s' % [output[0] for output in fn.outputs]
            break

x = theano.tensor.dscalar('x')
f = theano.function([x], [theano.tensor.log(x) * x],
                    mode=theano.compile.MonitorMode(
                        post_func=detect_nan))
f(0)