### PR TITLE
Add breakpoint Op to Theano

### DIFF
--- a/theano/sandbox/cuda/tests/test_opt.py
+++ b/theano/sandbox/cuda/tests/test_opt.py
@@ -165,7 +165,7 @@ def test_gpuallocempty():
 
     f_cpu = theano.function([], tensor.AllocEmpty('int32')(2,3))
     l_cpu = f_cpu.maker.fgraph.toposort()
-    assert not numpy.any([isinstance(x.op, basic_ops.GpuAllocEmpty) for x in l_cpu])    
+    assert not numpy.any([isinstance(x.op, basic_ops.GpuAllocEmpty) for x in l_cpu])
 
 class Test_local_elemwise_alloc(test_opt.Test_local_elemwise_alloc):
     dtype = 'float32'
@@ -330,7 +330,7 @@ def test_opt_gpujoin_joinvectors_elemwise_then_minusone():
 
 
 def test_opt_gpujoin_joinvectors_negativeaxes():
-    """ 
+    """
     Test that negative axis concatenation works as expected.
     """
 

--- a/theano/sandbox/gpuarray/opt.py
+++ b/theano/sandbox/gpuarray/opt.py
@@ -342,8 +342,9 @@ def local_gpu_pdbbreakpoint_op(node):
         new_inputs = node.inputs[:1]
         input_transfered = []
 
-        # Propagate the transfers to gpu through the PdbBreakpoint node
-        # while leaving the PdbBreakpoint node fully on the host
+        # Go through the monitored variables, only transfering on GPU those
+        # for which the input comes from the GPU or the output will be
+        # transfered on the GPU.
         nb_monitored_vars = len(node.outputs)
         for i in range(nb_monitored_vars):
 
@@ -352,23 +353,22 @@ def local_gpu_pdbbreakpoint_op(node):
 
             input_is_from_gpu = (inp.owner and
                                  isinstance(inp.owner.op, HostFromGpu))
-            output_used = len(out.clients) > 0
-            output_goes_to_gpu = all([c[0] != "output" and
+            output_goes_to_gpu = any([c[0] != "output" and
                                       isinstance(c[0].op, GpuFromHost)
                                       for c in out.clients])
 
-            if input_is_from_gpu and output_used and not output_goes_to_gpu:
+            if input_is_from_gpu:
                 # The op should be applied on the GPU version of the input
                 new_inputs.append(inp.owner.inputs[0])
                 input_transfered.append(True)
 
-            elif not input_is_from_gpu and output_used and output_goes_to_gpu:
+            elif output_goes_to_gpu:
                 # The input should be transfered to the gpu
                 new_inputs.append(gpu_from_host(inp))
                 input_transfered.append(True)
 
             else:
-                # Both are on the gpu or on the host. No transfer is required.
+                # No transfer is required.
                 new_inputs.append(inp)
                 input_transfered.append(False)
 
@@ -378,12 +378,7 @@ def local_gpu_pdbbreakpoint_op(node):
             return False
 
         # Apply the op on the new inputs
-        new_op_outputs = node.op(*new_inputs)
-
-        # Ensure that new_op_outputs is a list of outputs (in case the op has
-        # only one output)
-        if not isinstance(new_op_outputs, list):
-            new_op_outputs = [new_op_outputs]
+        new_op_outputs = node.op(*new_inputs, return_list=True)
 
         # Propagate the transfer to the gpu through the outputs that require
         # it

--- a/theano/sandbox/gpuarray/opt.py
+++ b/theano/sandbox/gpuarray/opt.py
@@ -15,6 +15,7 @@ from theano.gof import (local_optimizer, EquilibriumDB,
 from theano.scan_module import scan_utils, scan_op, scan_opt
 
 from theano.tensor.nnet.conv import ConvOp
+from theano.tests.breakpoint import PdbBreakpoint
 from .type import GpuArrayType, GpuArrayConstant
 from .basic_ops import (host_from_gpu, gpu_from_host,
                         HostFromGpu, GpuFromHost,
@@ -328,6 +329,74 @@ def local_gpu_print_op(node):
     new_op = node.op.__class__(global_fn=gpu_print_wrapper)
     new_op.old_op = node.op
     return new_op(gpu_x)
+
+
+@register_opt('fast_compile')
+@local_optimizer([PdbBreakpoint])
+def local_gpu_pdbbreakpoint_op(node):
+    if isinstance(node.op, PdbBreakpoint):
+
+        old_inputs = node.inputs
+        old_outputs = node.outputs
+
+        new_inputs = node.inputs[:1]
+        input_transfered = []
+
+        # Propagate the transfers to gpu through the PdbBreakpoint node
+        # while leaving the PdbBreakpoint node fully on the host
+        nb_monitored_vars = len(node.outputs)
+        for i in range(nb_monitored_vars):
+
+            inp = old_inputs[i+1]
+            out = old_outputs[i]
+
+            input_is_from_gpu = (inp.owner and
+                                 isinstance(inp.owner.op, HostFromGpu))
+            output_used = len(out.clients) > 0
+            output_goes_to_gpu = all([c[0] != "output" and
+                                      isinstance(c[0].op, GpuFromHost)
+                                      for c in out.clients])
+
+            if input_is_from_gpu and output_used and not output_goes_to_gpu:
+                # The op should be applied on the GPU version of the input
+                new_inputs.append(inp.owner.inputs[0])
+                input_transfered.append(True)
+
+            elif not input_is_from_gpu and output_used and output_goes_to_gpu:
+                # The input should be transfered to the gpu
+                new_inputs.append(gpu_from_host(inp))
+                input_transfered.append(True)
+
+            else:
+                # Both are on the gpu or on the host. No transfer is required.
+                new_inputs.append(inp)
+                input_transfered.append(False)
+
+        # Only continue the optimization if at least one input has been
+        # transfered to the gpu
+        if not any(input_transfered):
+            return False
+
+        # Apply the op on the new inputs
+        new_op_outputs = node.op(*new_inputs)
+
+        # Ensure that new_op_outputs is a list of outputs (in case the op has
+        # only one output)
+        if not isinstance(new_op_outputs, list):
+            new_op_outputs = [new_op_outputs]
+
+        # Propagate the transfer to the gpu through the outputs that require
+        # it
+        new_outputs = []
+        for i in range(len(new_op_outputs)):
+            if input_transfered[i]:
+                new_outputs.append(host_from_gpu(new_op_outputs[i]))
+            else:
+                new_outputs.append(new_op_outputs[i])
+
+        return new_outputs
+
+    return False
 
 
 @register_opt('fast_compile')

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -83,7 +83,7 @@ class PdbBreakpoint(Op):
 
         # Build the Apply node
         inputs = [condition] + list(monitored_vars)
-        outputs = [inp.type.make_variable() for inp in monitored_vars]
+        outputs = [inp.type() for inp in monitored_vars]
         return Apply(op=self, inputs=inputs, outputs=outputs)
 
     def perform(self, node, inputs, output_storage):

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -61,7 +61,7 @@ class PdbBreakpoint(Op):
 
     """
 
-    __props__ = ()
+    __props__ = ("name",)
 
     def __init__(self, name):
         self.name = name

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -2,9 +2,9 @@ import numpy
 import pdb
 
 import theano
-import theano.tensor as T
 from theano.gof import Op, Apply
 from theano.gradient import DisconnectedType
+
 
 class PdbBreakpoint(Op):
     """

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -93,8 +93,19 @@ class PdbBreakpoint(Op):
             output_storage[i][0] = monitored[i]
 
     def grad(self, inputs, output_gradients):
-        return ([DisconnectedType()] + output_gradients)
+        return ([DisconnectedType()()] + output_gradients)
 
     def infer_shape(self, inputs, input_shapes):
         # Return the shape of every input but the condition (first input)
         return input_shapes[1:]
+
+    def connection_pattern(self, node):
+
+        nb_inp = len(node.inputs)
+        nb_out = nb_inp - 1
+
+        # First input is connected to no output and every other input n is
+        # connected to input n-1
+        connections = [[out_idx == inp_idx - 1 for out_idx in range(nb_out)]
+                       for inp_idx in range(nb_inp)]
+        return connections

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -3,6 +3,7 @@ import pdb
 import theano
 import theano.tensor as T
 from theano.gof import Op, Apply
+from theano.gradient import DisconnectedType
 
 class PdbBreakpoint(Op):
     """
@@ -90,8 +91,7 @@ class PdbBreakpoint(Op):
             output_storage[i][0] = monitored[i]
 
     def grad(self, inputs, output_gradients):
-        return ([inputs[0].zeros_like().astype(theano.config.floatX)] +
-                output_gradients)
+        return ([DisconnectedType()] + output_gradients)
 
     def infer_shape(self, inputs, input_shapes):
         # Return the shape of every input but the condition

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -1,0 +1,98 @@
+import pdb
+
+import theano
+import theano.tensor as T
+from theano.gof import Op, Apply
+
+class PdbBreakpoint(Op):
+    """
+    This is an identity-like op with the side effect of enforcing a
+    conditional breakpoint, inside a theano function, based on a symbolic
+    scalar condition.
+
+    @type name: String
+    @param name: name of the conditional breakpoint. To be printed when the
+                 breakpoint is activated.
+
+    :note: WARNING. At least one of the outputs of the op must be used
+                    otherwise the op will be removed from the Theano graph
+                    due to its outputs being unused
+
+    :note: WARNING. Employing the function inside a theano graph can prevent
+                    Theano from applying certain optimizations to improve
+                    performance, reduce memory consumption and/or reduce
+                    numerical instability.
+
+            Detailed explanation:
+            As of 2014-12-01 the PdbBreakpoint op is not known by any
+            optimization. Setting a PdbBreakpoint op in the middle of a
+            pattern that is usually optimized out will block the optimization.
+
+    Example:
+
+    .. code-block:: python
+
+        import theano
+        import theano.tensor as T
+        from theano.tests.breakpoint import PdbBreakpoint
+
+        input = T.fvector()
+        target = T.fvector()
+
+        # Mean squared error between input and target
+        mse = (input - target) ** 2
+
+        # Conditional breakpoint to be activated if the total MSE is higher
+        # than 100. The breakpoint will monitor the inputs, targets as well
+        # as the individual error values
+        breakpointOp = PdbBreakpoint("MSE too high")
+        condition = T.gt(mse.sum(), 100)
+        mse, _, _ = breakpointOp(condition, mse, input, target)
+
+        # Compile the theano function
+        fct = theano.function([input, target], mse)
+
+        # Use the function
+        print fct([10, 0], [10, 5]) # Will NOT activate the breakpoint
+        print fct([0, 0], [10, 5]) # Will activate the breakpoint
+
+
+    """
+
+    __props__ = ()
+
+    def __init__(self, name):
+        self.name = name
+
+    def make_node(self, condition, *monitored_vars):
+
+        # Validate that the condition is a scalar (else it is not obvious how
+        # is should be evaluated)
+        assert (condition.ndim == 0)
+
+        # Build the Apply node
+        inputs = [condition] + list(monitored_vars)
+        outputs = [inp.type.make_variable() for inp in monitored_vars]
+        return Apply(op=self, inputs=inputs, outputs=outputs)
+
+    def perform(self, node, inputs, output_storage):
+        condition = inputs[0]
+        monitored = inputs[1:]
+
+        if condition:
+            print "-------------------------------------------------"
+            print "Conditional breakpoint %s activated" % self.name
+            print "The monitored variables are stored in 'monitored'"
+            print "-------------------------------------------------"
+            pdb.set_trace()
+
+        for i in range(len(output_storage)):
+            output_storage[i][0] = monitored[i]
+
+    def grad(self, inputs, output_gradients):
+        return ([inputs[0].zeros_like().astype(theano.config.floatX)] +
+                output_gradients)
+
+    def infer_shape(self, inputs, input_shapes):
+        # Return the shape of every input but the condition
+        return input_shapes[1:]

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -83,7 +83,8 @@ class PdbBreakpoint(Op):
         if condition:
             print "-------------------------------------------------"
             print "Conditional breakpoint %s activated" % self.name
-            print "The monitored variables are stored in 'monitored'"
+            print "The monitored variables are stored in, in order,"
+            print "in the list variable 'monitored'"
             print "-------------------------------------------------"
             pdb.set_trace()
 
@@ -94,5 +95,5 @@ class PdbBreakpoint(Op):
         return ([DisconnectedType()] + output_gradients)
 
     def infer_shape(self, inputs, input_shapes):
-        # Return the shape of every input but the condition
+        # Return the shape of every input but the condition (first input)
         return input_shapes[1:]

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -68,6 +68,10 @@ class PdbBreakpoint(Op):
 
     def make_node(self, condition, *monitored_vars):
 
+        # Ensure that condition is a theano tensor
+        if not isinstance(condition, theano.Variable):
+            condition = theano.tensor.as_tensor_variable(condition)
+
         # Validate that the condition is a scalar (else it is not obvious how
         # is should be evaluated)
         assert (condition.ndim == 0)

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -72,6 +72,11 @@ class PdbBreakpoint(Op):
         # is should be evaluated)
         assert (condition.ndim == 0)
 
+        # Build the op's view_map; every output i is a view of the input i+1.
+        self.view_map = {}
+        for i in range(len(monitored_vars)):
+            self.view_map[i] = [i+1]
+
         # Build the Apply node
         inputs = [condition] + list(monitored_vars)
         outputs = [inp.type.make_variable() for inp in monitored_vars]

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -48,7 +48,8 @@ class PdbBreakpoint(Op):
         # as the individual error values
         breakpointOp = PdbBreakpoint("MSE too high")
         condition = T.gt(mse.sum(), 100)
-        mse, _, _ = breakpointOp(condition, mse, input, target)
+        mse, monitored_input, monitored_target = breakpointOp(condition, mse,
+                                                              input, target)
 
         # Compile the theano function
         fct = theano.function([input, target], mse)

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -84,7 +84,7 @@ class PdbBreakpoint(Op):
         if condition:
             print "-------------------------------------------------"
             print "Conditional breakpoint %s activated" % self.name
-            print "The monitored variables are stored in, in order,"
+            print "The monitored variables are stored, in order,"
             print "in the list variable 'monitored'"
             print "-------------------------------------------------"
             pdb.set_trace()

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -98,14 +98,15 @@ class PdbBreakpoint(Op):
 
     def perform(self, node, inputs, output_storage):
         condition = inputs[0]
-        try:
-            monitored = [numpy.asarray(inp) for inp in inputs[1:]]
-        except:
-            raise ValueError("Some of the inputs to the PdbBreakpoint op '%s'"
-                             "could not be casted to NumPy arrays" %
-                             self.name)
 
         if condition:
+            try:
+                monitored = [numpy.asarray(inp) for inp in inputs[1:]]
+            except:
+                raise ValueError("Some of the inputs to the PdbBreakpoint op "
+                                 "'%s' could not be casted to NumPy arrays" %
+                                 self.name)
+
             print("\n")
             print("-------------------------------------------------")
             print("Conditional breakpoint '%s' activated\n" % self.name)
@@ -116,10 +117,15 @@ class PdbBreakpoint(Op):
             print("-------------------------------------------------")
             pdb.set_trace()
 
-        # Take the new values in monitored, cast them back to their original
-        # type and store them in the output_storage
-        for i in range(len(output_storage)):
-            output_storage[i][0] = self.inp_types[i].filter(monitored[i])
+            # Take the new values in monitored, cast them back to their
+            # original type and store them in the output_storage
+            for i in range(len(output_storage)):
+                output_storage[i][0] = self.inp_types[i].filter(monitored[i])
+
+        else:
+            # Simply return views on the monitored variables
+            for i in range(len(output_storage)):
+                output_storage[i][0] = inputs[i+1]
 
     def grad(self, inputs, output_gradients):
         return ([DisconnectedType()()] + output_gradients)

--- a/theano/tests/test_breakpoint.py
+++ b/theano/tests/test_breakpoint.py
@@ -4,6 +4,7 @@ import theano.tensor as T
 from theano.tests import unittest_tools as utt
 from theano.tests.breakpoint import PdbBreakpoint
 
+
 class TestPdbBreakpoint(utt.InferShapeTester):
 
     def setUp(self):
@@ -28,7 +29,7 @@ class TestPdbBreakpoint(utt.InferShapeTester):
 
     def test_infer_shape(self):
 
-        input1_value = numpy.arange(6).reshape(2,3).astype("float32")
+        input1_value = numpy.arange(6).reshape(2, 3).astype("float32")
         input2_value = 10.0
 
         self._compile_and_check([self.input1, self.input2],
@@ -40,7 +41,7 @@ class TestPdbBreakpoint(utt.InferShapeTester):
 
     def test_grad(self):
 
-        input1_value = numpy.arange(9).reshape(3,3).astype("float32")
+        input1_value = numpy.arange(9).reshape(3, 3).astype("float32")
         input2_value = 10.0
 
         grads = [T.grad(self.monitored_input1.sum(), self.input1),
@@ -62,7 +63,7 @@ class TestPdbBreakpoint(utt.InferShapeTester):
 
     def test_fprop(self):
 
-        input1_value = numpy.arange(9).reshape(3,3).astype("float32")
+        input1_value = numpy.arange(9).reshape(3, 3).astype("float32")
         input2_value = 10.0
         fct = theano.function([self.input1, self.input2],
                               [self.monitored_input1, self.monitored_input2])
@@ -75,6 +76,6 @@ class TestPdbBreakpoint(utt.InferShapeTester):
 
         node = self.monitored_output.owner
         connection_pattern = self.breakpointOp.connection_pattern(node)
-        expected_pattern = [[0,0,0],[1,0,0],[0,1,0],[0,0,1]]
+        expected_pattern = [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]]
 
         assert connection_pattern == expected_pattern

--- a/theano/tests/test_breakpoint.py
+++ b/theano/tests/test_breakpoint.py
@@ -59,18 +59,15 @@ class TestPdbBreakpoint(utt.InferShapeTester):
 
         for i in range(len(gradients)):
             numpy.testing.assert_allclose(gradients[i], expected_gradients[i])
-            
+
     def test_fprop(self):
-        
+
         input1_value = numpy.arange(9).reshape(3,3).astype("float32")
         input2_value = 10.0
         fct = theano.function([self.input1, self.input2],
                               [self.monitored_input1, self.monitored_input2])
 
         output = fct(input1_value, input2_value)[:-1]
-        
-        import pdb
-        pdb.set_trace()
 
         expected_output = [numpy.ones((3, 3), dtype="float32"),
                            numpy.array(1., dtype="float32")]

--- a/theano/tests/test_breakpoint.py
+++ b/theano/tests/test_breakpoint.py
@@ -1,11 +1,14 @@
 import numpy
 import theano
 import theano.tensor as T
+from theano.tests import unittest_tools as utt
 from theano.tests.breakpoint import PdbBreakpoint
 
-class TestPdbBreakpoint:
+class TestPdbBreakpoint(utt.InferShapeTester):
 
-    def setup(self):
+    def setUp(self):
+
+        super(TestPdbBreakpoint, self).setUp()
 
         # Sample computation that involves tensors with different numbers
         # of dimensions
@@ -25,20 +28,15 @@ class TestPdbBreakpoint:
 
     def test_infer_shape(self):
 
-        input1_value = numpy.arange(9).reshape(3,3).astype("float32")
+        input1_value = numpy.arange(6).reshape(2,3).astype("float32")
         input2_value = 10.0
 
-        fct = theano.function([self.input1, self.input2],
-                              [self.monitored_input1.shape,
-                               self.monitored_input2.shape,
-                               self.monitored_output.shape])
-
-        shapes = fct(input1_value, input2_value)
-
-        assert tuple(shapes[0]) == input1_value.shape
-        assert tuple(shapes[1]) == tuple()
-        assert tuple(shapes[2]) == (input1_value.shape[0],
-                                    input1_value.shape[0])
+        self._compile_and_check([self.input1, self.input2],
+                                [self.monitored_input1,
+                                 self.monitored_input2,
+                                 self.monitored_output],
+                                [input1_value, input2_value],
+                                PdbBreakpoint)
 
     def test_grad(self):
 

--- a/theano/tests/test_breakpoint.py
+++ b/theano/tests/test_breakpoint.py
@@ -16,7 +16,7 @@ class TestPdbBreakpoint:
 
         # Declare the conditional breakpoint
         self.breakpointOp = PdbBreakpoint("Sum of output too high")
-        self.condition = T.gt(self.output.sum(), 100)
+        self.condition = T.gt(self.output.sum(), 1000)
         (self.monitored_input1,
          self.monitored_input2,
          self.monitored_output) = self.breakpointOp(self.condition,

--- a/theano/tests/test_breakpoint.py
+++ b/theano/tests/test_breakpoint.py
@@ -14,7 +14,7 @@ class TestPdbBreakpoint:
         self.output = T.dot((self.input1 - self.input2),
                             (self.input1 - self.input2).transpose())
 
-        # Declare the conditional breakpoint 
+        # Declare the conditional breakpoint
         self.breakpointOp = PdbBreakpoint("Sum of output too high")
         self.condition = T.gt(self.output.sum(), 100)
         (self.monitored_input1,
@@ -24,43 +24,48 @@ class TestPdbBreakpoint:
                                                     self.input2, self.output)
 
     def test_infer_shape(self):
-        
+
         input1_value = numpy.arange(9).reshape(3,3).astype("float32")
         input2_value = 10.0
-    
+
         fct = theano.function([self.input1, self.input2],
                               [self.monitored_input1.shape,
                                self.monitored_input2.shape,
                                self.monitored_output.shape])
-                               
+
         shapes = fct(input1_value, input2_value)
-        
+
         assert tuple(shapes[0]) == input1_value.shape
         assert tuple(shapes[1]) == tuple()
         assert tuple(shapes[2]) == (input1_value.shape[0],
                                     input1_value.shape[0])
 
     def test_grad(self):
-        
+
         input1_value = numpy.arange(9).reshape(3,3).astype("float32")
         input2_value = 10.0
 
         grads = [T.grad(self.monitored_input1.sum(), self.input1),
                  T.grad(self.monitored_input2.sum(), self.input2)]
-        fct = theano.function([self.input1, self.input2], grads)
-        
-        gradients = fct(input1_value, input2_value)
-        
+
+        # Add self.monitored_input1 as an output to the Theano function to
+        # prevent Theano from optimizing the PdbBreakpoint op out of the
+        # function graph
+        fct = theano.function([self.input1, self.input2],
+                              grads + [self.monitored_input1])
+
+        gradients = fct(input1_value, input2_value)[:-1]
+
         expected_gradients = [numpy.ones((3, 3), dtype="float32"),
                               numpy.array(1., dtype="float32")]
-        
+
         for i in range(len(gradients)):
-            numpy.testing.assert_allclose(gradients[i], expected_gradients[i])        
+            numpy.testing.assert_allclose(gradients[i], expected_gradients[i])
 
     def test_connection_pattern(self):
-        
+
         node = self.monitored_output.owner
         connection_pattern = self.breakpointOp.connection_pattern(node)
         expected_pattern = [[0,0,0],[1,0,0],[0,1,0],[0,0,1]]
-        
+
         assert connection_pattern == expected_pattern

--- a/theano/tests/test_breakpoint.py
+++ b/theano/tests/test_breakpoint.py
@@ -1,0 +1,66 @@
+import numpy
+import theano
+import theano.tensor as T
+from theano.tests.breakpoint import PdbBreakpoint
+
+class TestPdbBreakpoint:
+
+    def setup(self):
+
+        # Sample computation that involves tensors with different numbers
+        # of dimensions
+        self.input1 = T.fmatrix()
+        self.input2 = T.fscalar()
+        self.output = T.dot((self.input1 - self.input2),
+                            (self.input1 - self.input2).transpose())
+
+        # Declare the conditional breakpoint 
+        self.breakpointOp = PdbBreakpoint("Sum of output to high")
+        self.condition = T.gt(self.output.sum(), 100)
+        (self.monitored_input1,
+         self.monitored_input2,
+         self.monitored_output) = self.breakpointOp(self.condition,
+                                                    self.input1,
+                                                    self.input2, self.output)
+
+    def test_infer_shape(self):
+        
+        input1_value = numpy.arange(9).reshape(3,3).astype("float32")
+        input2_value = 10.0
+    
+        fct = theano.function([self.input1, self.input2],
+                              [self.monitored_input1.shape,
+                               self.monitored_input2.shape,
+                               self.monitored_output.shape])
+                               
+        shapes = fct(input1_value, input2_value)
+        
+        assert tuple(shapes[0]) == input1_value.shape
+        assert tuple(shapes[1]) == tuple()
+        assert tuple(shapes[2]) == (input1_value.shape[0],
+                                    input1_value.shape[0])
+
+    def test_grad(self):
+        
+        input1_value = numpy.arange(9).reshape(3,3).astype("float32")
+        input2_value = 10.0
+
+        grads = [T.grad(self.monitored_input1.sum(), self.input1),
+                 T.grad(self.monitored_input2.sum(), self.input2)]
+        fct = theano.function([self.input1, self.input2], grads)
+        
+        gradients = fct(input1_value, input2_value)
+        
+        expected_gradients = [numpy.ones((3, 3), dtype="float32"),
+                              numpy.array(1., dtype="float32")]
+        
+        for i in range(len(gradients)):
+            numpy.testing.assert_allclose(gradients[i], expected_gradients[i])        
+
+    def test_connection_pattern(self):
+        
+        node = self.monitored_output.owner
+        connection_pattern = self.breakpointOp.connection_pattern(node)
+        expected_pattern = [[0,0,0],[1,0,0],[0,1,0],[0,0,1]]
+        
+        assert connection_pattern == expected_pattern

--- a/theano/tests/test_breakpoint.py
+++ b/theano/tests/test_breakpoint.py
@@ -59,6 +59,21 @@ class TestPdbBreakpoint(utt.InferShapeTester):
 
         for i in range(len(gradients)):
             numpy.testing.assert_allclose(gradients[i], expected_gradients[i])
+            
+    def test_fprop(self):
+        
+        input1_value = numpy.arange(9).reshape(3,3).astype("float32")
+        input2_value = 10.0
+        fct = theano.function([self.input1, self.input2],
+                              [self.monitored_input1, self.monitored_input2])
+
+        output = fct(input1_value, input2_value)[:-1]
+        
+        import pdb
+        pdb.set_trace()
+
+        expected_output = [numpy.ones((3, 3), dtype="float32"),
+                           numpy.array(1., dtype="float32")]
 
     def test_connection_pattern(self):
 

--- a/theano/tests/test_breakpoint.py
+++ b/theano/tests/test_breakpoint.py
@@ -67,10 +67,9 @@ class TestPdbBreakpoint(utt.InferShapeTester):
         fct = theano.function([self.input1, self.input2],
                               [self.monitored_input1, self.monitored_input2])
 
-        output = fct(input1_value, input2_value)[:-1]
-
-        expected_output = [numpy.ones((3, 3), dtype="float32"),
-                           numpy.array(1., dtype="float32")]
+        output = fct(input1_value, input2_value)
+        numpy.testing.assert_allclose(output[0], input1_value)
+        numpy.testing.assert_allclose(output[1], input2_value)
 
     def test_connection_pattern(self):
 

--- a/theano/tests/test_breakpoint.py
+++ b/theano/tests/test_breakpoint.py
@@ -15,7 +15,7 @@ class TestPdbBreakpoint:
                             (self.input1 - self.input2).transpose())
 
         # Declare the conditional breakpoint 
-        self.breakpointOp = PdbBreakpoint("Sum of output to high")
+        self.breakpointOp = PdbBreakpoint("Sum of output too high")
         self.condition = T.gt(self.output.sum(), 100)
         (self.monitored_input1,
          self.monitored_input2,


### PR DESCRIPTION
This is just a small utility class to allow a user to put a conditional breakpoint, with pdb, inside the execution of a Theano function. It is implemented in a similar way to the Print() op in that it's a identity-like op with a side effect. It takes multiple inputs and the first one needs to be a 0d tensor and is interpreted as the condition that will decide the activation of the breakpoint. When, during execution, that condition is evaluated to True, the breakpoint will be activated. The subsequent inputs are interpreted as the variables the user wants to monitor and will be made available to the user when the conditional breakpoint activates.

I am not sure what the best way to test this class would be. It is easy enough to test that the breakpoint doesn't activate in a particular case but testing that it does activate seems a little bit more subtle.