### PR TITLE
Autoname fix unit tests

### DIFF
--- a/theano/gof/tests/test_graph.py
+++ b/theano/gof/tests/test_graph.py
@@ -330,44 +330,50 @@ class TestEval(unittest.TestCase):
 class TestAutoName:
 
     def test_auto_name(self):
-        ## Re-init counter
-        Variable.__count__ = count(0)
+        ## Get counter value
+        autoname_id = next(Variable.__count__)
+        Variable.__count__ = count(autoname_id)
         r1, r2 = MyVariable(1), MyVariable(2)
-        assert r1.auto_name == "auto_0"
-        assert r2.auto_name == "auto_1"
+        assert r1.auto_name == "auto_" + str(autoname_id)
+        assert r2.auto_name == "auto_" + str(autoname_id + 1)
 
     def test_constant(self):
-        ## Re-init counter
-        Variable.__count__ = count(0)
+        ## Get counter value
+        autoname_id = next(Variable.__count__)
+        Variable.__count__ = count(autoname_id)
         r1 = tensor.constant(1.5)
         r2 = tensor.constant(1.5)
-        assert r1.auto_name == "auto_0"
-        assert r2.auto_name == "auto_1"
+        assert r1.auto_name == "auto_" + str(autoname_id)
+        assert r2.auto_name == "auto_" + str(autoname_id + 1)
 
     def test_tensorvariable(self):
-        ## Re-init counter
-        Variable.__count__ = count(0)
+        ## Get counter value
+        autoname_id = next(Variable.__count__)
+        Variable.__count__ = count(autoname_id)
         r1 = tensor.TensorType(dtype='int32', broadcastable=())('myvar')
         r2 = tensor.TensorVariable(tensor.TensorType(dtype='int32',
                                                      broadcastable=()))
         r3 = shared(numpy.random.randn(3,4))
-        assert r1.auto_name == "auto_0"
-        assert r2.auto_name == "auto_1"
-        assert r3.auto_name == "auto_2"
+        assert r1.auto_name == "auto_" + str(autoname_id)
+        assert r2.auto_name == "auto_" + str(autoname_id + 1)
+        assert r3.auto_name == "auto_" + str(autoname_id + 2)
+
 
     def test_sparsevariable(self):
-        ## Re-init counter
-        Variable.__count__ = count(0)
+        ## Get counter value
+        autoname_id = next(Variable.__count__)
+        Variable.__count__ = count(autoname_id)
         r1 = sparse.csc_matrix(name='x', dtype='float32')
         r2 = sparse.dense_from_sparse(r1)
         r3 = sparse.csc_from_dense(r2)
-        assert r1.auto_name == "auto_0"
-        assert r2.auto_name == "auto_1"
-        assert r3.auto_name == "auto_2"
+        assert r1.auto_name == "auto_" + str(autoname_id)
+        assert r2.auto_name == "auto_" + str(autoname_id + 1)
+        assert r3.auto_name == "auto_" + str(autoname_id + 2)
 
     def test_cudandarrayvariable(self):
-        ## Re-init counter
-        Variable.__count__ = count(0)
+        ## Get counter value
+        autoname_id = next(Variable.__count__)
+        Variable.__count__ = count(autoname_id)
         mytype = tensor.TensorType(dtype='int32', broadcastable=())
         r1 = CudaNdarrayVariable(type='int32')
         r2 = CudaNdarrayVariable(type='int32')
@@ -375,14 +381,15 @@ class TestAutoName:
                                  data=1)
         r4 = CudaNdarraySharedVariable(name='x', type=mytype,
                                        value=1, strict=False)
-        assert r1.auto_name == "auto_0"
-        assert r2.auto_name == "auto_1"
-        assert r3.auto_name == "auto_2"
-        assert r4.auto_name == "auto_3"
+        assert r1.auto_name == "auto_" + str(autoname_id)
+        assert r2.auto_name == "auto_" + str(autoname_id + 1)
+        assert r3.auto_name == "auto_" + str(autoname_id + 2)
+        assert r4.auto_name == "auto_" + str(autoname_id + 3)
 
     def test_randomvariable(self):
-        ## Re-init counter
-        Variable.__count__ = count(0)
+        ## Get counter value
+        autoname_id = next(Variable.__count__)
+        Variable.__count__ = count(autoname_id)
         mytype = tensor.TensorType(dtype='int32', broadcastable=())
         r1 = tensor.shared_randomstreams.RandomStateSharedVariable(name='x',
                                                                    type=mytype,
@@ -392,17 +399,18 @@ class TestAutoName:
                                                                    type=mytype,
                                                                    value=1,
                                                                    strict=False)
-        assert r1.auto_name == "auto_0"
-        assert r2.auto_name == "auto_1"
+        assert r1.auto_name == "auto_" + str(autoname_id)
+        assert r2.auto_name == "auto_" + str(autoname_id + 1)
 
 
     def test_clone(self):
-        ## Re-init counter
-        Variable.__count__ = count(0)
+        ## Get counter value
+        autoname_id = next(Variable.__count__)
+        Variable.__count__ = count(autoname_id)
         r1 = MyVariable(1)
         r2 = r1.clone()
-        assert r1.auto_name == "auto_0"
-        assert r2.auto_name == "auto_1"
+        assert r1.auto_name == "auto_" + str(autoname_id)
+        assert r2.auto_name == "auto_" + str(autoname_id + 1)
 
 
 


### PR DESCRIPTION
Unit tests read __count__ value instead of setting it

Note: this is just to have no side effect in the tests. No news.