### PR TITLE
Python 3.x compatibility.

### DIFF
--- a/theano/misc/strutil.py
+++ b/theano/misc/strutil.py
@@ -14,7 +14,7 @@ def render_string(string, sub):
     """
     try:
         finalCode = string % sub
-    except Exception , E:
+    except Exception, E:
         # If unable to render the string, render longer and longer
         # initial substrings until we find the minimal initial substring
         # that causes an error

--- a/theano/tensor/nnet/ConvGrad3D.py
+++ b/theano/tensor/nnet/ConvGrad3D.py
@@ -276,5 +276,5 @@ class ConvGrad3D(theano.Op):
 
 convGrad3D = ConvGrad3D()
 
-from Conv3D import conv3D
-from ConvTransp3D import convTransp3D
+from theano.tensor.nnet.Conv3D import conv3D
+from theano.tensor.nnet.ConvTransp3D import convTransp3D

--- a/theano/tensor/nnet/ConvTransp3D.py
+++ b/theano/tensor/nnet/ConvTransp3D.py
@@ -426,5 +426,5 @@ def computeR(W, b, d, H, Rshape=None):
     return R
 
 
-from Conv3D import conv3D
-from ConvGrad3D import convGrad3D
+from theano.tensor.nnet.Conv3D import conv3D
+from theano.tensor.nnet.ConvGrad3D import convGrad3D


### PR DESCRIPTION
Removing the space in front of the comma seems necessary for python's
2to3 tool to recognize that instance, no kidding.

An alternative to `theano.tensor.nnet.Conv3D` would be `.Conv3D`, but it's slightly inferior iirc; probably doesn't matter here though.

I also did `import theano` on 2.x and that "test" passed.