### PR TITLE
COp conflict between old section markers and new section markers

### DIFF
--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -1076,21 +1076,15 @@ class COp(Op):
             raise ValueError('Both the new and the old syntax for '
                              'identifying code sections are present in the '
                              'provided C code. These two syntaxes should not '
-                             'be used at the same times')
+                             'be used at the same time.')
 
         self.code_sections = dict()
         for i, code in enumerate(self.func_codes):
             if self.backward_re.search(code):
                 # This is backward compat code that will go away in a while
 
-                # Check for code outside of the supported sections
-                split = self.backward_re.split(code)
-                if split[0].strip() != '':
-                    raise ValueError('Stray code before first section '
-                                     'marker (in file %s): %s' %
-                                     (self.func_files[i], split[0]))
-
                 # Separate the code into the proper sections
+                split = self.backward_re.split(code)
                 n = 1
                 while n < len(split):
                     if split[n] == 'APPLY':


### PR DESCRIPTION
This PR does the following : 
-fixes false positives in the detection of old section markers
-add an error message specific for the case where no section marker has been detected in the code
-add an error message specific for the case where both types of section markers have been detected in the code
-adds to the section that processes the old syntax checks that were only present in the section for new syntax
-adds a few comments