### PR TITLE
Update the whitelist of flags passed directly to nvcc

### DIFF
--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -293,7 +293,8 @@ class NVCC_compiler(object):
                             '-L', '--fmad', '--ftz', '--maxrregcount',
                             '--prec-div', '--prec-sqrt',  '--use_fast_math',
                             '-fmad', '-ftz', '-maxrregcount',
-                            '-prec-div', '-prec-sqrt', '-use_fast_math']:
+                            '-prec-div', '-prec-sqrt', '-use_fast_math',
+                            '--use-local-env', '--cl-version=']:
                 if pa.startswith(pattern):
                     preargs1.append(pa)
         preargs2 = [pa for pa in preargs


### PR DESCRIPTION
instead of being passed to -Xlinker.
These are necessary to compile on Windows, at least in the case
where more than one version of visual studio's cl.exe are available.