### PR TITLE
Fix equilibrium opt error recently introduced

### DIFF
--- a/theano/compile/ops.py
+++ b/theano/compile/ops.py
@@ -387,6 +387,19 @@ class Shape_i(gof.Op):
         return [None]
 
 
+def shape_i(var, i):
+    """This is useful in optimization that need to get the shape. This
+    remove the need of the following shape_feature optimization that
+    convert it. So this speed up optimization and remove Equilibrium
+    max iteration problems.
+
+    """
+    if (hasattr(var, 'fgraph') and
+        hasattr(node.outputs[0].fgraph, 'shape_feature')):
+        return node.outputs[0].fgraph.shape_feature.shape_of[var][i]
+    return Shape_i(i)(var)
+
+
 def register_shape_i_c_code(typ, code, check_input, version=()):
     """ Tell Shape_i how to generate C code for a Theano Type
 

--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -7,6 +7,7 @@ from theano.gradient import DisconnectedType
 from theano.gof import Optimizer, local_optimizer, COp
 from theano.gof.type import CDataType, Generic
 from theano.compat import PY3
+from theano.compile.ops import shape_i
 from theano.tensor.nnet import SoftmaxGrad
 from theano.tensor.basic import ShapeError
 from theano.sandbox.cuda.type import CudaNdarrayType
@@ -601,9 +602,10 @@ def dnn_conv(img, kerns, border_mode='valid', subsample=(1, 1),
         img = gpu_contiguous(img)
         kerns = gpu_contiguous(kerns.dimshuffle(1, 0, 2, 3))
         conv_mode = 'cross' if conv_mode == 'conv' else 'conv'
-        shape = theano.tensor.stack(img.shape[0], kerns.shape[1],
-                                    img.shape[2] + kerns.shape[2] - 1,
-                                    img.shape[3] + kerns.shape[3] - 1)
+
+        shape = theano.tensor.stack(shape_i(img, 0), shape_i(kerns, 1),
+                                    shape_i(img, 2) + shape_i(kerns, 2) - 1,
+                                    shape_i(img, 3) + shape_i(kerns, 3)- 1)
         desc = GpuDnnConvDesc(border_mode='valid', subsample=(1, 1),
                               conv_mode=conv_mode)(shape, kerns.shape)
         return GpuDnnConvGradI()(kerns, img, desc, shape[2], shape[3])


### PR DESCRIPTION
A PR introduced the shape_to_shape_i opt in the GPU opt. But this cause this opt to get called too often with the default equilibrium max_use_ratio.

We fix this. This caused tests like theano/sandbox/cuda/tests/test_conv_cuda_ndarray.py:test_full to raise errors.

I think it is bad for opt to introduce to ugly graph as this cause too much work for the optimizer. This allow optimizer to introduce less work for futur optimizer.