### PR TITLE
Adding GpuSplit op to cuda submodule

### DIFF
--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -288,7 +288,7 @@ if cuda_available:
             GpuDimShuffle, GpuCAReduce, GpuReshape, GpuContiguous,
             GpuSubtensor, GpuIncSubtensor,
             GpuAdvancedSubtensor1, GpuAdvancedIncSubtensor1,
-            GpuFlatten, GpuShape, GpuAlloc,
+            GpuFlatten, GpuShape, GpuAlloc, GpuSplit,
             GpuJoin, fscalar, fvector, fmatrix, frow, fcol,
             ftensor3, ftensor4,
             scalar, vector, matrix, row, col,

--- a/theano/sandbox/cuda/basic_ops.py
+++ b/theano/sandbox/cuda/basic_ops.py
@@ -3229,6 +3229,16 @@ class GpuJoin(tensor.Join, GpuOp):
 gpu_join = GpuJoin()
 
 
+class GpuSplit(tensor.Split, GpuOp):
+    def make_node(self, x, axis, splits):
+        assert isinstance(x.type, CudaNdarrayType)
+        node = tensor.Split.make_node(self, x, axis, splits)
+        outs = [CudaNdarrayType(dtype=o.dtype,
+                                broadcastable=o.type.broadcastable)()
+                for o in node.outputs]
+        return Apply(self, [x] + node.inputs[1:], outs)
+
+
 class GpuAlloc(GpuOp):
     """Implement Alloc on the gpu.
 

--- a/theano/sandbox/cuda/basic_ops.py
+++ b/theano/sandbox/cuda/basic_ops.py
@@ -3231,7 +3231,7 @@ gpu_join = GpuJoin()
 
 class GpuSplit(tensor.Split, GpuOp):
     def make_node(self, x, axis, splits):
-        assert isinstance(x.type, CudaNdarrayType)
+        x = as_cuda_ndarray_variable(x)
         node = tensor.Split.make_node(self, x, axis, splits)
         outs = [CudaNdarrayType(dtype=o.dtype,
                                 broadcastable=o.type.broadcastable)()

--- a/theano/sandbox/cuda/tests/test_opt.py
+++ b/theano/sandbox/cuda/tests/test_opt.py
@@ -291,6 +291,27 @@ def test_local_gpu_subtensor():
     assert any([isinstance(node.op, cuda.GpuElemwise) for node in topo])
 
 
+def test_local_split():
+    """ Test that the GpuSplit op is being applied and works """
+    # Construct symbolic split
+    x = tensor.vector()
+    splits = tensor.lvector()
+    ra, rb, rc = tensor.split(x, splits, n_splits=3, axis=0)
+    # Compile function to use CPU
+    f = theano.function([x, splits], [ra, rb, rc], mode=mode_without_gpu)
+    # Get values for CPU version
+    cpu_res = f([0, 1, 2, 3, 4, 5], [3, 2, 1])
+    l = f.maker.fgraph.toposort()
+    # Ensure that one op is theano.tensor.Split
+    assert any([isinstance(o.op, theano.tensor.Split) for o in l])
+    # GPU version
+    f = theano.function([x, splits], [ra, rb, rc], mode=mode_with_gpu)
+    gpu_res = f([0, 1, 2, 3, 4, 5], [3, 2, 1])
+    l = f.maker.fgraph.toposort()
+    assert any([isinstance(o.op, theano.sandbox.cuda.GpuSplit) for o in l])
+    # Check equality
+    assert all([(cpu == gpu).all() for cpu, gpu in zip(cpu_res, gpu_res)])
+
 def test_print_op():
     """ Test that print ops don't block gpu optimization"""
     b = tensor.fmatrix()

--- a/theano/sandbox/cuda/tests/test_opt.py
+++ b/theano/sandbox/cuda/tests/test_opt.py
@@ -294,7 +294,7 @@ def test_local_gpu_subtensor():
 def test_local_split():
     """ Test that the GpuSplit op is being applied and works """
     # Construct symbolic split
-    x = tensor.vector()
+    x = tensor.fvector()
     splits = tensor.lvector()
     ra, rb, rc = tensor.split(x, splits, n_splits=3, axis=0)
     # Compile function to use CPU

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -3213,7 +3213,7 @@ class Split(Op):
         for i in xrange(self.len_splits):
             upper_idx = lower_idx + splits[i]
             general_key[axis] = slice(lower_idx, upper_idx, None)
-            outputs[i][0] = x.__getitem__(general_key).copy()
+            outputs[i][0] = x.__getitem__(tuple(general_key)).copy()
             lower_idx = upper_idx
 
     def infer_shape(self, node, in_shapes):


### PR DESCRIPTION
As discussed here (towards the end):
https://groups.google.com/forum/#!searchin/theano-users/GpuSplit/theano-users/ZDuZkFvnEfI/eNe-NuZJibMJ
GpuSplit needs to be ported to the new GPU backend.  This adds the GpuSplit op and an accompanying optimization.  

I had to change the `perform` method in the Theano basic tensor `Split` class. It was calling `__getitem__` on `x` with a list argument which caused a `NotImplementedError` when `x` was a CudaNdarray.  So, I'm converting the index arg to a tuple first.  Thanks to @f0k for this.

This is my first op so please let me know if there's anything I'm doing wrong!  I got a lot of help on this from @f0k and @benanne.