### PR TITLE
Better error message when the test_value do not have the right type

### DIFF
--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -295,7 +295,8 @@ AddConfigVar('traceback.limit',
              "The number of stack to trace. -1 mean all.",
 # We default to 6 to be able to know where v1 + v2 is created in the
 # user script. The bigger this number is, the more run time it takes.
-             IntParam(6),
+# We need to default to 7 to support theano.tensor.tensor(...).
+             IntParam(7),
              in_c_key=False)
 
 AddConfigVar('experimental.mrg',

--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -455,7 +455,7 @@ class PureOp(object):
             except Exception, e:
                 # Better error message.
                 detailed_err_msg = (
-                    "For compute_test_value, one input test value do not"
+                    "For compute_test_value, one input test value does not"
                     " have the requested type.\n")
                 tr = getattr(v.tag, 'trace', None)
                 if tr:

--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -16,8 +16,10 @@ import inspect
 import logging
 import numpy
 import os
-import sys
 import re
+import StringIO
+import sys
+import traceback
 import warnings
 
 import theano
@@ -448,7 +450,31 @@ class PureOp(object):
             return v.get_value(borrow=True, return_internal_type=True)
         elif isinstance(v, graph.Variable) and hasattr(v.tag, 'test_value'):
             # ensure that the test value is correct
-            return v.type.filter(v.tag.test_value)
+            try:
+                ret = v.type.filter(v.tag.test_value)
+            except Exception, e:
+                # Better error message.
+                detailed_err_msg = (
+                    "For compute_test_value, one input test value do not"
+                    " have the requested type.\n")
+                tr = getattr(v.tag, 'trace', None)
+                if tr:
+                    sio = StringIO.StringIO()
+                    traceback.print_list(tr, sio)
+                    tr = sio.getvalue()
+                    detailed_err_msg += (
+                        " \nBacktrace when that variable is created:\n")
+                    detailed_err_msg += str(tr)
+                detailed_err_msg += (
+                    "\nThe error when converting the test value to that"
+                    " variable type:")
+                # We need to only have 1 args and it should be of type
+                # string.  Otherwise, it print the tuple and so the
+                # new line do not get printed.
+                args = (detailed_err_msg,) + tuple(str(arg) for arg in e.args)
+                e.args = ("\n".join(args),)
+                raise
+            return ret
 
         raise AttributeError('%s has no test value' % v)
 

--- a/theano/gof/type.py
+++ b/theano/gof/type.py
@@ -307,8 +307,7 @@ class PureType(object):
     def make_constant(self, value, name=None):
         return self.Constant(type=self, data=value, name=name)
 
-
-    def __call__(self, name = None):
+    def __call__(self, name=None, limit=None):
         """Return a new `Variable` instance of Type `self`.
 
         :Parameters:
@@ -316,7 +315,7 @@ class PureType(object):
             A pretty string for printing and debugging.
 
         """
-        return utils.add_tag_trace(self.make_variable(name))
+        return utils.add_tag_trace(self.make_variable(name), limit=limit)
 
     def values_eq(self, a, b):
         """

--- a/theano/gof/type.py
+++ b/theano/gof/type.py
@@ -307,7 +307,7 @@ class PureType(object):
     def make_constant(self, value, name=None):
         return self.Constant(type=self, data=value, name=name)
 
-    def __call__(self, name=None, limit=None):
+    def __call__(self, name=None):
         """Return a new `Variable` instance of Type `self`.
 
         :Parameters:
@@ -315,7 +315,7 @@ class PureType(object):
             A pretty string for printing and debugging.
 
         """
-        return utils.add_tag_trace(self.make_variable(name), limit=limit)
+        return utils.add_tag_trace(self.make_variable(name))
 
     def values_eq(self, a, b):
         """

--- a/theano/gof/utils.py
+++ b/theano/gof/utils.py
@@ -50,16 +50,18 @@ if sys.version_info[:2] > (3, 4):
     simple_extract_stack = traceback.extract_stack
 
 
-def add_tag_trace(thing, limit=None):
+def add_tag_trace(thing, user_line=1):
     """Add tag.trace to an node or variable.
 
     The argument is returned after being affected (inplace).
     :param thing: the object where we add .tag.trace
-    :param limit: The limit of the stack size.
-        If None use, config.traceback.limit
+    :param user_line: The max number of user line to keep.
+
+    :note: we alse use config.traceback.limit for the maximum number
+        of stack level we look.
+
     """
-    if limit is None:
-        limit = config.traceback.limit
+    limit = config.traceback.limit
     if limit == -1:
         limit = None
     tr = simple_extract_stack(limit=limit)[:-1]
@@ -72,14 +74,21 @@ def add_tag_trace(thing, limit=None):
         file_path = tr[-1][0]
         rm = False
         for p in ["theano/tensor/",
-                  "theano/gof/"]:
+                  "theano/gof/",
+                  "theano/scalar/basic.py",
+                  "theano/sandbox/",
+                  "theano/scan_module/",
+                  "theano/sparse/",
+                  "theano/typed_list/",
+        ]:
             if p in file_path:
                 tr = tr[:-1]
                 rm = True
                 break
         if not rm:
             break
-
+    if len(tr) > user_line:
+        tr = tr[:user_line]
     thing.tag.trace = tr
     return thing
 

--- a/theano/gof/utils.py
+++ b/theano/gof/utils.py
@@ -50,12 +50,16 @@ if sys.version_info[:2] > (3, 4):
     simple_extract_stack = traceback.extract_stack
 
 
-def add_tag_trace(thing):
+def add_tag_trace(thing, limit=None):
     """Add tag.trace to an node or variable.
 
     The argument is returned after being affected (inplace).
+    :param thing: the object where we add .tag.trace
+    :param limit: The limit of the stack size.
+        If None use, config.traceback.limit
     """
-    limit = config.traceback.limit
+    if limit is None:
+        limit = config.traceback.limit
     if limit == -1:
         limit = None
     tr = simple_extract_stack(limit=limit)[:-1]

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -744,7 +744,12 @@ def get_scalar_constant_value(orig_v, elemwise=True):
 
 def tensor(*args, **kwargs):
     name = kwargs.pop('name', None)
-    return TensorType(*args, **kwargs).make_variable(name=name)
+    # This add an indirection to the normal call stack. So raise the
+    # limit to keep the good user line.
+    limit = config.traceback.limit
+    if limit != -1:
+        limit += 1
+    return TensorType(*args, **kwargs)(name=name, limit=limit)
 
 
 def _multi(*fns):

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -744,12 +744,7 @@ def get_scalar_constant_value(orig_v, elemwise=True):
 
 def tensor(*args, **kwargs):
     name = kwargs.pop('name', None)
-    # This add an indirection to the normal call stack. So raise the
-    # limit to keep the good user line.
-    limit = config.traceback.limit
-    if limit != -1:
-        limit += 1
-    return TensorType(*args, **kwargs)(name=name, limit=limit)
+    return TensorType(*args, **kwargs)(name=name)
 
 
 def _multi(*fns):


### PR DESCRIPTION
fix gh-1372

Also make sure to get the stack trace when calling theano.tensor.tensor()

Here is an example of the error message.

```
nouiz@Nouiz-lap-ub:~/src/Theano$ THEANO_FLAGS=compute_test_value=raise python test_222.py 
Traceback (most recent call last):
  File "test_222.py", line 11, in <module>
    T.dot(x, y)
  File "/home/nouiz/src/Theano/theano/tensor/basic.py", line 4759, in dot
    return _dot(a, b)
  File "/home/nouiz/src/Theano/theano/gof/op.py", line 517, in __call__
    storage_map[ins] = [self._get_test_value(ins)]
  File "/home/nouiz/src/Theano/theano/gof/op.py", line 454, in _get_test_value
    ret = v.type.filter(v.tag.test_value)
  File "/home/nouiz/src/Theano/theano/tensor/type.py", line 131, in filter
    raise TypeError(err_msg, data)
TypeError: For compute_test_value, one input test value do not have the requested type.
 
Backtrace when that variable is created:
  File "test_222.py", line 5, in <module>
    x = T.fmatrix('x')

The error when converting the test value to that variable type:
TensorType(float32, matrix) cannot store a value of dtype float64 without risking loss of precision. If you do not mind this loss, you can: 1) explicitly cast your data to float32, or 2) set "allow_input_downcast=True" when calling "function".
[[ 0.90931082  0.52493038  0.94435282  0.40533961]
 [ 0.39912492  0.92240594  0.90570598  0.7427407 ]
 [ 0.29428007  0.97414465  0.68690935  0.19203368]]
```