### PR TITLE
AdvancedSubtensor1 support for local_useless_subtensor optimization

### DIFF
--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -2021,6 +2021,8 @@ def local_useless_subtensor(node):
                 return False
             if step != 1:
                 return False
+        else:
+            return False
     else:
         return False
 

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -1992,7 +1992,7 @@ def local_useless_subtensor(node):
         try:
             length = get_scalar_constant_value(shape_of[node.inputs[0]][0])
         except NotScalarConstantError:
-            pass
+            return False
         
         # get index (which must be a vector by definition)
         idx = node.inputs[1]

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -1920,7 +1920,10 @@ def local_set_to_inc_subtensor(node):
 @gof.local_optimizer([Subtensor, AdvancedSubtensor1])
 def local_useless_subtensor(node):
     """
-    Remove Subtensor if it takes the full input
+    Remove Subtensor/AdvancedSubtensor1 if it takes the full input. In the
+    AdvancedSubtensor1 case, the full input is taken when the indices are
+    equivalent to `arange(0, input.shape[0], 1)` using either an explicit
+    list/vector or the ARange op.
     """
     # This optimization needs ShapeOpt and fgraph.shape_feature
     if not hasattr(node.fgraph, 'shape_feature'):

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -1917,16 +1917,18 @@ def local_set_to_inc_subtensor(node):
 
 @register_canonicalize
 @register_specialize
-@gof.local_optimizer([Subtensor])
+@gof.local_optimizer([Subtensor, AdvancedSubtensor1])
 def local_useless_subtensor(node):
     """
     Remove Subtensor if it takes the full input
     """
+    # This optimization needs ShapeOpt and fgraph.shape_feature
+    if not hasattr(node.fgraph, 'shape_feature'):
+        return
+
+    shape_of = node.fgraph.shape_feature.shape_of
+
     if isinstance(node.op, Subtensor):
-        # This optimization needs ShapeOpt and fgraph.shape_feature
-        if not hasattr(node.fgraph, 'shape_feature'):
-            return
-        shape_of = node.fgraph.shape_feature.shape_of
         cdata = node.op.get_constant_idx(node.inputs, allow_partial=True)
         for pos, idx in enumerate(cdata):
             if not isinstance(idx, slice):
@@ -1985,8 +1987,41 @@ def local_useless_subtensor(node):
                 pass
             else:
                 return False
+    elif isinstance(node.op, AdvancedSubtensor1):
+        # get length of the indexed tensor along the first axis
+        try:
+            length = get_scalar_constant_value(shape_of[node.inputs[0]][0])
+        except NotScalarConstantError:
+            pass
+        
+        # get index (which must be a vector by definition)
+        idx = node.inputs[1]
+        
+        # `idx` must be equivalent to [0,1,...,shape[0] - 1] to qualify for
+        # this optimization
+        if isinstance(idx, T.Constant):
+            idx = idx.value
+            if len(idx) != length:
+                return False
+            if numpy.any(idx != numpy.arange(length)):
+                return False
+        elif idx.owner is not None and isinstance(idx.owner.op, T.ARange):
+            try:
+                start, stop, step = map(get_scalar_constant_value,
+                                        idx.owner.inputs)
+            except NotScalarConstantError:
+                return False
+            
+            if start != 0:
+                return False
+            if stop != length:
+                return False
+            if step != 1:
+                return False
+    else:
+        return False
 
-        return [node.inputs[0]]
+    return [node.inputs[0]]
 
 
 @register_canonicalize

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -45,6 +45,7 @@ from theano.tensor import vector, ivector, lvector, fvector, dvector
 from theano.tensor import matrix, imatrix, lmatrix, fmatrix, dmatrix
 from theano.tensor import scalars, vectors, matrices, fmatrices, dmatrices
 from theano.tensor import (
+        AdvancedSubtensor1,
         as_tensor_variable,
         inplace,
         Join,
@@ -1712,6 +1713,27 @@ def test_local_useless_subtensor():
             assert any([isinstance(node.op, Subtensor) for node in prog])
         f([[1, 2, 3], [4, 5, 6]], 1)
         f([[1, 2, 3], [4, 5, 6]], 3)
+
+    # Test AdvancedSubtensor1 case when all rows are selected by a list/vector
+    # or ARange op
+    for dims, res in (([0, 1], True),
+                      ([1, 0], False),
+                      ([0, 0], False),
+                      ([0, 0, 1], False),
+                      (T.arange(2), True),
+                      (T.arange(2, -1), False),
+                      (T.arange(1, 2), False)):
+        f = function([x], tensor.exp(x_c).__getitem__(dims), mode=mode_opt)
+        #theano.printing.debugprint(f)
+        prog = f.maker.fgraph.toposort()
+        if res:
+            assert isinstance(prog[0].op, theano.tensor.SpecifyShape), dims
+            assert prog[1].op == tensor.exp, dims
+            assert len(prog) == 2, dims
+        else:
+            assert any([isinstance(node.op, AdvancedSubtensor1)
+                        for node in prog])
+        f([[0, 1, 2], [3, 4, 5]])  # let debugmode test something
 
 
 class test_local_subtensor_make_vector(unittest.TestCase):

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -1721,7 +1721,9 @@ def test_local_useless_subtensor():
                       ([0, 0], False),
                       ([0, 0, 1], False),
                       (T.arange(2), True),
-                      (T.arange(2, -1), False),
+                      (T.arange(0, 2), True),
+                      (T.arange(0, 2, 2), False),
+                      (T.arange(0, 2, -1), False),
                       (T.arange(1, 2), False)):
         f = function([x], tensor.exp(x_c).__getitem__(dims), mode=mode_opt)
         #theano.printing.debugprint(f)


### PR DESCRIPTION
I added `AdvancedSubtensor1` support for the `local_useless_subtensor` optimization where the following cases are optimized:
* `x[[0,1,...,#rows(x) - 1]] -> x` with a constant vector
* `x[T.arange(x.shape[0])] -> x`

I'm not sure if there is an `AdvancedSubtensor` case, too. The only one I could imagine would be `x[[0,0,...,1,1,...,#rows(x),#rows(x),...], [0,1,...,#cols(x),0,1,...,#cols(x),...]].reshape((#rows(x), #cols(x))` given `x` is a matrix (could be generalized for all tensors). Is this worth the effort? It seems like a very unlikely case, but I could do it if you feel it should be included. What I'm no clear about, though, is if that's actually a case for this optimization because the `AdvancedSubtensor` op will give a vector in any case. Only combined with `reshape` will this be a equivalent to just using `x` instead of the indexing + reshaping.

This is part of gh-2207