### PR TITLE
Add a way for almost-equal types replacements to be patched over automatically.

### DIFF
--- a/theano/gof/fg.py
+++ b/theano/gof/fg.py
@@ -89,7 +89,7 @@ class FunctionGraph(utils.object2):
 
         Note: the intermediate nodes between 'inputs' and 'outputs' are not explicitely
         passed.
-         
+
         :param inputs: inputs nodes of the graph, usually declared by the user
         :param outputs: outputs nodes of the graph.
         :param clone: If true, we will clone the graph. This is
@@ -462,12 +462,22 @@ class FunctionGraph(utils.object2):
         if verbose:
             print reason, r, new_r
         if r.fgraph is not self:
-            raise Exception("Cannot replace %s because it does not belong to this FunctionGraph" % r, str(reason))
-        if not r.type == new_r.type:
-            raise TypeError("The type of the replacement must be the same as the type of the original Variable.", r, new_r, r.type, new_r.type, str(reason))
+            raise Exception("Cannot replace %s because it does not belong "
+                            "to this FunctionGraph" % r, str(reason))
+        if r.type != new_r.type:
+            new_r2 = r.type.convert_variable(new_r)
+            # We still make sure that the type converts correctly
+            if new_r2 is None or new_r2.type != r.type:
+                raise TypeError("The type of the replacement must be "
+                                "compatible with the type of the original "
+                                "Variable.", r, new_r, r.type, new_r.type,
+                                str(reason))
+            new_r = new_r2
         if r not in self.variables:
-            # this variable isn't in the graph... don't raise an exception here, just return silently
-            # because it makes it easier to implement some optimizations for multiple-output ops
+            # this variable isn't in the graph... don't raise an
+            # exception here, just return silently because it makes it
+            # easier to implement some optimizations for
+            # multiple-output ops
             return
 
         if theano.config.compute_test_value != 'off':
@@ -756,7 +766,7 @@ class FunctionGraph(utils.object2):
                 del d[attr]
         # The class Updater take fct as parameter and they are lambda function, so unpicklable.
 
-        # execute_callbacks_times have reference to optimizer, and they can't 
+        # execute_callbacks_times have reference to optimizer, and they can't
         # be pickled as the decorators with parameters aren't pickable.
         if "execute_callbacks_times" in d:
             del d["execute_callbacks_times"]

--- a/theano/gof/type.py
+++ b/theano/gof/type.py
@@ -394,6 +394,23 @@ class Type(object2, PureType, CLinkerType):
     types.  Type references are also useful to do type-checking in pattern-based optimizations.
 
     """
+    def convert_variable(self, var):
+        """Patch variable so that its type will match self, if possible.
+
+        If the variable can't be converted, this should return None.
+
+        The conversion can only happen if the following implication is
+        true for all possible `val`.
+
+          self.is_valid_value(val) => var.type.is_valid_value(val)
+
+        For the majority of types this means that you can only have
+        non-broadcastable dimensions become broadcastable and not the
+        inverse.
+
+        The default is to not convert anything which is always safe.
+        """
+        return None
 
 
 class SingletonType(Type):

--- a/theano/sandbox/cuda/type.py
+++ b/theano/sandbox/cuda/type.py
@@ -232,6 +232,13 @@ class CudaNdarrayType(Type):
         return (type(self) == type(other) and
                 other.broadcastable == self.broadcastable)
 
+    def convert_variable(self, var):
+        if (type(self) == type(var.type) and
+            self.ndim == var.type.ndim and
+            all(sb == ob or ob for sb, ob in zip(self.broadcastable,
+                                                 var.type.broadcastable))):
+            return theano.tensor.patternbroadcast(var, self.broadcastable)
+
     def __hash__(self):
         """Hash equal for same kinds of CudaNdarrayType"""
         return hash(type(self)) ^ hash(self.broadcastable)

--- a/theano/sandbox/gpuarray/type.py
+++ b/theano/sandbox/gpuarray/type.py
@@ -148,6 +148,14 @@ class GpuArrayType(Type):
                 self.typecode == other.typecode and
                 self.broadcastable == other.broadcastable)
 
+    def convert_variable(self, var):
+        if (type(self) == type(var.type) and
+            self.typecode == var.type.typecode and
+            self.ndim == var.type.ndim and
+            all(sb == ob or ob for sb, ob in zip(self.broadcastable,
+                                                 var.type.broadcastable))):
+            return theano.tensor.patternbroadcast(var, self.broadcastable)
+
     def __hash__(self):
         return (hash(self.typecode) ^ hash(self.broadcastable))
 

--- a/theano/tensor/type.py
+++ b/theano/tensor/type.py
@@ -260,6 +260,14 @@ class TensorType(Type):
         return type(self) == type(other) and other.dtype == self.dtype \
             and other.broadcastable == self.broadcastable
 
+    def convert_variable(self, var):
+        if (type(self) == type(var.type) and
+            self.dtype == var.type.dtype and
+            self.ndim == var.type.ndim and
+            all(sb == ob or ob for sb, ob in zip(self.broadcastable,
+                                                var.type.broadcastable))):
+            return theano.tensor.patternbroadcast(var, self.broadcastable)
+
     @staticmethod
     def may_share_memory(a, b):
         # This is a method of TensorType, so both a and b should be ndarrays


### PR DESCRIPTION
This should eliminate the "we discovered a broadcastable dimension during optimizations and therefore it breaks" problem.