### PR TITLE
Update test_hessian_bug_grad_grad_two_scans to run faster

### DIFF
--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -3775,6 +3775,7 @@ class T_Scan(unittest.TestCase):
             inp = scan_node.op.outer_non_seqs(scan_node)
             assert len(inp) == 1
 
+    @attr('slow')
     def test_hessian_bug_grad_grad_two_scans(self):
         #Bug reported by Bitton Tenessi
         # NOTE : The test to reproduce the bug reported by Bitton Tenessi

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -3775,26 +3775,26 @@ class T_Scan(unittest.TestCase):
             inp = scan_node.op.outer_non_seqs(scan_node)
             assert len(inp) == 1
 
-    @attr('slow')
     def test_hessian_bug_grad_grad_two_scans(self):
         #Bug reported by Bitton Tenessi
+        # NOTE : The test to reproduce the bug reported by Bitton Tenessi
+        # was modified from its original version to be faster to run.
 
-        W_flat = tensor.fvector(name='W')
-        W_flat.tag.test_value = numpy.ones((8,), dtype=numpy.float32)
-        W = W_flat.reshape((2, 2, 2))
+        W = tensor.fvector(name='W')
+        n_steps = tensor.iscalar(name='Nb_steps')
 
-        def loss_outer(i_outer, sum_outer, W):
+        def loss_outer(sum_outer, W):
 
-            def loss_inner(i_inner, sum_inner, W):
+            def loss_inner(sum_inner, W):
 
-                return sum_inner + (W**2).sum().sum().sum()
+                return sum_inner + (W**2).sum()
 
             result_inner, _ = theano.scan(
                 fn=loss_inner,
                 outputs_info=tensor.as_tensor_variable(
                     numpy.asarray(0, dtype=numpy.float32)),
-                sequences=tensor.arange(1, dtype='int32'),
                 non_sequences=[W],
+                n_steps=1,
             )
             return sum_outer + result_inner[-1]
 
@@ -3802,15 +3802,15 @@ class T_Scan(unittest.TestCase):
             fn=loss_outer,
             outputs_info=tensor.as_tensor_variable(
                 numpy.asarray(0, dtype=numpy.float32)),
-            sequences=tensor.arange(1, dtype='int32'),
             non_sequences=[W],
+            n_steps=n_steps,
         )
 
         cost = result_outer[-1]
-        H = theano.gradient.hessian(cost, W_flat)
+        H = theano.gradient.hessian(cost, W)
         print >> sys.stderr, "."
-        f = theano.function([W_flat], H)
-        f(numpy.ones((8,), dtype='float32'))
+        f = theano.function([W, n_steps], H)
+        f(numpy.ones((8,), dtype='float32'), 1)
 
 
 def test_speed():


### PR DESCRIPTION
This PR modifies the test to rely on a simpler graph and avoid structures which slow down the optimization phase considerably. The new test fails in the same way as the original did before PR #1614 fixed the corresponding bug.

The original test was timed by @sebastien-j to take ~2 hours in DebugMode (don't know if it was timed with patience=3 or patience=default). It now takes ~2 minutes in DebugMode with patience=3.