### PR TITLE
Speed up local useless subtensor

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -544,7 +544,8 @@ get_scalar_constant_value_elemwises = (
     scal.IntDiv, scal.TrueDiv, scal.Minimum, scal.Maximum)
 
 
-def get_scalar_constant_value(orig_v, elemwise=True):
+def get_scalar_constant_value(orig_v, elemwise=True,
+                              only_process_constants=False):
     """return the constant scalar(0-D) value underlying variable `v`
 
     If v is the output of dimshuffles, fills, allocs, rebroadcasts,
@@ -557,6 +558,11 @@ def get_scalar_constant_value(orig_v, elemwise=True):
 
     :param elemwise: If False, we won't try to go into elemwise.
         So this call is faster.
+
+    :param only_process_constants: If True, we only attempt to obtain
+            the value of `orig_v` if it's directly constant and don't
+            try to dig through dimshuffles, fills, allocs, and other to figure
+            out its value.
 
     :note: There may be another function similar to this one in the
         code, but I'm not sure where it is.
@@ -581,7 +587,7 @@ def get_scalar_constant_value(orig_v, elemwise=True):
                 data = v.data
             return numpy_scalar(data)
 
-        if getattr(v, 'owner', None):
+        if not only_process_constants and getattr(v, 'owner', None):
             if isinstance(v.owner.op, (Alloc, DimShuffle, Rebroadcast,
                                        compile.ops.OutputGuard,
                                        compile.DeepCopyOp)):
@@ -4048,7 +4054,7 @@ def flatten(x, outdim=1):
 class Tile(Op):
     """
     DEPRECATED: use tile() instead.
-    
+
     Construct an array by repeating the input x according to reps pattern.
 
     Tiles its input according to reps. The length of reps is the number of

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -1932,7 +1932,8 @@ def local_useless_subtensor(node):
     shape_of = node.fgraph.shape_feature.shape_of
 
     if isinstance(node.op, Subtensor):
-        cdata = node.op.get_constant_idx(node.inputs, allow_partial=True)
+        cdata = node.op.get_constant_idx(node.inputs, allow_partial=True,
+                                         only_process_constants=True)
         for pos, idx in enumerate(cdata):
             if not isinstance(idx, slice):
                 # If idx is not a slice, this means we remove this dimension

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -1947,15 +1947,17 @@ def local_useless_subtensor(node):
                 # is not a useless subtensor
                 return False
 
-            length_pos_data = maxsize
+        for pos, idx in enumerate(cdata):
 
             length_pos = shape_of[node.inputs[0]][pos]
-            try:
-                length_pos_data = get_scalar_constant_value(length_pos)
-            except NotScalarConstantError:
-                pass
 
             if isinstance(idx.stop, (int, numpy.integer)):
+                length_pos_data = maxsize
+                try:
+                    length_pos_data = get_scalar_constant_value(length_pos)
+                except NotScalarConstantError:
+                    pass
+
                 if idx.stop < length_pos_data:
                     return False
             elif isinstance(idx.stop, gof.Variable):
@@ -1996,10 +1998,10 @@ def local_useless_subtensor(node):
             length = get_scalar_constant_value(shape_of[node.inputs[0]][0])
         except NotScalarConstantError:
             return False
-        
+
         # get index (which must be a vector by definition)
         idx = node.inputs[1]
-        
+
         # `idx` must be equivalent to [0,1,...,shape[0] - 1] to qualify for
         # this optimization
         if isinstance(idx, T.Constant):
@@ -2014,7 +2016,7 @@ def local_useless_subtensor(node):
                                         idx.owner.inputs)
             except NotScalarConstantError:
                 return False
-            
+
             if start != 0:
                 return False
             if stop != length:


### PR DESCRIPTION
Refactor local_useless_subtensor to allow earlier exiting of the function
Add a parameter to Subtensor.get_constant_idx() to prevent calls to get_scalar_constant_value() which can result in constant folding.

With this modification, in FAST_RUN, the optimization phase in test_scan.py:T_Scan.test_hessian_bug_grad_grad_two_scans goes from ~6 minutes to ~4 minutes.