### PR TITLE
[WIP] add equivalent of mgrid/ogrid functionality

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4353,6 +4353,76 @@ def arange(start, stop=None, step=1, dtype=None):
     return _arange[dtype](start, stop, step)
 
 
+class _nd_grid(object):
+    """Create a dense n-dimensional 'meshgrid' with equally spaced points.
+
+    Used to create the instance ``mgrid`` and ``ogrid`` which act similarly
+    to their numpy equivalents.
+
+    Parameters
+    ==========
+        sparse : boolean, optional, default=True
+            Specifying False leads to the equivalent of numpy's mgrid
+            functionality. Specifying True leads to the equivalent of ogrid.
+
+    Examples
+    ========
+    >>> a = T.mgrid[0:5, 0:3]
+    >>> a[0].eval()
+    array([[0, 0, 0],
+           [1, 1, 1],
+           [2, 2, 2],
+           [3, 3, 3],
+           [4, 4, 4]], dtype=int8)
+    >>> a[1].eval()
+    array([[0, 1, 2],
+           [0, 1, 2],
+           [0, 1, 2],
+           [0, 1, 2],
+           [0, 1, 2]], dtype=int8)
+
+    >>> b = T.ogrid[0:5, 0:3]
+    >>> b[0].eval()
+    array([[0],
+           [1],
+           [2],
+           [3],
+           [4]], dtype=int8)
+    >>> b[1].eval()
+    array([[0, 1, 2, 3]], dtype=int8)
+    """
+    def __init__(self, sparse=False):
+        self.sparse = sparse
+
+    def __getitem__(self, *args):
+
+        ndim = len(args[0])
+        ranges = [arange(sl.start or 0,
+                         sl.stop or None,
+                         sl.step or 1) for sl in args[0]]
+        shapes = [tuple([1] * j + [r.shape[0]] + [1] * (ndim - 1 - j))
+                  for j, r in enumerate(ranges)]
+        ranges = [r.reshape(shape) for r, shape in zip(ranges, shapes)]
+        ones = [ones_like(r) for r in ranges]
+        if self.sparse:
+            grids = ranges
+        else:
+            grids = []
+            for i in range(ndim):
+                grid = 1
+                for j in range(ndim):
+                    if j == i:
+                        grid = grid * ranges[j]
+                    else:
+                        grid = grid * ones[j]
+                grids.append(grid)
+        return grids
+
+
+mgrid = _nd_grid()
+ogrid = _nd_grid(sparse=True)
+
+
 class PermuteRowElements(Op):
     """Permute the elements of each row (inner-most dim) of a tensor.
 

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -46,7 +46,8 @@ from theano.tensor import (_shared, wvector, bvector, autocast_float_as,
         itensor3, Tile, switch, Diagonal, Diag,
         nonzero, flatnonzero, nonzero_values,
         stacklists, DimShuffle, hessian, ptp, power,
-        swapaxes, choose, Choose
+        swapaxes, choose, Choose,
+        mgrid, ogrid
         )
 
 from theano.tests import unittest_tools as utt
@@ -5186,6 +5187,37 @@ class TestARange(unittest.TestCase):
         assert numpy.all(f(2) == len(numpy.arange(0, 2)))
         assert numpy.all(f(2) == len(numpy.arange(0, 2)))
         assert numpy.all(f(0) == len(numpy.arange(0, 0)))
+
+
+class TestNdGrid(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_mgrid_numpy_equiv_float(self):
+        nfmgrid = numpy.mgrid[0:1:.1, 1:10:1., 10:100:10.]
+        tfmgrid = mgrid[0:1:.1, 1:10:1., 10:100:10.]
+        for ng, tg in zip(nfmgrid, tfmgrid):
+            assert_array_equal(ng, tg.eval())
+
+    def test_mgrid_numpy_equiv_int(self):
+        nimgrid = numpy.mgrid[0:2:1, 1:10:1, 10:100:10]
+        timgrid = mgrid[0:2:1, 1:10:1, 10:100:10]
+        for ng, tg in zip(nimgrid, timgrid):
+            assert_array_equal(ng, tg.eval())
+
+    def test_ogrid_numpy_equiv_float(self):
+        nfogrid = numpy.ogrid[0:1:.1, 1:10:1., 10:100:10.]
+        tfogrid = ogrid[0:1:.1, 1:10:1., 10:100:10.]
+        for ng, tg in zip(nfogrid, tfogrid):
+            assert_array_equal(ng, tg.eval())
+
+    def test_ogrid_numpy_equiv_int(self):
+        niogrid = numpy.ogrid[0:2:1, 1:10:1, 10:100:10]
+        tiogrid = ogrid[0:2:1, 1:10:1, 10:100:10]
+        for ng, tg in zip(niogrid, tiogrid):
+            assert_array_equal(ng, tg.eval())
+
 
 
 class TestInversePermutation(unittest.TestCase):


### PR DESCRIPTION
With reference to [this discussion](https://groups.google.com/forum/#!msg/theano-users/ueOfrjiYvZA/TrqAMQSi8ewJ) here is, albeit a lot later than I would have liked, an implementation of the `numpy.mgrid/ogrid` functionality for `theano.tensor`.

The basic idea is already coded, along with some equivalence tests to the numpy functionality.

However, some questions remain:
- Do we want the "imaginary step sizes shorthand", which turns step size into *number of steps, endpoint included*. I find this behavior slightly scary in the theano context, so for now it is not implemented.
- I added a few rudimentary tests, but I am probably missing some standard catches to test for. Please comment if this is the case.
- I added a docstring for the `_ndgrid` class. However, `mgrid` and `ogrid` are instances of these classes and should have different docstrings explaining their functionality. In numpy this is solved by injecting docstrings a posteriori into these instances. Is there a standard for doing this in theano as well?
- Generally, I am not entirely familiar with coding conventions in theano. So if something stands out as weird, please yell. That way I'll learn :)

