### PR TITLE
Flatten C code

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4078,6 +4078,79 @@ class Flatten(Op):
             return [None]
         return self.make_node(*eval_points).outputs
 
+    def c_code_cache_version(self):
+        return (1,)
+
+    def c_code(self, node, name, inputs, outputs, sub):
+        x, = inputs
+        out, = outputs
+        outdim = self.outdim
+        fail = sub['fail']
+        return """
+        if (%(outdim)s == PyArray_NDIM(%(x)s))
+        {
+            if (NULL != %(out)s && %(x)s != %(out)s)
+                Py_XDECREF(%(out)s);
+
+            %(out)s = %(x)s;
+        }
+        else
+        {
+            if (%(outdim)s == 1)
+            {
+                if (NULL != %(out)s)
+                    Py_XDECREF(%(out)s);
+
+                npy_intp size = PyArray_SIZE(%(x)s);
+                PyArray_Dims newshape;
+                newshape.ptr = &size;
+                newshape.len = 1;
+                %(out)s = (PyArrayObject*)PyArray_Newshape(%(x)s,
+                                                           &newshape,
+                                                           NPY_CORDER);
+            }
+            else
+            {
+                if (NULL != %(out)s)
+                    Py_XDECREF(%(out)s);
+
+                npy_intp *oldshape = PyArray_DIMS(%(x)s);
+                npy_intp newshape_dims[%(outdim)s];
+
+                int i;
+                for (i = 0; i < %(outdim)s - 1; ++i)
+                    newshape_dims[i] = oldshape[i];
+
+                newshape_dims[i] = 1;
+
+                for (int j = %(outdim)s - 1; j < PyArray_NDIM(%(x)s); ++j)
+                    newshape_dims[i] *= oldshape[j];
+
+                PyArray_Dims newshape;
+                newshape.ptr = newshape_dims;
+                newshape.len = %(outdim)s;
+                %(out)s = (PyArrayObject*)PyArray_Newshape(%(x)s,
+                                                           &newshape,
+                                                           NPY_CORDER);
+            }
+        }
+        if (!%(out)s)
+        {
+            //The error message should have been set by
+            // PyArray_Newshape
+            %(fail)s;
+        }
+        if (!PyArray_ISALIGNED(%(out)s)) {
+            PyErr_Format(
+                PyExc_RuntimeError,
+                "PyArray_Newshape returned an object that isn't"
+                " aligned! NumPy versions 1.6.2, 1.7.0 and 1.7.1 have"
+                " this problem for some input shape/new shape"
+                " combinations. Use another NumPy version.");
+            %(fail)s;
+        }
+        """ % locals()
+
 
 def flatten(x, outdim=1):
     return Flatten(outdim)(x)


### PR DESCRIPTION
I added C code to the `Flatten` op. @lamblin mentioned in another PR that it is desirable to avoid multiple C code variants per op. The current implementation is parameterized by `outdim` which will cause a precompiled module per `outdim` value. There are two options: 1) `outdim` remains a constructor argument but is fed to the `Apply` node in `make_node`. Thus, `outdim` would still have to be a constant value and it could be checked in `make_node` as it's done now. 2) `outdim` could become a proper input of the `Flatten` op which means it could change during runtime. It's probably a rare case that someone actually wants to do this. Then, the sanity checks in `make_node` would not be possible anymore in the general case. Which variant do you guys prefer?