### PR TITLE
Add missing `host_from_gpu` import to `cuda.opt_util`

### DIFF
--- a/theano/sandbox/cuda/opt_util.py
+++ b/theano/sandbox/cuda/opt_util.py
@@ -8,7 +8,7 @@ from theano.gof import local_optimizer
 from theano.tensor import DimShuffle
 
 from theano.sandbox.cuda.basic_ops import (
-    GpuFromHost, HostFromGpu, GpuDimShuffle, GpuElemwise)
+    GpuFromHost, HostFromGpu, host_from_gpu, GpuDimShuffle, GpuElemwise)
 
 def grab_cpu_scalar(v, nd):
     if v.owner is not None:


### PR DESCRIPTION
`theano.sandbox.cuda.opt_util.grap_cpu_scalar` failed due to the missing `host_from_gpu` import. This caused the `local_dnn_conv*_alpha_merge` optimizers to fail.