### PR TITLE
Set borrow=False for scan inner inputs

### DIFF
--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -543,7 +543,7 @@ class Scan(PureOp):
                   self.n_sit_sot +
                   self.n_nit_sot)
         wrapped_inputs = [Param(x, borrow=True) for x in self.inputs]
-        wrapped_outputs = [Out(x, borrow=(x not in self.inputs)) for x in
+        wrapped_outputs = [Out(x, borrow=False) for x in
                            self.outputs[:slices]]
         wrapped_outputs += self.outputs[slices:]
         profile = None


### PR DESCRIPTION
A user reported a test case not working with Scan on gpu. This is probably overkill but it fixes the bug and gives us time to investigate.