### PR TITLE
fixed error due to integer border_mode in dnn.py

### DIFF
--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -465,6 +465,8 @@ class GpuDnnConv(DnnBase, COp):
         if border_mode == 'full':
             padh = kh - 1
             padw = kw - 1
+        elif isinstance(border_mode, int):
+            padh, padw = border_mode, border_mode
         elif isinstance(border_mode, tuple):
             padh, padw = border_mode
         else:


### PR DESCRIPTION
the situation of border_mode as int was not considered in the function get_out_shape in dnn.py, in the latest versions. 