### PR TITLE
Fix connection_pattern and add test

### DIFF
--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -817,6 +817,25 @@ class T_Scan(unittest.TestCase):
         rval = theano.function([x], y, updates=updates)(inp)
         assert numpy.all(rval == inp[:-1])
 
+    def test_connection_pattern(self):
+        """Test connection_pattern() in the presence of recurrent outputs
+        with multiple taps.
+
+        This test refers to a bug signaled on the theano-users mailing list
+        on March 10 2015 by David Schneider-Joseph.
+        """
+        def fn(a_m2, a_m1, b_m2, b_m1):
+            return a_m1, b_m1
+
+        a0 = theano.shared(numpy.arange(2))
+        b0 = theano.shared(numpy.arange(2))
+
+        (a, b), _ = theano.scan(fn,
+                        outputs_info=[{'initial': a0, 'taps': [-2, -1]},
+                                      {'initial': b0, 'taps': [-2, -1]}],
+                        n_steps=2)
+        tensor.grad(a[-1], a0)
+
     # simple rnn, one input, one state, weights for each; input/state are
     # vectors, weights are scalars; using shared variables and past
     # taps (sequences and outputs)


### PR DESCRIPTION
Fixes #2594. As far as I can tell, the bug relied is that the code relied on self.get_input_pos(), which gives indices of **inner** inputs and used the results as if they were indices of **outer** inputs.

This fixes the bug that was raised on the theano-users mailing list but I am not sure it fixes every issue that could come up with connection_pattern. I have the impression (but I'm not 100% certain) that the code relies on the number of inner outputs and outer outputs being the same to work (mainly lines 1413-1417 after my changes) which is not guaranteed. Could one of @lamblin or @abergeron have a look and tell my what you think.