### PR TITLE
Minor fix in gof/cc.py

### DIFF
--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -1784,7 +1784,7 @@ class DualLinker(link.Linker):
 
 class HideC(object):
     def __hide(*args):
-        raise MethodNotDefined()
+        raise utils.MethodNotDefined()
 
     c_code = __hide
     c_code_cleanup = __hide


### PR DESCRIPTION
MethodNotDefined is called from utils module in all other places in the file except here. I had my program crashing here, and when I changed it to utils.MethodNotDefined it was fixed.