### PR TITLE
Traceback

### DIFF
--- a/theano/gof/utils.py
+++ b/theano/gof/utils.py
@@ -67,9 +67,9 @@ def add_tag_trace(thing, user_line=1):
     tr = simple_extract_stack(limit=limit)[:-1]
     # Different python version use different sementic for
     # limit. python 2.7 include the call to extrack_stack. The -1 get
-    # rid of it.  We also want to get rid of the add_tag_trace call.
-    if tr and "add_tag_trace" in tr[-1][-1]:
-        tr = tr[:-1]
+    # rid of it.
+
+    # Get rid of Theano internal
     while tr:
         file_path = tr[-1][0]
         rm = False

--- a/theano/gof/utils.py
+++ b/theano/gof/utils.py
@@ -87,8 +87,10 @@ def add_tag_trace(thing, user_line=1):
                 break
         if not rm:
             break
+    # Keep only the most recent stack level.
+    # The order is from the oldest to the newest
     if len(tr) > user_line:
-        tr = tr[:user_line]
+        tr = tr[-user_line:]
     thing.tag.trace = tr
     return thing
 


### PR DESCRIPTION
This prevent using that in ipython notebook. It is too late for this fix to be done for GTC presentation.