### PR TITLE
Don't apply alpha_merge and output_merge when the proc node has more than one client.

### DIFF
--- a/theano/sandbox/cuda/opt_util.py
+++ b/theano/sandbox/cuda/opt_util.py
@@ -6,7 +6,6 @@ from theano import scalar as scal, Constant
 from theano.gof import local_optimizer
 from theano.tensor import (DimShuffle, get_scalar_constant_value,
                            NotScalarConstantError)
-from theano.tensor.opt import broadcast_like
 
 from theano.sandbox.cuda.basic_ops import (
     GpuFromHost, HostFromGpu, host_from_gpu, GpuDimShuffle, GpuElemwise)
@@ -101,7 +100,9 @@ def output_merge(cls, alpha_in, beta_in, out_in, nd):
                     # other cases are too complex for now
                     return None
                 if W.broadcastable != targ.inputs[out_in].broadcastable:
-                    W = broadcast_like(W, targ.inputs[out_in], node.fgraph)
+                    # May change later to do the broadcast, but it's
+                    # under discussion.
+                    return None
                 inputs = list(targ.inputs)
                 inputs[out_in] = W
                 inputs[beta_in] = _one.clone()

--- a/theano/sandbox/cuda/opt_util.py
+++ b/theano/sandbox/cuda/opt_util.py
@@ -33,12 +33,11 @@ def grab_cpu_scalar(v, nd):
             return v.dimshuffle(())
 
 
-def find_node(v, cls):
+def find_node(v, cls, ignore_clients=False):
     # This digs through possibly redundant transfers to for the node
     # that has the op class specified.
-    if v.owner is not None:
-        if (isinstance(v.owner.op, cls) and
-            len(v.clients) == 1):
+    if v.owner is not None and (ignore_clients or len(v.clients) == 1):
+        if isinstance(v.owner.op, cls):
             return v.owner
         elif (isinstance(v.owner.op, GpuFromHost) and
               v.owner.inputs[0].owner is not None and

--- a/theano/sandbox/cuda/opt_util.py
+++ b/theano/sandbox/cuda/opt_util.py
@@ -41,6 +41,7 @@ def find_node(v, cls, ignore_clients=False):
             return v.owner
         elif (isinstance(v.owner.op, GpuFromHost) and
               v.owner.inputs[0].owner is not None and
+              (ignore_clients or len(v.owner.inputs[0].clients) == 1) and
               isinstance(v.owner.inputs[0].owner.op, HostFromGpu)):
             return find_node(v.owner.inputs[0].owner.inputs[0], cls)
         else:

--- a/theano/sandbox/cuda/tests/test_dnn.py
+++ b/theano/sandbox/cuda/tests/test_dnn.py
@@ -680,10 +680,9 @@ def test_dnn_conv_merge_mouts():
     rr = conv * lr
 
     f = theano.function([img, kern, out], [fr, rr], mode=mode_with_gpu)
-    assert not isinstance(f.maker.fgraph.outputs[0].owner.inputs[0].owner.op,
-                          dnn.GpuDnnConv)
-    assert not isinstance(f.maker.fgraph.outputs[1].owner.inputs[0].owner.op,
-                          dnn.GpuDnnConv)
+    convs = [n for n in f.maker.fgraph.toposort()
+             if isinstance(n.op, dnn.GpuDnnConv)]
+    assert len(convs) == 1
 
 
 def test_dnn_conv_merge_broad():

--- a/theano/sandbox/cuda/tests/test_dnn.py
+++ b/theano/sandbox/cuda/tests/test_dnn.py
@@ -687,8 +687,7 @@ def test_dnn_conv_merge_mouts():
 
 
 def test_dnn_conv_merge_broad():
-    # make sure it doesn't attempt to output/alpha merge a convolution
-    # that has multiple clients.
+    # Make sure that output merge works on broadcasted outputs.
     if not cuda.dnn.dnn_available():
         raise SkipTest(cuda.dnn.dnn_available.msg)
     img = T.ftensor4()

--- a/theano/sandbox/cuda/tests/test_dnn.py
+++ b/theano/sandbox/cuda/tests/test_dnn.py
@@ -686,14 +686,11 @@ def test_dnn_conv_merge_mouts():
 
 
 def test_dnn_conv_merge_broad():
-    # Make sure that output merge works on broadcasted outputs.
+    # Make sure that we don't apply output_merge on broadcasted values.
     if not cuda.dnn.dnn_available():
         raise SkipTest(cuda.dnn.dnn_available.msg)
     img = T.ftensor4()
     kern = T.ftensor4()
-
-    img_val = numpy.random.random((2, 1, 8, 8)).astype('float32')
-    kern_val = numpy.random.random((3, 1, 4, 5)).astype('float32')
 
     conv = dnn.dnn_conv(img, kern)
 
@@ -702,22 +699,9 @@ def test_dnn_conv_merge_broad():
     # this does broadcasting
     fr = conv + lr
 
-    f1 = theano.function([img, kern], [fr], mode=mode_with_gpu)
-    assert isinstance(f1.maker.fgraph.outputs[0].owner.inputs[0].owner.op,
-                      dnn.GpuDnnConv)
-
-    mode = mode_with_gpu
-    mode = mode.excluding('local_dnn_conv_alpha_merge')
-    mode = mode.excluding('local_dnn_conv_output_merge')
-
-    f2 = theano.function([img, kern], [fr], mode=mode)
-    assert not isinstance(f2.maker.fgraph.outputs[0].owner.inputs[0].owner.op,
+    f = theano.function([img, kern], [fr])
+    assert not isinstance(f.maker.fgraph.outputs[0].owner.inputs[0].owner.op,
                           dnn.GpuDnnConv)
-
-    out_f1 = f1(img_val, kern_val)
-    out_f2 = f2(img_val, kern_val)
-
-    utt.assert_allclose(out_f1, out_f2)
 
 
 def test_dnn_conv_grad():

--- a/theano/sandbox/cuda/tests/test_dnn.py
+++ b/theano/sandbox/cuda/tests/test_dnn.py
@@ -700,8 +700,12 @@ def test_dnn_conv_merge_broad():
     fr = conv + lr
 
     f = theano.function([img, kern], [fr])
-    assert not isinstance(f.maker.fgraph.outputs[0].owner.inputs[0].owner.op,
-                          dnn.GpuDnnConv)
+    convs = [n for n in f.maker.fgraph.toposort()
+             if isinstance(n.op, dnn.GpuDnnConv)]
+    assert len(convs) == 1
+    conv = convs[0]
+    # Assert output was not merged
+    assert isinstance(conv.inputs[2].owner.op, GpuAllocEmpty)
 
 
 def test_dnn_conv_grad():

--- a/theano/sandbox/cuda/tests/test_dnn.py
+++ b/theano/sandbox/cuda/tests/test_dnn.py
@@ -714,7 +714,6 @@ def test_dnn_conv_merge_broad():
     assert not isinstance(f2.maker.fgraph.outputs[0].owner.inputs[0].owner.op,
                           dnn.GpuDnnConv)
 
-
     out_f1 = f1(img_val, kern_val)
     out_f2 = f2(img_val, kern_val)
 

--- a/theano/sandbox/gpuarray/opt_util.py
+++ b/theano/sandbox/gpuarray/opt_util.py
@@ -42,6 +42,7 @@ def find_node(v, cls, ignore_clients=False):
             return v.owner
         elif (isinstance(v.owner.op, GpuFromHost) and
               v.owner.inputs[0].owner is not None and
+              (ignore_clients or len(v.owner.inputs[0].clients) == 1) and
               isinstance(v.owner.inputs[0].owner.op, HostFromGpu)):
             return find_node(v.owner.inputs[0].owner.inputs[0], cls)
         else:


### PR DESCRIPTION
Also apply output_merge in the case when the new output has to be broadcasted.

This may help speed up some graphs by not duplicating heavy nodes in the graph.