### PR TITLE
Apply decorator for stochastic tests on test_run_nnet

### DIFF
--- a/theano/sandbox/cuda/tests/test_extra_ops.py
+++ b/theano/sandbox/cuda/tests/test_extra_ops.py
@@ -162,7 +162,7 @@ class TestGpuCumsum(theano.tensor.tests.test_extra_ops.TestCumsumOp):
             utt.assert_allclose(np.cumsum(a, axis=axis), f(a))
 
             # Use multiple GPU gridblocks
-            a_shape = [5, 5]
+            a_shape = [4, 4]
             a_shape[1-shape_axis] = self.max_grid_size1+1
             a = np.random.random(a_shape).astype("float32")
             utt.assert_allclose(np.cumsum(a, axis=axis), f(a), rtol=5e-5)

--- a/theano/sandbox/cuda/tests/test_mlp.py
+++ b/theano/sandbox/cuda/tests/test_mlp.py
@@ -125,6 +125,7 @@ def run_nnet(use_gpu, n_batch=60, n_in=1024, n_hid=2048, n_out=10,
     return numpy.asarray(rval), dt
 
 
+@utt.AttemptManyTimes(n_attempts=3, n_req_successes=1)
 def test_run_nnet():
     for n_in in 1024, 2048, 4096:
         for n_hid in 1024, 2048, 4096:

--- a/theano/tests/unittest_tools.py
+++ b/theano/tests/unittest_tools.py
@@ -1,4 +1,5 @@
 from copy import copy, deepcopy
+from functools import wraps
 import logging
 from StringIO import StringIO
 import sys
@@ -370,6 +371,7 @@ class AttemptManyTimes:
         # Wrap fct in a function that will attempt to run it multiple
         # times and return the result if the test passes enough times
         # of propagate the raised exception if it doesn't.
+        @wraps(fct)
         def attempt_multiple_times(*args, **kwargs):
 
             # Keep a copy of the current seed for unittests so that we can use


### PR DESCRIPTION
Also improves AttemptManyTimes to keep intact the name of the test in the event of a test failure.

Fixes #2047