### PR TITLE
rename NotScalarConstantValue->NotScalarConstantError

### DIFF
--- a/theano/sandbox/cuda/opt_util.py
+++ b/theano/sandbox/cuda/opt_util.py
@@ -52,7 +52,7 @@ def is_equal(var, val):
     try:
         v = get_scalar_constant_value(var)
         return v == val
-    except NotScalarConstantValue:
+    except NotScalarConstantError:
         return False
 
 


### PR DESCRIPTION
I think this was a typo, since I can't find a reference for NotScalarConstantValue anywhere.