### PR TITLE
Added a config variable to disable the GCC-based cuDNN compilation check

### DIFF
--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -54,16 +54,20 @@ if ((err = cudnnCreate(&_handle)) != CUDNN_STATUS_SUCCESS) {
   return 1;
 }
 """
-            # Do not run here the test program. It would run on the
-            # default gpu, not the one selected by the user. If mixed
-            # GPU are installed or if the GPUs are configured in
-            # exclusive mode, this cause bad detection.
-            comp, out, err = gof.cmodule.GCC_compiler.try_flags(
-                ["-l", "cudnn", "-I" + os.path.dirname(__file__),
-                 "-I" + os.path.join(theano.config.cuda.root, 'include'),
-                 "-L" + os.path.join(theano.config.cuda.root, 'lib64')],
-                preambule=preambule, body=body,
-                try_run=False, output=True)
+            if config.cuda.disable_gcc_cudnn_check:
+                comp = True
+                err = None
+            else:
+                # Do not run here the test program. It would run on the
+                # default gpu, not the one selected by the user. If mixed
+                # GPU are installed or if the GPUs are configured in
+                # exclusive mode, this cause bad detection.
+                comp, out, err = gof.cmodule.GCC_compiler.try_flags(
+                    ["-l", "cudnn", "-I" + os.path.dirname(__file__),
+                     "-I" + os.path.join(theano.config.cuda.root, 'include'),
+                     "-L" + os.path.join(theano.config.cuda.root, 'lib64')],
+                    preambule=preambule, body=body,
+                    try_run=False, output=True)
 
             dnn_available.avail = comp
             if not dnn_available.avail:

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -51,6 +51,12 @@ AddConfigVar('cuda.root',
         in_c_key=False)
 
 
+AddConfigVar('cuda.disable_gcc_cudnn_check',
+             "Disable the GCC-based cuDNN compilation check",
+             BoolParam(default=False),
+             in_c_key=False)
+
+
 def filter_nvcc_flags(s):
     assert isinstance(s, str)
     flags = [flag for flag in s.split(' ') if flag]


### PR DESCRIPTION
Added a config variable to disable the GCC-based cuDNN compilation check as it breaks on Windows with the GTX900 series CUDA 6.5 and CUDA 7.0.

When using the GTX900 series version of CUDA 6.5 from nVidia on the Windows platform, I have found that this breaks on two different machines, one on Win 8, the other on Win 7, while it *seemed to* work okay on the non 900 series version (e.g. on an older card with a different CUDA 6.5 toolkit this hack was not necessary). Using CUDA toolkit 7.0 does not fix the issue.

The problem occurs at startup when Theano tests cuDNN with a simple GCC-based test. GCC fails to locate cuda.h:

```
AssertionError: cuDNN optimization was enabled, but Theano was not able to use it. We got this error:
Theano can not compile with cuDNN. We got this error:
c:\users\geoff\appdata\local\temp\try_flags_uk5iph.c:4:18: fatal error: cuda.h: No such file or directory
compilation terminated.
```

This simple hack allows you to put a config variable in your `.theanorc` that will skip this test, allowing Theano to proceed.
