### PR TITLE
Add numpy.compress to theano.tensor

### DIFF
--- a/theano/tensor/extra_ops.py
+++ b/theano/tensor/extra_ops.py
@@ -514,15 +514,14 @@ def squeeze(x):
 def compress(condition, x, axis=None, out=None):
     """Return selected slices of an array along given axis.
 
-    It returns the input array, but with the
-    broadcastable dimensions removed. This is
-    always `x` itself or a view into `x`.
-    Wrapping of numpy.compress
+    It returns the input tensor, but with selected slices along a given axis
+    retained. If no axis is provided, the tensor is flattened
+    Corresponds to numpy.compress
 
-    :param x: 1 dimension, bools
+    :param x: Input data, tensor variable
 
-    :param condition: array of the same shape as x with corresponding weights.
-        Optional.
+    :param condition: 1 dimensional array of non-zero and zero values
+    corresponding to indices of slices along a selected axis
 
     :return: `x` with selected slices
 
@@ -530,6 +529,7 @@ def compress(condition, x, axis=None, out=None):
     """
     # This is done to keep the same function signature then NumPy.
     assert out is None
+
     indices = theano.tensor.basic.flatnonzero(condition)
     return x.take(indices, axis=axis)
 

--- a/theano/tensor/extra_ops.py
+++ b/theano/tensor/extra_ops.py
@@ -511,6 +511,75 @@ def squeeze(x):
     return view
 
 
+class CompressOp(theano.Op):
+    # See the compress function for docstring
+
+    def __init__(self, axis=None):
+        self.axis = axis
+
+    def __eq__(self, other):
+        return (type(self) == type(other) and
+                self.axis == other.axis)
+
+    def __hash__(self):
+        return hash(type(self)) ^ hash(self.axis)
+
+    def make_node(self, condition, x):
+        x = basic.as_tensor_variable(x)
+
+        condition = basic.as_tensor_variable(condition)
+        if condition.ndim != 1:
+            raise TypeError("Conditions cannot have a number of "
+                            "dimension different of 1.")
+
+        return theano.Apply(self, [condition, x], [x.type()])
+
+    def perform(self, node, inputs, output_storage):
+        condition = inputs[0]
+        x = inputs[1]
+        z = output_storage[0]
+        z[0] = np.compress(condition.astype(bool), x, axis=self.axis)
+        print z[0]
+
+    def infer_shape(self, node, ins_shapes):
+        condition = node.inputs[0]
+        n = condition.ndim # TODO: Find way to get condition vector shape
+
+        if self.axis is None:
+            out_shape = (n,)
+        else:
+            out_shape = list(ins_shapes[1])
+            out_shape[self.axis] -= n
+            out_shape = tuple(out_shape)
+        print out_shape
+        return [out_shape]
+
+    def __str__(self):
+        return self.__class__.__name__
+
+
+def compress(condition, x, axis=None, out=None):
+    """Return selected slices of an array along given axis.
+
+    It returns the input array, but with the
+    broadcastable dimensions removed. This is
+    always `x` itself or a view into `x`.
+    Wrapping of numpy.compress
+
+    :param x: 1 dimension, bools
+
+    :param condition: array of the same shape as x with corresponding weights.
+        Optional.
+
+    :return: `x` with selected slices
+
+    .. versionadded:: 0.7
+    """
+    # This is done to keep the same function signature then NumPy.
+    assert out is None
+    return CompressOp(axis=axis)(condition, x)
+
+
 class RepeatOp(theano.Op):
     # See the repeat function for docstring
 

--- a/theano/tensor/extra_ops.py
+++ b/theano/tensor/extra_ops.py
@@ -511,7 +511,7 @@ def squeeze(x):
     return view
 
 
-def compress(condition, x, axis=None, out=None):
+def compress(condition, x, axis=None):
     """Return selected slices of an array along given axis.
 
     It returns the input tensor, but with selected slices along a given axis
@@ -527,9 +527,6 @@ def compress(condition, x, axis=None, out=None):
 
     .. versionadded:: 0.7
     """
-    # This is done to keep the same function signature then NumPy.
-    assert out is None
-
     indices = theano.tensor.basic.flatnonzero(condition)
     return x.take(indices, axis=axis)
 

--- a/theano/tensor/nlinalg.py
+++ b/theano/tensor/nlinalg.py
@@ -700,3 +700,35 @@ def norm(x, ord):
             raise ValueError(0)
     elif ndim > 2:
         raise NotImplementedError("We don't support norm witn ndim > 2")
+
+
+class TensorSolve(Op):
+    """Computes the pseudo-inverse of a matrix :math:`A`.
+
+    The pseudo-inverse of a matrix A, denoted :math:`A^+`, is
+    defined as: "the matrix that 'solves' [the least-squares problem]
+    :math:`Ax = b`," i.e., if :math:`\\bar{x}` is said solution, then
+    :math:`A^+` is that matrix such that :math:`\\bar{x} = A^+b`.
+
+    Note that :math:`Ax=AA^+b`, so :math:`AA^+` is close to the identity matrix.
+    This method is not faster then `matrix_inverse`. Its strength comes from
+    that it works for non-square matrices.
+    If you have a square matrix though, `matrix_inverse` can be both more
+    exact and faster to compute. Also this op does not get optimized into a
+    solve op.
+    """
+
+    __props__ = ()
+
+    def __init__(self):
+        pass
+
+    def make_node(self, x):
+        x = as_tensor_variable(x)
+        assert x.ndim == 2
+        return Apply(self, [x], [x.type()])
+
+    def perform(self, node, (x,), (z, )):
+        z[0] = numpy.linalg.pinv(x).astype(x.dtype)
+
+tensorsolve = TensorSolve()

--- a/theano/tensor/nlinalg.py
+++ b/theano/tensor/nlinalg.py
@@ -700,35 +700,3 @@ def norm(x, ord):
             raise ValueError(0)
     elif ndim > 2:
         raise NotImplementedError("We don't support norm witn ndim > 2")
-
-
-class TensorSolve(Op):
-    """Computes the pseudo-inverse of a matrix :math:`A`.
-
-    The pseudo-inverse of a matrix A, denoted :math:`A^+`, is
-    defined as: "the matrix that 'solves' [the least-squares problem]
-    :math:`Ax = b`," i.e., if :math:`\\bar{x}` is said solution, then
-    :math:`A^+` is that matrix such that :math:`\\bar{x} = A^+b`.
-
-    Note that :math:`Ax=AA^+b`, so :math:`AA^+` is close to the identity matrix.
-    This method is not faster then `matrix_inverse`. Its strength comes from
-    that it works for non-square matrices.
-    If you have a square matrix though, `matrix_inverse` can be both more
-    exact and faster to compute. Also this op does not get optimized into a
-    solve op.
-    """
-
-    __props__ = ()
-
-    def __init__(self):
-        pass
-
-    def make_node(self, x):
-        x = as_tensor_variable(x)
-        assert x.ndim == 2
-        return Apply(self, [x], [x.type()])
-
-    def perform(self, node, (x,), (z, )):
-        z[0] = numpy.linalg.pinv(x).astype(x.dtype)
-
-tensorsolve = TensorSolve()

--- a/theano/tensor/tests/test_extra_ops.py
+++ b/theano/tensor/tests/test_extra_ops.py
@@ -346,16 +346,19 @@ class SqueezeTester(utt.InferShapeTester):
 
 class CompressTester(utt.InferShapeTester):
     axis_list = [None,
+                 -1,
                  0,
                  0,
                  0,
                  1]
     cond_list = [[1, 0, 1, 0, 0, 1],
                  [0, 1, 1, 0],
+                 [0, 1, 1, 0],
                  [],
                  [0, 0, 0, 0],
                  [1, 1, 0, 1, 0]]
     shape_list = [(2, 3),
+                  (4, 3),
                   (4, 3),
                   (4, 3),
                   (4, 3),

--- a/theano/tensor/tests/test_extra_ops.py
+++ b/theano/tensor/tests/test_extra_ops.py
@@ -382,18 +382,6 @@ class CompressTester(utt.InferShapeTester):
             assert tested.shape == expected.shape
             assert numpy.allclose(tested, expected)
 
-    def test_infer_shape(self):
-        for axis, cond, shape in zip(self.axis_list, self.cond_list, self.shape_list):
-            cond_var = theano.tensor.ivector()
-            data     = numpy.random.random(size=shape).astype(theano.config.floatX)
-            data_var = theano.tensor.matrix()
-
-            self._compile_and_check([cond_var, data_var],
-                                    [self.op(cond_var, data_var, axis=axis)],
-                                    [cond, data],
-                                    tensor.AdvancedSubtensor1,
-                                    warn=False)
-
 
 class TestRepeatOp(utt.InferShapeTester):
     def _possible_axis(self, ndim):

--- a/theano/tensor/tests/test_extra_ops.py
+++ b/theano/tensor/tests/test_extra_ops.py
@@ -347,11 +347,17 @@ class SqueezeTester(utt.InferShapeTester):
 class CompressTester(utt.InferShapeTester):
     axis_list = [None,
                  0,
+                 0,
+                 0,
                  1]
     cond_list = [[1, 0, 1, 0, 0, 1],
                  [0, 1, 1, 0],
+                 [],
+                 [0, 0, 0, 0],
                  [1, 1, 0, 1, 0]]
     shape_list = [(2, 3),
+                  (4, 3),
+                  (4, 3),
                   (4, 3),
                   (3, 5)]
 

--- a/theano/tensor/tests/test_extra_ops.py
+++ b/theano/tensor/tests/test_extra_ops.py
@@ -369,7 +369,7 @@ class CompressTester(utt.InferShapeTester):
         for axis, cond, shape in zip(self.axis_list, self.cond_list, self.shape_list):
             cond_var = theano.tensor.ivector()
             data     = numpy.random.random(size=shape).astype(theano.config.floatX)
-            data_var = tensor.TensorType(theano.config.floatX, [False]*2)()
+            data_var = theano.tensor.matrix()
 
             f = theano.function([cond_var, data_var], self.op(cond_var, data_var, axis=axis))
 
@@ -383,7 +383,7 @@ class CompressTester(utt.InferShapeTester):
         for axis, cond, shape in zip(self.axis_list, self.cond_list, self.shape_list):
             cond_var = theano.tensor.ivector()
             data     = numpy.random.random(size=shape).astype(theano.config.floatX)
-            data_var = tensor.TensorType(theano.config.floatX, [False]*2)()
+            data_var = theano.tensor.matrix()
 
             self._compile_and_check([cond_var, data_var],
                                     [self.op(cond_var, data_var, axis=axis)],

--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -596,10 +596,10 @@ class _tensor_py_operators:
         """
         return theano.tensor.extra_ops.squeeze(self)
 
-    def compress(self, a, axis=None, out=None):
+    def compress(self, a, axis=None):
         """Return selected slices only
         """
-        return theano.tensor.extra_ops.compress(self, a, axis=axis, out=None)
+        return theano.tensor.extra_ops.compress(self, a, axis=axis)
 
 
 class TensorVariable(_tensor_py_operators, Variable):

--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -596,6 +596,11 @@ class _tensor_py_operators:
         """
         return theano.tensor.extra_ops.squeeze(self)
 
+    def compress(self, a, axis=None, out=None):
+        """Return selected slices only
+        """
+        return theano.tensor.extra_ops.compress(self, a, axis=axis, out=None)
+
 
 class TensorVariable(_tensor_py_operators, Variable):
     """Subclass to add the tensor operators to the basic `Variable` class."""


### PR DESCRIPTION
Added `numpy.compress` to the `theano.TensorVariable` interface, including unit tests.
Ref. issue #1080

There is one problem with the implementation at the moment... which I haven't been able to resolve on my own.

Namely, it is that I cannot estimate the shape of outputs.
The input into `compress` is a vector of bools which represents whether an element/slice should be retained in the output, as well as the matrix being operated on.
I cannot retrieve the dimension of the condition vector.

Any advice/help would be appreciated.