### PR TITLE
[CRASH] Fix crash in connection_pattern when there are mitmots

### DIFF
--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -1414,11 +1414,8 @@ class Scan(PureOp):
             corresponding inner output(s) in a sequence.
             """
             s = 0
-            if self.n_mit_mot > 0:
-                e = len(self.mitmot_out_taps()[0])
-            else:
-                e = 1
-            for p in xrange(oidx):
+            e = 0
+            for p in xrange(oidx + 1):
                 s = e
                 if p < self.n_mit_mot:
                     e += len(self.mitmot_out_taps()[p])

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -838,7 +838,7 @@ class T_Scan(unittest.TestCase):
                         n_steps=2)
         tensor.grad(a[-1], a0)
 
-    def test_connection_pattern2():
+    def test_connection_pattern2(self):
         # This tests for a crash in connection_pattern() when a scan node
         # has more than one mitmot (multiple input taps as well as
         # multiple output taps) output


### PR DESCRIPTION
In `scan.connection_pattern._get_inner_outs_idx()`, the indices related to the first mitmot would get counted twice. This PR also adds a test for this crash.

