### PR TITLE
Fix fun_files->func_files typo in error handler for COp unknown sections

### DIFF
--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -1146,7 +1146,7 @@ class COp(Op):
                 while n < len(split):
                     if split[n] not in self.SECTIONS:
                         raise ValueError("Unknown section type (in file %s): %s" %
-                                         (self.fun_files[i], split[n]))
+                                         (self.func_files[i], split[n]))
                     if split[n] not in self.code_sections:
                         self.code_sections[split[n]] = ""
                     self.code_sections[split[n]] += split[n+1]


### PR DESCRIPTION
One character typo: the variable is called `self.func_files`, not `self.fun_files`. Only shows up if you have a C file with an invalid section (like `#section suport_code`).