### PR TITLE
Ticket #201: Misleading error message when replacing variables with "givens"

### DIFF
--- a/theano/compile/pfunc.py
+++ b/theano/compile/pfunc.py
@@ -147,6 +147,8 @@ def rebuild_collect_shared(outputs,
 
     # In this loop we're just adding all variables used as inputs to replacements
     # to the clone_d dictionary.. This will be used in the following loop
+    # which checks if any of the variables used in the replacement is going to be
+    # replaced, and throws an error.
     for v_orig, v_repl in replace_pairs:
         if not isinstance(v_orig, Variable):
             raise TypeError('given keys must be Variable', v_orig)

--- a/theano/compile/pfunc.py
+++ b/theano/compile/pfunc.py
@@ -161,7 +161,9 @@ def rebuild_collect_shared(outputs,
         clone_v_get_shared_updates(v_repl,
                                    copy_inputs_over)
 
-    # This is the original loop
+    # This loop will check if any of replaced variables has been used as
+    # in any replacement. This includes replacing the variable itself,
+    # i.e. (a: a+1)
     for v_orig, v_repl in new_replace_pairs:
         if v_orig in clone_d:
             raise AssertionError(
@@ -172,10 +174,8 @@ def rebuild_collect_shared(outputs,
                 "f(v) is a function of v, is not allowed. Here, v: "
                 "%s is used to compute another u but it is scheduled "
                 "to be replaced by: %s." % (v_orig, v_repl))
-
+        # this will disallow replacing the same variable twice
         clone_d[v_orig] = v_repl
-        #clone_d[v_orig] = clone_v_get_shared_updates(v_repl,
-        #                                             copy_inputs_over)
 
     if inputs is None:
         inputs = []

--- a/theano/compile/pfunc.py
+++ b/theano/compile/pfunc.py
@@ -73,8 +73,7 @@ def rebuild_collect_shared(outputs,
     update_expr = []
     # list of shared inputs that are used as inputs of the graph
     shared_inputs = []
-    var_inputs = {}
-    
+
     def clone_v_get_shared_updates(v, copy_inputs_over):
         '''
         Clones a variable and its inputs recursively until all are in
@@ -134,7 +133,6 @@ def rebuild_collect_shared(outputs,
             clone_d[a] = a.clone_with_new_inputs([clone_d[i] for i in
                                                   a.inputs],
                                                  strict=rebuild_strict)
-            #var_inputs[a] = [clone_d[i] for i in a.inputs]
             for old_o, new_o in zip(a.outputs, clone_d[a].outputs):
                 clone_d.setdefault(old_o, new_o)
         return clone_d[a]
@@ -147,30 +145,36 @@ def rebuild_collect_shared(outputs,
     except Exception:
         replace_pairs = replace
 
+    # In this loop we're just adding all variables used as inputs to replacements
+    # to the clone_d dictionary.. This will be used in the following loop
     for v_orig, v_repl in replace_pairs:
         if not isinstance(v_orig, Variable):
             raise TypeError('given keys must be Variable', v_orig)
         if not isinstance(v_repl, Variable):
             v_repl = shared(v_repl)
-        
+
+        clone_v_get_shared_updates(v_repl,
+                                   copy_inputs_over)
+
+    # This is the original loop
+    for v_orig, v_repl in replace_pairs:
+        if not isinstance(v_orig, Variable):
+            raise TypeError('given keys must be Variable', v_orig)
+        if not isinstance(v_repl, Variable):
+            v_repl = shared(v_repl)
+
+        if v_orig in clone_d:
+            raise AssertionError(
+                    "When using 'givens' or 'replace' with several "
+                    "(old_v, new_v) replacement pairs, you can not have a "
+                    "new_v variable depend on an old_v one. For instance, "
+                    "givens = {a:b, b:(a+1)} is not allowed. Here, the old_v "
+                    "%s is used to compute other new_v's, but it is scheduled "
+                    "to be replaced by %s." % (v_orig, v_repl))
+            
         clone_d[v_orig] = clone_v_get_shared_updates(v_repl,
                                                      copy_inputs_over)
 
-    import pdb; pdb.set_trace()
-
-    for a_orig, _ in replace_pairs:
-        for b_orig, _ in replace_pairs:
-            if a_orig != b_orig:
-                if b_orig == clone_d[a_orig]:
-                    raise AssertionError(
-                        "When using 'givens' or 'replace' with several "
-                        "(v, new_v) replacement pairs, you can not have "
-                        "co-dependency between updated variables. "
-                        "For instance, givens = {v:new_v, u:f(v)}, where "
-                        "f(v) is a function of v, is not allowed. Here, v: "
-                        "%s is used to compute other u: %s, but it is scheduled "
-                        "to be replaced by: %s." % (b_orig, a_orig, clone_d[b_orig]))
-        
     if inputs is None:
         inputs = []
 

--- a/theano/compile/tests/test_pfunc.py
+++ b/theano/compile/tests/test_pfunc.py
@@ -352,7 +352,7 @@ class Test_pfunc(unittest.TestCase):
                 updates=[(z, (z + x + y)), (z, (z - x))])
 
     def test_givens(self):
-        x = shared(0)
+        x = shared(0, name='x')
         assign = pfunc([], x, givens={x: 3})
         assert assign() == 3
         assert x.get_value(borrow=True) == 0
@@ -604,50 +604,42 @@ class Test_pfunc(unittest.TestCase):
         assert len(f.maker.fgraph.inputs) == 1
         assert len(f.maker.fgraph.outputs) == 1
 
-    # def test_givens_replaces_shared_variable2(self):
-    #     a = shared(1., 'a')
-    #     a.default_update = a + 3
-    #     c = a + 10
+    def test_givens_replaces_shared_variable2(self):
+        a = shared(1., 'a')
+        a.default_update = a + 3
+        c = a + 10
 
-    #     # This is not allowed in Theano anymore
-    #     self.assertRaises(AssertionError, theano.function,
-    #                       [], c, givens={a: (a + 10)})
-    # 
-    # def test_givens_replaces_shared_variables3(self):
-    #     a = shared(1, name='a')
-    #     b = shared(2, name='b')
-    #     c = shared(3, name='c')
+        # This is not allowed in Theano anymore
+        self.assertRaises(AssertionError, theano.function,
+                          [], c, givens={a: (a + 10)})
 
-    #     y = a + b + c
-        
-    #     f_allowed = pfunc([], y, givens= [
-    #         (a, c),
-    #         (b, c),
-    #     ])
-    #     assert f_allowed() == 9
-        
-        # f_not_allowed1 = pfunc([], y, givens= [
-        #     (a, a+1),
-        # ])
-        # self.assertRaises(AssertionError, f_not_allowed1)
+    def test_givens_replaces_shared_variables3(self):
+        a = shared(1, name='a')
+        b = shared(2, name='b')
+        c = shared(3, name='c')
 
-        # f_not_allowed2 = pfunc([], y, givens= [
-        #     (a, c),
-        #     (a, b),
-        # ])
-        # self.assertRaises(AssertionError, f_not_allowed2)
+        y = a + b + c
 
-        # f_not_allowed3 = pfunc([], y, givens= [
-        #     (b, a),
-        #     (a, b),
-        # ])
-        # self.assertRaises(AssertionError, f_not_allowed3)
+        f_allowed = pfunc([], y, givens= [
+            (a, c),
+            (b, c),
+        ])
+        assert f_allowed() == 9
 
-        # f_not_allowed4 = pfunc([], y, givens= [
-        #     (b, a),
-        #     (a, c),
-        # ])
-        # self.assertRaises(AssertionError, f_not_allowed4)
+        self.assertRaises(AssertionError, theano.function,
+                          [], y, givens= [(a, a+1)])
+
+        self.assertRaises(AssertionError, theano.function,
+                          [], y, givens= [(a, c),
+                                          (a, b),])
+
+        self.assertRaises(AssertionError, theano.function,
+                          [], y, givens= [(b, a),
+                                          (a, b),])
+
+        self.assertRaises(AssertionError, theano.function,
+                          [], y, givens= [(b, a),
+                                          (a, c),])
 
     def test_duplicate_inputs(self):
         x = theano.tensor.lscalar('x')

--- a/theano/compile/tests/test_pfunc.py
+++ b/theano/compile/tests/test_pfunc.py
@@ -604,14 +604,50 @@ class Test_pfunc(unittest.TestCase):
         assert len(f.maker.fgraph.inputs) == 1
         assert len(f.maker.fgraph.outputs) == 1
 
-    def test_givens_replaces_shared_variable2(self):
-        a = shared(1., 'a')
-        a.default_update = a + 3
-        c = a + 10
-        f = pfunc([], c, givens={a: (a + 10)})
+    # def test_givens_replaces_shared_variable2(self):
+    #     a = shared(1., 'a')
+    #     a.default_update = a + 3
+    #     c = a + 10
 
-        assert f() == 21
-        assert f() == 34
+    #     # This is not allowed in Theano anymore
+    #     self.assertRaises(AssertionError, theano.function,
+    #                       [], c, givens={a: (a + 10)})
+    # 
+    # def test_givens_replaces_shared_variables3(self):
+    #     a = shared(1, name='a')
+    #     b = shared(2, name='b')
+    #     c = shared(3, name='c')
+
+    #     y = a + b + c
+        
+    #     f_allowed = pfunc([], y, givens= [
+    #         (a, c),
+    #         (b, c),
+    #     ])
+    #     assert f_allowed() == 9
+        
+        # f_not_allowed1 = pfunc([], y, givens= [
+        #     (a, a+1),
+        # ])
+        # self.assertRaises(AssertionError, f_not_allowed1)
+
+        # f_not_allowed2 = pfunc([], y, givens= [
+        #     (a, c),
+        #     (a, b),
+        # ])
+        # self.assertRaises(AssertionError, f_not_allowed2)
+
+        # f_not_allowed3 = pfunc([], y, givens= [
+        #     (b, a),
+        #     (a, b),
+        # ])
+        # self.assertRaises(AssertionError, f_not_allowed3)
+
+        # f_not_allowed4 = pfunc([], y, givens= [
+        #     (b, a),
+        #     (a, c),
+        # ])
+        # self.assertRaises(AssertionError, f_not_allowed4)
 
     def test_duplicate_inputs(self):
         x = theano.tensor.lscalar('x')


### PR DESCRIPTION
Here we don't allow any replacement in "givens" that can be ambiguous. Meaning that it's order-dependent. We don't allow replacing a variable with a function of itself too. I have added test cases for the new functionality and corrected an old test that will be no longer allowed.