### PR TITLE
[CRASH new backend] Fix comparison between ssize_t and size_t

### DIFF
--- a/theano/sandbox/gpuarray/subtensor.py
+++ b/theano/sandbox/gpuarray/subtensor.py
@@ -51,14 +51,18 @@ class GpuSubtensor(HideC, Subtensor):
             else {
                 if (*start < 0) *start += len;
                 if (*start < 0) *start = (*step < 0) ? -1 : 0;
-                if (*start >= len) *start = (*step < 0) ? len-1 : len;
+                if (*start > -1 && *start >= len) {
+                    *start = (*step < 0) ? len-1 : len;
+                }
             }
 
             if (stop_n) *stop = (*step < 0) ? -1 : len;
             else {
                 if (*stop < 0) *stop += len;
                 if (*stop < 0) *stop = (*step < 0) ? -1 : 0;
-                if (*stop >= len) *stop = (*step < 0) ? len-1 : len;
+                if (*stop > -1 && *stop >= len) {
+                    *stop = (*step < 0) ? len-1 : len;
+                }
             }
             if (*stop < *start && *step > 0)
                 *stop = *start;
@@ -149,7 +153,7 @@ class GpuSubtensor(HideC, Subtensor):
         return sio.getvalue()
 
     def c_code_cache_version(self):
-        return (5,)
+        return (6,)
 
 
 class GpuIncSubtensor(IncSubtensor):


### PR DESCRIPTION
`*start` and `*stop` are `ssize_t` and `len` is `size_t`. When either `ssize_t` is below 0, is will automatically be cast to `size_t` for the comparison and will thus appear to be incredibly large, making the check pass even if it shouldn't.