### PR TITLE
[CRASH] Improve shared variable management in Scan

### DIFF
--- a/theano/scan_module/scan.py
+++ b/theano/scan_module/scan.py
@@ -870,7 +870,8 @@ def scan(fn,
                         tensor.unbroadcast(
                             tensor.shape_padleft(input.variable), 0),
                         actual_n_steps))
-                sit_sot_inner_outputs.append(input.update)
+                tensor_update = tensor.as_tensor_variable(input.update)
+                sit_sot_inner_outputs.append(tensor_update)
                 # Not that pos is not a negative index. The sign of pos is used
                 # as a flag to indicate if this output should be part of the
                 # update rules or part of the standard outputs of scan.

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -1372,7 +1372,7 @@ class T_Scan(unittest.TestCase):
         if not cuda.cuda_available:
             raise SkipTest('Optional package cuda disabled')
 
-        rs = theano.sandbox.rng_mrg.MRG_RandomStreams()
+        rs = theano.sandbox.rng_mrg.MRG_RandomStreams(use_cuda=True)
         output, _ = theano.scan(lambda : rs.uniform((3,)), n_steps=3)
         cPickle.loads(cPickle.dumps(output))
 

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -1376,6 +1376,14 @@ class T_Scan(unittest.TestCase):
         output, _ = theano.scan(lambda : rs.uniform((3,)), n_steps=3)
         cPickle.loads(cPickle.dumps(output))
 
+        # Also ensure that, after compilation, the Scan has been moved
+        # on the gpu
+        fct = theano.function([], output, mode=mode_with_gpu)
+        scan_nodes = self.scan_nodes_from_fct(fct)
+        assert len(scan_nodes) == 1
+        assert (scan_nodes[0].op.info.get('gpu', False) or
+                scan_nodes[0].op.info.get('gpua', False))
+
     def test_cuda_gibbs_chain(self):
         from theano.sandbox import cuda
         if not cuda.cuda_available:

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -1363,6 +1363,19 @@ class T_Scan(unittest.TestCase):
 
         assert_raises(TypeError, cPickle.load, open(path, "r"))
 
+    def test_consistent_inner_fct(self):
+        # Test that scan does not falsely detect inconsistencies in a valid
+        # inner graph
+
+        # The pickled scan op used in this test requires the use of a gpu
+        from theano.sandbox import cuda
+        if not cuda.cuda_available:
+            raise SkipTest('Optional package cuda disabled')
+
+        rs = theano.sandbox.rng_mrg.MRG_RandomStreams()
+        output, _ = theano.scan(lambda : rs.uniform((3,)), n_steps=3)
+        cPickle.loads(cPickle.dumps(output))
+
     def test_cuda_gibbs_chain(self):
         from theano.sandbox import cuda
         if not cuda.cuda_available:


### PR DESCRIPTION
~~Those checks were added for the sake of completeness in a previous PR but they were not required for any use case known at that time.~~

~~This PR deactivates them for the time being because it appears these checks are causing issues with valid graphs (https://groups.google.com/forum/#!topic/theano-users/y7Nb8oYRUa0).~~

~~Since they are not required anywhere, they can be deactivated for the time being but we should go back eventually to figure out why.~~

Updated description:
The PR changes the way Scan handles some shared variables as recurrent outputs to make sure the associated and outputs are on the CPU. 

The current way it's implemented would mistakenly have MRG_RandomStreams with an input state on the CPU and the output state on GPU. This wasn't caught by anything but, eventually, through the optimization process, the graph was modified and made consistent so no one ever had any issue with this. The recently-added checks for the consistency of the inner graph caught the inconsistency and that is what caused the crash.
