### PR TITLE
Fix crash in Alloc grad

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2523,7 +2523,7 @@ class Alloc(gof.Op):
             new_order = list(x.broadcastable)
             idx = 0
             for i in range(x.ndim):
-                if not new_order[i]:
+                if i not in axis_broadcasted:
                     new_order[i] = idx
                     idx += 1
                 else:

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2512,22 +2512,20 @@ class Alloc(gof.Op):
         axis = range(n_axes_to_sum)
         # The broadcasted dimensions
         axis_broadcasted = []
+        axis_kept = []
         for i, (ib, gb) in enumerate(
             zip(inputs[0].broadcastable,
                 # We need the dimensions corresponding to x
                 grads[0].broadcastable[-inputs[0].ndim:])):
             if ib and not gb:
                 axis_broadcasted.append(i + n_axes_to_sum)
+            else:
+                axis_kept.append(i)
         gx = gz.sum(axis=axis + axis_broadcasted)
         if axis_broadcasted:
-            new_order = list(x.broadcastable)
-            idx = 0
-            for i in range(x.ndim):
-                if i not in axis_broadcasted:
-                    new_order[i] = idx
-                    idx += 1
-                else:
-                    new_order[i] = 'x'
+            new_order = ['x'] * x.ndim
+            for idx, axis in enumerate(axis_kept):
+                new_order[axis] = idx
             gx = gx.dimshuffle(new_order)
             # Dimshuffle to add back the broadcasted dims
         # The *elements* of the output are not connected to

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -2073,6 +2073,16 @@ AllocDimshuffleGradTester = makeBroadcastTester(
         x3=(rand(s3),),
     ),
 )
+AllocDimshuffleGradTester2 = makeBroadcastTester(
+    name='Allocb4GradTester',
+    op=lambda x: alloc(x.dimshuffle('x', 0), 1, s2, s3),
+    expected=(lambda x: numpy.zeros((1, s2, s3), dtype=x.dtype) + x),
+    grad=dict(
+        x1=(rand(s3),),
+        x2=(rand(s3),),
+        x3=(rand(s3),),
+    ),
+)
 
 
 class ApplyDefaultTestOp(theano.Op):

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -2062,6 +2062,19 @@ Allocb4GradTester = makeBroadcastTester(
 )
 
 
+# Partial un broadcast of a dimshuffled input
+AllocDimshuffleGradTester = makeBroadcastTester(
+    name='Allocb4GradTester',
+    op=lambda x: alloc(x.dimshuffle('x', 'x', 0), 1, s2, s3),
+    expected=(lambda x: numpy.zeros((1, s2, s3), dtype=x.dtype) + x),
+    grad=dict(
+        x1=(rand(s3),),
+        x2=(rand(s3),),
+        x3=(rand(s3),),
+    ),
+)
+
+
 class ApplyDefaultTestOp(theano.Op):
     def __init__(self, id):
         self.default_output = id


### PR DESCRIPTION
fix gh-2836

This is a crash in alloc grad, when the inputs have a broadcastable dimension that isn't broadcasted by the node.

reported by Dmitry Bogdanov