### PR TITLE
small optimization of log likelihood function computation

### DIFF
--- a/theano/tensor/tests/mlp_test.py
+++ b/theano/tensor/tests/mlp_test.py
@@ -113,7 +113,7 @@ class LogisticRegression(object):
         # LP[T.arange(y.shape[0]),y] is a vector v containing [LP[0,y[0]], LP[1,y[1]], LP[2,y[2]], ..., LP[n-1,y[n-1]]]
         # and T.mean(LP[T.arange(y.shape[0]),y]) is the mean (across minibatch examples) of the elements in v,
         # i.e., the mean log-likelihood across the minibatch.
-        return T.log(self.p_y_given_x)[T.arange(y.shape[0]), y]
+        return T.log(self.p_y_given_x[T.arange(y.shape[0]), y])
 
 
 class HiddenLayer(object):


### PR DESCRIPTION
I think that it's not necessary to compute the logarithm of the whole matrix.
We can compute the logarithm only of classes from the labels array.