### PR TITLE
Downsample: C implementation for average, sum

### DIFF
--- a/theano/tensor/signal/downsample.py
+++ b/theano/tensor/signal/downsample.py
@@ -610,7 +610,7 @@ class DownsampleFactorMaxGrad(Op):
         else:
             return [theano.tensor.zeros_like(x),
                     theano.tensor.zeros_like(maxout),
-                    theano.gradients.grad_not_implemented(
+                    theano.gradient.grad_not_implemented(
                         self, 2, gz, 'Hessian not implemented with padding')]
 
     def c_code(self, node, name, inp, out, sub):

--- a/theano/tensor/signal/tests/test_downsample.py
+++ b/theano/tensor/signal/tests/test_downsample.py
@@ -33,7 +33,9 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
         out_shp.append(input.shape[-1] / ds[1] + yi)
         output_val = numpy.zeros(out_shp)
         func = numpy.max
-        if mode != 'max':
+        if mode == 'sum':
+            func = numpy.sum
+        elif mode != 'max':
             func = numpy.average
 
         for k in numpy.ndindex(*input.shape[:-2]):
@@ -76,7 +78,9 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
         tt = []
         y = pad_img(x)
         func = numpy.max
-        if mode != 'max':
+        if mode == 'sum':
+            func = numpy.sum
+        elif mode != 'max':
             func = numpy.average
         inc_pad = mode == 'average_inc_pad'
 
@@ -145,7 +149,9 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
         out_shp.append(out_c)
 
         func = numpy.max
-        if mode != 'max':
+        if mode == 'sum':
+            func = numpy.sum
+        elif mode != 'max':
             func = numpy.average
 
         output_val = numpy.zeros(out_shp)
@@ -169,6 +175,7 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
         for maxpoolshp, ignore_border, mode in product(maxpoolshps,
                                                        [True, False],
                                                        ['max',
+                                                        'sum',
                                                         'average_inc_pad',
                                                         'average_exc_pad']):
                 # print 'maxpoolshp =', maxpoolshp
@@ -198,23 +205,23 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
         stridesizes = ((1, 1), (3, 3), (5, 7))
         # generate random images
         imval = rng.rand(4, 10, 16, 16)
+        # The same for each mode
         outputshps = ((4, 10, 16, 16), (4, 10, 6, 6), (4, 10, 4, 3),
                       (4, 10, 16, 16), (4, 10, 6, 6), (4, 10, 4, 3),
                       (4, 10, 14, 14), (4, 10, 5, 5), (4, 10, 3, 2),
                       (4, 10, 14, 14), (4, 10, 6, 6), (4, 10, 4, 3),
                       (4, 10, 12, 14), (4, 10, 4, 5), (4, 10, 3, 2),
                       (4, 10, 12, 14), (4, 10, 5, 6), (4, 10, 4, 3))
-        # The same for each mode
-        outputshps = outputshps + outputshps + outputshps
         images = tensor.dtensor4()
         indx = 0
         for mode, maxpoolshp, ignore_border in product(['max',
+                                                        'sum',
                                                         'average_inc_pad',
                                                         'average_exc_pad'],
                                                        maxpoolshps,
                                                        [True, False]):
                 for stride in stridesizes:
-                    outputshp = outputshps[indx]
+                    outputshp = outputshps[indx % len(outputshps)]
                     indx += 1
                     # DownsampleFactorMax op
                     numpy_output_val = \
@@ -251,7 +258,8 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
             stride = stridesizes[indx]
             maxpoolshp = maxpoolshps[indx]
             for ignore_border, mode in product([True, False],
-                                               ['max', 'average_inc_pad',
+                                               ['max', 'sum',
+                                                'average_inc_pad',
                                                 'average_exc_pad']):
                 indx_out = indx * 2
                 if not ignore_border:
@@ -283,7 +291,7 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
         c = 2  # channel size
         images = tensor.dtensor4()
         for indx, mode in product(numpy.arange(len(maxpoolsizes)),
-                                  ['max', 'average_inc_pad',
+                                  ['max', 'sum', 'average_inc_pad',
                                    'average_exc_pad']):
             imgsize = imgsizes[indx]
             imval = rng.rand(m, c, imgsize[0], imgsize[1]) - 0.5
@@ -486,7 +494,7 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
 
         for maxpoolshp, ignore_border, mode in product(maxpoolshps,
                                                        [True, False],
-                                                       ['max',
+                                                       ['max', 'sum',
                                                         'average_inc_pad',
                                                         'average_exc_pad']):
                 # print 'maxpoolshp =', maxpoolshp
@@ -537,7 +545,7 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
 
         for maxpoolshp, ignore_border, mode in product(maxpoolshps,
                                                        [True, False],
-                                                       ['max',
+                                                       ['max', 'sum',
                                                         'average_inc_pad',
                                                         'average_exc_pad']):
                 # print 'maxpoolshp =', maxpoolshp
@@ -574,7 +582,7 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
 
         for maxpoolshp, ignore_border, mode in product(maxpoolshps,
                                                        [True, False],
-                                                       ['max',
+                                                       ['max', 'sum',
                                                         'average_inc_pad',
                                                         'average_exc_pad']):
                 # print 'maxpoolshp =', maxpoolshp

--- a/theano/tensor/signal/tests/test_downsample.py
+++ b/theano/tensor/signal/tests/test_downsample.py
@@ -189,7 +189,7 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
                                      mode=mode)
                 f = function([images, ], [output, ])
                 output_val = f(imval)
-                assert numpy.all(output_val == numpy_output_val)
+                utt.assert_allclose(output_val, numpy_output_val)
 
                 # DownsampleFactorMax op
                 maxpool_op = DownsampleFactorMax(maxpoolshp,


### PR DESCRIPTION
Hi. I'd like to propose the following changes to the downsampling code:
* extend the C implementation of Downsample to support `average_inc_pad` and `average_exc_pad`,
* add a new `sum` mode to the Python and C implementations.

The C implementation for the `average_*` modes reuses most of the code from `max`. The `sum` mode is a relatively straightforward extension.