### PR TITLE
Move gpu tests from T_Scan to ScanGpuTests

### DIFF
--- a/theano/sandbox/gpuarray/__init__.py
+++ b/theano/sandbox/gpuarray/__init__.py
@@ -54,6 +54,14 @@ if pygpu:
             optdb.add_tags('gpuarray_opt', 'fast_run', 'fast_compile', 'inplace')
         elif config.gpuarray.init_device != '':
             init_dev(config.gpuarray.init_device)
+
+        from .basic_ops import (GpuAlloc, GpuContiguous, GpuEye, GpuFromHost,
+                                GpuJoin, GpuReshape, GpuSplit, HostFromGpu)
+        from .basic_ops import host_from_gpu, gpu_from_host
+        from .elemwise import GpuElemwise
+        from .subtensor import (GpuSubtensor, GpuIncSubtensor,
+                                GpuAdvancedIncSubtensor1)
+
     except Exception:
         error("Could not initialize pygpu, support disabled", exc_info=True)
 else:

--- a/theano/sandbox/gpuarray/opt.py
+++ b/theano/sandbox/gpuarray/opt.py
@@ -735,7 +735,7 @@ optdb.register('gpua_scanOp_make_inplace',
                scan_opt.ScanInplaceOptimizer(typeConstructor=GpuArrayType,
                                              gpua_flag=True),
                75,
-               'gpua',
+               'gpuarray',
                'fast_run',
                'inplace',
                'scan')

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -203,16 +203,17 @@ def grab_scan_node(output):
         return rval
 
 
+def scan_nodes_from_fct(fct):
+    nodes = fct.maker.fgraph.toposort()
+    scan_nodes = [n for n in nodes if isinstance(n.op, Scan)]
+    return scan_nodes
+
+
 class T_Scan(unittest.TestCase):
 
     def setUp(self):
         utt.seed_rng()
         super(T_Scan, self).setUp()
-
-    def scan_nodes_from_fct(self, fct):
-        nodes = fct.maker.fgraph.toposort()
-        scan_nodes = [n for n in nodes if isinstance(n.op, Scan)]
-        return scan_nodes
 
     # generator network, only one output , type scalar ; no sequence or
     # non sequence arguments
@@ -4261,7 +4262,7 @@ class T_Scan(unittest.TestCase):
             f = theano.function([W, v], out, mode=mode_with_opt)
             f(numpy.zeros((3, 3), dtype=theano.config.floatX), [1, 2])
 
-            scan_nodes = self.scan_nodes_from_fct(f)
+            scan_nodes = scan_nodes_from_fct(f)
             assert len(scan_nodes) == 1
             scan_node = scan_nodes[0]
 
@@ -4305,7 +4306,7 @@ class T_Scan(unittest.TestCase):
               [1, 2],
               numpy.zeros((3, 3), theano.config.floatX))
 
-            scan_nodes = self.scan_nodes_from_fct(f)
+            scan_nodes = scan_nodes_from_fct(f)
             assert len(scan_nodes) == 1
             scan_node = scan_nodes[0]
 

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -4431,7 +4431,7 @@ class T_Scan_Gpuarray(unittest.TestCase, ScanGpuTests):
     def __init__(self, *args, **kwargs):
         from theano.sandbox import gpuarray
         self.gpu_backend = gpuarray
-        self.mode_with_gpu = mode_with_opt.including('gpuarray_opt', 'scan')
+        self.mode_with_gpu = mode_with_opt.including('gpuarray', 'scan')
         super(T_Scan_Gpuarray, self).__init__(*args, **kwargs)
 
     def setUp(self):


### PR DESCRIPTION
This PR refactors the gpu tests in test_scan.py to make them more easily usable to test both the cuda and the gpuarray backends.

The tests that can be made to work for both backends are moved to ScanGpuTests and are modified to rely on certain attributes/methods that will manage the interactions with the concrete gpu backend. The classes T_Scan_Cuda and T_Scan_Gpuarray inherit from ScanGpuTests and TestCase and implement these attributes/methods so that the tests will rely on their respective backends.

Some tests were highly cuda specific so they we moved to T_Scan_Cuda instead of ScanGpuTests.