### PR TITLE
broadcastable option to tensor.alloc

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2400,7 +2400,7 @@ class Alloc(gof.Op):
     """
     __props__ = ()
 
-    def make_node(self, value, *shape):
+    def make_node(self, value, *shape, **kwargs):
         v = as_tensor_variable(value)
         sh = [as_tensor_variable(s) for s in shape]
         bcast = []
@@ -2417,10 +2417,13 @@ class Alloc(gof.Op):
                 raise TypeError('Shape arguments to Alloc must be integers, '
                                 'but argument %s is not for apply node: %s' %
                                 (i, s_as_str))
-            # if s is constant 1, then we're broadcastable in that dim
-            try:
-                const_shp = get_scalar_constant_value(s)
-            except NotScalarConstantError:
+            if kwargs.get('broadcastable', True):
+                # if s is constant 1, then we're broadcastable in that dim
+                try:
+                    const_shp = get_scalar_constant_value(s)
+                except NotScalarConstantError:
+                    const_shp = None
+            else:
                 const_shp = None
             bcast.append(numpy.all(1 == const_shp))
         otype = TensorType(dtype=v.dtype, broadcastable=bcast)


### PR DESCRIPTION
Added a broadcastable option to tensor.alloc. When ``broadcatable=False``, no axis will be set broadcastable even when its dim is 1. The default value is ``True``. As an example,

```
In [2]: from theano import tensor
In [3]: a = tensor.alloc(1,1,10)
In [4]: print a.broadcastable
(True, False)
In [5]: b = tensor.alloc(1,1,10,broadcastable=False)
In [6]: print b.broadcastable
(False, False)
In [7]: c = tensor.alloc(1,1,10,broadcastable=True)
In [8]: print c.broadcastable
(True, False)
```

This becomes handy when tensor.alloc is used to initialize a variable passed to the inner scan function as a part of ``outputs_info``, since the broadcastable patterns affects the variable filter inside the scan op.