### PR TITLE
Add opt for gpuarray.GpuElemwise so exponent of pow has same dtype as output

### DIFF
--- a/theano/sandbox/gpuarray/elemwise.py
+++ b/theano/sandbox/gpuarray/elemwise.py
@@ -189,8 +189,8 @@ class GpuElemwise(HideC, Elemwise):
             pass
         for npy, ga in [("npy_uint8", "ga_ubyte"),
                         ("npy_uint16", "ga_ushort"),
-                        ("npy_uin32", "ga_uint"),
-                        ("npy_uin64", "ga_ulong"),
+                        ("npy_uint32", "ga_uint"),
+                        ("npy_uint64", "ga_ulong"),
                         ("npy_int8", "ga_byte"),
                         ("npy_int16", "ga_short"),
                         ("npy_int32", "ga_int"),

--- a/theano/sandbox/gpuarray/opt.py
+++ b/theano/sandbox/gpuarray/opt.py
@@ -14,7 +14,7 @@ from theano.gof import (local_optimizer, EquilibriumDB,
                         SequenceDB, Optimizer, toolbox)
 from theano.gof.optdb import LocalGroupDB
 
-from theano.scalar.basic import Scalar, Pow, Cast, upcast
+from theano.scalar.basic import Scalar, Pow, Cast
 from theano.scan_module import scan_utils, scan_op, scan_opt
 
 from theano.tensor.nnet.conv import ConvOp

--- a/theano/sandbox/gpuarray/opt.py
+++ b/theano/sandbox/gpuarray/opt.py
@@ -265,8 +265,8 @@ def local_gpu_elemwise(node):
         name = 'Gpu' + name
 
     res = GpuElemwise(scal_op, name=name,
-                          inplace_pattern=copy.copy(op.inplace_pattern),
-                          nfunc_spec=op.nfunc_spec)
+                      inplace_pattern=copy.copy(op.inplace_pattern),
+                      nfunc_spec=op.nfunc_spec)
 
     # If the elemwise operation is a pow, casts might be required on the
     # inputs and or outputs because only the (float, float)->float and

--- a/theano/sandbox/gpuarray/opt.py
+++ b/theano/sandbox/gpuarray/opt.py
@@ -274,6 +274,12 @@ def local_gpu_elemwise(node):
     if isinstance(op.scalar_op, Pow):
         old_out_dtype = node.outputs[0].dtype
         old_inp_dtypes = [inp.dtype for inp in node.inputs]
+
+        # Upcast the input dtypes with 'float32' to obtain a floating-point
+        # dtype in which to do the computation.
+        # TODO : Currently, a bug in GpuElemwise prevents support for float16.
+        # It should be fixed and then the upcast below can use 'float16'
+        # instead of 'float32'
         new_out_dtype = upcast("float32", *old_inp_dtypes)
 
         # Transfer the inputs on the GPU and cast them to the right dtype

--- a/theano/sandbox/gpuarray/tests/test_elemwise.py
+++ b/theano/sandbox/gpuarray/tests/test_elemwise.py
@@ -46,6 +46,26 @@ class test_gpu_Broadcast(test_Broadcast):
         super(test_gpu_Broadcast, self).test_c_inplace()
 
 
+def test_elemwise_pow():
+    # Test that GpuElemwise(pow) can compile with any combination of integer
+    # or float input dtype.
+    dev = theano.sandbox.gpuarray.init_dev.device
+    if not dev.startswith('cuda'):
+        raise SkipTest("Cuda specific tests")
+
+    dtypes = ["uint8", "uint16", "uint32", "uint64",
+              "int8", "int16", "int32", "int64",
+              "float32", "float64"]
+
+    for dtype_base in dtypes:
+        for dtype_exp in dtypes:
+            # Compile a gpu function with the specified dtypes
+            base = theano.tensor.vector(dtype=dtype_base)
+            exp = theano.tensor.vector(dtype=dtype_exp)
+            output = base ** exp
+            f = theano.function([base, exp], output)
+
+
 class test_GpuDimShuffle(test_DimShuffle):
     op = GpuDimShuffle
 

--- a/theano/sandbox/gpuarray/tests/test_elemwise.py
+++ b/theano/sandbox/gpuarray/tests/test_elemwise.py
@@ -55,7 +55,7 @@ def test_elemwise_pow():
 
     dtypes = ["uint8", "uint16", "uint32", "uint64",
               "int8", "int16", "int32", "int64",
-              "float32", "float64"]
+              "float16", "float32", "float64"]
 
     for dtype_base in dtypes:
         for dtype_exp in dtypes:

--- a/theano/sandbox/gpuarray/tests/test_elemwise.py
+++ b/theano/sandbox/gpuarray/tests/test_elemwise.py
@@ -1,6 +1,8 @@
+import numpy
+
 import theano
 from theano import scalar, gof
-from theano.tests.unittest_tools import SkipTest
+from theano.tests.unittest_tools import SkipTest, assert_allclose
 
 from theano.tensor.tests.test_elemwise import (test_Broadcast, test_DimShuffle,
                                                test_CAReduce, T_reduce_dtype)
@@ -59,11 +61,20 @@ def test_elemwise_pow():
 
     for dtype_base in dtypes:
         for dtype_exp in dtypes:
+
             # Compile a gpu function with the specified dtypes
             base = theano.tensor.vector(dtype=dtype_base)
             exp = theano.tensor.vector(dtype=dtype_exp)
             output = base ** exp
             f = theano.function([base, exp], output)
+
+            # Call the function to make sure the output is valid
+            base_val = numpy.random.randint(0, 5, size=10).astype(dtype_base)
+            exp_val = numpy.random.randint(0, 3, size=10).astype(dtype_exp)
+
+            out = f(base_val, exp_val)
+            expected_out = base_val ** exp_val
+            assert_allclose(out, expected_out)
 
 
 class test_GpuDimShuffle(test_DimShuffle):


### PR DESCRIPTION
In the gpuarray backend, pow can only be done on inputs that are both float (producing a float output) or both double (producing a double output). Currently, some unit tests for Scan attempt to do `a_float ** an_int16` which raises a compilation error. This optimization adds  a cast to ensure that the exponent has the same dtype as the output to prevent this.