### PR TITLE
Fix sequence cutting in Scan

### DIFF
--- a/theano/scan_module/scan.py
+++ b/theano/scan_module/scan.py
@@ -500,20 +500,18 @@ def scan(fn,
                     nw_slice.name = nw_name
 
                 # We cut the sequence such that seq[i] to correspond to
-                # seq[i-k]
-                if maxtap < 0:
-                    offset = abs(maxtap)
+                # seq[i-k]. For the purposes of cutting the sequences, we
+                # need to pretend tap 0 is used to avoid cutting the sequences
+                # too long if the taps are all lower or all higher than 0.
+                maxtap_proxy = max(maxtap, 0)
+                mintap_proxy = min(mintap, 0)
+                start = (k - mintap_proxy)
+                if k == maxtap_proxy:
+                    nw_seq = seq['input'][start:]
                 else:
-                    offset = 0
-                if maxtap == mintap and maxtap != 0:
-                    if maxtap < 0:
-                        nw_seq = seq['input'][:maxtap]
-                    else:
-                        nw_seq = seq['input'][maxtap:]
-                elif maxtap - k != 0:
-                    nw_seq = seq['input'][offset + k - mintap: -(maxtap - k)]
-                else:
-                    nw_seq = seq['input'][offset + k - mintap:]
+                    end = -(maxtap_proxy - k)
+                    nw_seq = seq['input'][start:end]
+
                 if go_backwards:
                     nw_seq = nw_seq[::-1]
 

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -624,6 +624,8 @@ class T_Scan(unittest.TestCase):
         assert numpy.all(rval == inp[:-1])
 
     def test_using_negative_taps_sequence(self):
+        # This test refers to a bug reported on github on May 22 2015 by
+        # user june-qijun
         def lp(x, x2):
             return x
         x = tensor.fvector('x')

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -630,11 +630,11 @@ class T_Scan(unittest.TestCase):
             return x
         x = tensor.fvector('x')
         res, upd = theano.scan(lp,
-                               sequences = dict(input = x, taps = [-2, -1]))
+                               sequences=dict(input=x, taps=[-2, -1]))
         f = theano.function([x], res, updates = upd)
 
         output =  f([1, 2, 3, 4, 5])
-        expected_output = numpy.array([1,2,3], dtype="float32")
+        expected_output = numpy.array([1, 2, 3], dtype="float32")
         utt.assert_allclose(output, expected_output)
 
     def test_connection_pattern(self):

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -623,6 +623,18 @@ class T_Scan(unittest.TestCase):
         rval = theano.function([x], y, updates=updates)(inp)
         assert numpy.all(rval == inp[:-1])
 
+    def test_using_negative_taps_sequence(self):
+        def lp(x, x2):
+            return x
+        x = tensor.fvector('x')
+        res, upd = theano.scan(lp,
+                               sequences = dict(input = x, taps = [-2, -1]))
+        f = theano.function([x], res, updates = upd)
+
+        output =  f([1, 2, 3, 4, 5])
+        expected_output = numpy.array([1,2,3], dtype="float32")
+        utt.assert_allclose(output, expected_output)
+
     def test_connection_pattern(self):
         """Test connection_pattern() in the presence of recurrent outputs
         with multiple taps.


### PR DESCRIPTION
Fixes #2946.

The code to figure out how to cut sequences gave invalid results if, for a given sequence, the taps we all negative without being all identical. 