### PR TITLE
Proper string representation of a ValueError on Softmax.make_node

### DIFF
--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -398,7 +398,7 @@ class Softmax(gof.Op):
         x = tensor.as_tensor_variable(x)
         if x.type.ndim not in (1, 2) \
                 or x.type.dtype not in tensor.float_dtypes:
-            raise ValueError('x must be 1-d or 2-d tensor of floats. Got ',
+            raise ValueError('x must be 1-d or 2-d tensor of floats. Got %s' %
                              x.type)
         if x.ndim == 1:
             x = tensor.shape_padleft(x, n_ones=1)


### PR DESCRIPTION
Very minor change to create an actual string representing the error, instead of a tuple of two strings