### PR TITLE
[Bug] Revert dot22->gemm optimization back to dot22->dot22scalar

### DIFF
--- a/theano/sandbox/cuda/opt.py
+++ b/theano/sandbox/cuda/opt.py
@@ -570,8 +570,6 @@ def local_gpu_dot22(node):
 @local_optimizer([gpu_from_host, tensor.blas.Dot22Scalar])
 def local_gpu_dot22scalar(node):
     """
-    Deprecated : _dot22scalar has been replace by gemm
-    see Dot22scalar for more details
     gpu_from_host(dot22scalar) -> gpudot(gpu_from_host)
 
     dot(host_from_gpu) -> host_from_gpu(gpudot22scalar)

--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -1984,6 +1984,13 @@ _dot22scalar = Dot22Scalar()
 @local_optimizer([T.mul])
 def local_dot22_to_dot22scalar(node):
     """
+    :note: Previous attempts to alter this optimization to replace dot22 with
+        gemm instead of dot22scalar resulted in some Scan nodes being
+        duplicated and the ScanSaveMem optimization never running on them,
+        resulting in highly increased memory usage. Until this issue is
+        resolved, this optimization should keep using dot22scalar instead of
+        gemm.
+
     :note: we upcast the scalar if after the multiplication with the
         dot this give the same type.
 


### PR DESCRIPTION
The previously done change from dot22->dot22scalar to dot22->gemm had the effect, under some not-fully-understood circumstances,  of duplicating certain Scan nodes and preventing certain optimizations (such as ScanSaveMem) on the duplicates. The result was a drastic increase in memory usage.

The issue should be investigated further and tests added to try and ensure this doesn't occur again but, in the mean time, this fixes this issue which is preventing from people from using the latest version.