### PR TITLE
Fix error and remove unnecessary constructor

### DIFF
--- a/theano/misc/pkl_utils.py
+++ b/theano/misc/pkl_utils.py
@@ -153,9 +153,6 @@ class PersistentNdarrayID(object):
 
 
 class PersistentCudaNdarrayID(PersistentNdarrayID):
-    def __init__(self, zip_file):
-        super(PersistentCudaNdarrayID, self).__init__(zip_file)
-
     def __call__(self, obj):
         if (cuda_ndarray is not None and
                 type(obj) is cuda_ndarray.cuda_ndarray.CudaNdarray):
@@ -203,12 +200,12 @@ class PersistentSharedVariableID(PersistentCudaNdarrayID):
         if id(obj) in self.ndarray_names:
             name = self.ndarray_names[id(obj)]
             count = self.name_counter[name]
+            self.name_counter[name] += 1
             if count:
                 if not self.allow_duplicates:
                     raise ValueError("multiple shared variables with the name "
                                      "`{0}` found".format(name))
                 name = '{0}_{1}'.format(name, count + 1)
-            self.name_counter[name] += 1
             return name
         return super(PersistentSharedVariableID, self)._resolve_name(obj)
 

--- a/theano/misc/tests/test_pkl_utils.py
+++ b/theano/misc/tests/test_pkl_utils.py
@@ -43,12 +43,13 @@ def test_dump_load_mrg():
 def test_dump_zip_names():
     foo_1 = theano.shared(0, name='foo')
     foo_2 = theano.shared(1, name='foo')
+    foo_3 = theano.shared(2, name='foo')
     with open('model.zip', 'wb') as f:
-        dump((foo_1, foo_2, numpy.array(2)), f)
+        dump((foo_1, foo_2, foo_3, numpy.array(3)), f)
     keys = numpy.load('model.zip').keys()
-    assert keys == ['foo', 'foo_2', 'array_0', 'pkl']
-    foo = numpy.load('model.zip')['foo']
-    assert foo == numpy.array(0)
+    assert keys == ['foo', 'foo_2', 'foo_3', 'array_0', 'pkl']
+    foo_3 = numpy.load('model.zip')['foo_3']
+    assert foo_3 == numpy.array(2)
     with open('model.zip', 'rb') as f:
-        foo_1, foo_2, array = load(f)
-    assert array == numpy.array(2)
+        foo_1, foo_2, foo_3, array = load(f)
+    assert array == numpy.array(3)


### PR DESCRIPTION
The counter that checked whether an array with that name already existed in the zip file should count the original names, not the enumerated ones, otherwise it saves them as `array`, `array_2`, `array_2`, ... instead of `array`, `array_2`, `array_3`.

Also removed a constructor which seemed useless.