### PR TITLE
Do not decref descriptor, as PyArray_View steals the reference

### DIFF
--- a/theano/sandbox/cuda/cuda_ndarray.cu
+++ b/theano/sandbox/cuda/cuda_ndarray.cu
@@ -1064,7 +1064,7 @@ CudaNdarray_TakeFrom(CudaNdarray * self, PyObject *args){
     if(!CudaNdarray_is_c_contiguous(indices) != 0) {
         PyErr_SetString(PyExc_NotImplementedError,
                         "CudaNdarray_TakeFrom: The indices must be contiguous in memory.");
-        Py_DECREF(indices_obj);
+        Py_DECREF(indices);
         return NULL;
     }
     int nb_indices = CudaNdarray_SIZE((CudaNdarray *)indices) / 2;// int64 are 8 bytes, float32 are 4 bytes

--- a/theano/sandbox/cuda/cuda_ndarray.cu
+++ b/theano/sandbox/cuda/cuda_ndarray.cu
@@ -1030,7 +1030,6 @@ CudaNdarray_TakeFrom(CudaNdarray * self, PyObject *args){
         PyObject * indices_float32 = NULL;
         indices_float32 = PyArray_View((PyArrayObject*)indices_obj,
                                                   float32_descr, NULL);
-        Py_DECREF(float32_descr);
         if (verbose) printf("ndarray indices\n");
         if (!indices_float32)
             return NULL;


### PR DESCRIPTION
This should fix the following errors:
```
*** Reference count error detected:
an attempt was made to deallocate 11 (f) ***
```