### PR TITLE
improve error message for grad of ProdWithoutZeros

### DIFF
--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -2139,3 +2139,8 @@ class ProdWithoutZeros(CAReduceDtype):
     def __init__(self, axis=None, dtype=None, acc_dtype=None):
         CAReduceDtype.__init__(self, mul_without_zeros, axis=axis,
                                dtype=dtype, acc_dtype=acc_dtype)
+    def grad(self, inp, grads):
+        raise NotImplementedError(
+                '2nd derivatives of `product(a)` is not currently supported.' 
+                'If `a` is guarenteed to contains no zeros, use `product(a, no_zeros_in_input=True)`.'
+                )

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -2140,7 +2140,9 @@ class ProdWithoutZeros(CAReduceDtype):
         CAReduceDtype.__init__(self, mul_without_zeros, axis=axis,
                                dtype=dtype, acc_dtype=acc_dtype)
     def grad(self, inp, grads):
-        raise NotImplementedError(
-                '2nd derivatives of `product(a)` is not currently supported.' 
-                'If `a` is guarenteed to contains no zeros, use `product(a, no_zeros_in_input=True)`.'
+        a, = inp
+        a_grad = theano.gradient.grad_not_implemented(self, 0, a,
+                "2nd derivatives of `product(a)` is not currently supported." 
+                "If `a` is guarenteed to contains no zeros, use `product(a, no_zeros_in_input=True)`."
                 )
+        return [a_grad]

--- a/theano/tensor/tests/test_elemwise.py
+++ b/theano/tensor/tests/test_elemwise.py
@@ -6,6 +6,7 @@ import unittest
 import numpy
 from nose.plugins.skip import SkipTest
 from nose.plugins.attrib import attr
+from nose.tools import raises
 
 import theano
 from theano import gof, scalar, config
@@ -670,6 +671,13 @@ class test_Prod(unittest.TestCase):
         pwz_a0 = ProdWithoutZeros(axis=0)(x)
         fn_a0 = theano.function([x], pwz_a0, mode=self.mode)
         assert numpy.allclose(fn_a0(x_val), [1, 10, 162])
+
+    @raises(theano.gradient.NullTypeGradError)
+    def test_prod_without_zeros_grad(self):
+        x = theano.tensor.dmatrix()
+        pwz_a1 = ProdWithoutZeros(axis=0)(x)
+        pwz_grad = theano.grad(theano.tensor.sum(pwz_a1), x)
+        fn_a1 = theano.function([x], pwz_grad, mode=self.mode)
 
     @attr('slow')
     def test_other_grad_tests(self):


### PR DESCRIPTION
PyMC3 users get cryptic errors from Theano if they use `prod` in their models. This aims to improve the situation.