### PR TITLE
Make local_dimshuffle_lift go through many nodes

### DIFF
--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -153,6 +153,28 @@ class test_dimshuffle_lift(unittest.TestCase):
         self.assertTrue(str(g) in (opt_str_g_inplace, opt_str_g_noinplace),
                         str(g))
 
+    def test_recursive_lift(self):
+        v = T.vector(dtype="float64")
+        m = T.matrix(dtype="float64")
+        out = ((v + 42) * (m + 84)).T
+        g = FunctionGraph([v, m], [out])
+        init_str_g = ("[DimShuffle{1,0}(Elemwise{mul,no_inplace}"
+                      "(DimShuffle{x,0}(Elemwise{add,no_inplace}"
+                      "(<TensorType(float64, vector)>, "
+                      "DimShuffle{x}(TensorConstant{42}))), "
+                      "Elemwise{add,no_inplace}"
+                      "(<TensorType(float64, matrix)>, "
+                      "DimShuffle{x,x}(TensorConstant{84}))))]")
+        self.assertTrue(str(g) == init_str_g)
+        dimshuffle_lift.optimize(g)
+        opt_str_g = ("[Elemwise{mul,no_inplace}(Elemwise{add,no_inplace}"
+                     "(DimShuffle{0,x}(<TensorType(float64, vector)>), "
+                     "DimShuffle{x,x}(TensorConstant{42})), "
+                     "Elemwise{add,no_inplace}(DimShuffle{1,0}"
+                     "(<TensorType(float64, matrix)>), "
+                     "DimShuffle{x,x}(TensorConstant{84})))]")
+        self.assertTrue(str(g) == opt_str_g)
+
 
 def test_add_canonizer_problem0():
     n_segments = 10

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -166,14 +166,15 @@ class test_dimshuffle_lift(unittest.TestCase):
                       "(<TensorType(float64, matrix)>, "
                       "DimShuffle{x,x}(TensorConstant{84}))))]")
         self.assertTrue(str(g) == init_str_g)
-        dimshuffle_lift.optimize(g)
+        new_out = local_dimshuffle_lift.transform(g.outputs[0].owner)[0]
+        new_g = FunctionGraph(g.inputs, [new_out])
         opt_str_g = ("[Elemwise{mul,no_inplace}(Elemwise{add,no_inplace}"
                      "(DimShuffle{0,x}(<TensorType(float64, vector)>), "
                      "DimShuffle{x,x}(TensorConstant{42})), "
                      "Elemwise{add,no_inplace}(DimShuffle{1,0}"
                      "(<TensorType(float64, matrix)>), "
                      "DimShuffle{x,x}(TensorConstant{84})))]")
-        self.assertTrue(str(g) == opt_str_g)
+        self.assertTrue(str(new_g) == opt_str_g)
 
 
 def test_add_canonizer_problem0():


### PR DESCRIPTION
Make local_dimshuffle_lift go through many nodes by recursively calling itself. This commit is following the patch provided by Fred here ( https://github.com/Theano/Theano/issues/2971 ). 

I tested it with following code.
```
import theano                                                                                   
import theano.tensor as T

v = T.vector()
m = T.matrix()
out0 = (v+m).T
out = (out0 + 42).T
theano.config.optimizer_verbose = True
f = theano.function([v, m], out)
```

The output before this optimization as follows,
```
local_dimshuffle_lift DimShuffle{1,0}.0 Elemwise{add,no_inplace}.0
local_dimshuffle_lift DimShuffle{1,0}.0 Elemwise{add,no_inplace}.0
MergeOptimizer tan.0 tan.0
MergeOptimizer sqr.0 sqr.0
...... { MergeOptimizers for many times, ignored here}
MergeOptimizer true_div.0 true_div.0
MergeOptimizer tan.0 tan.0
constant_folding DimShuffle{x,x}.0 TensorConstant{(1, 1) of 42}
local_upcast_elemwise_constant_inputs Elemwise{add,no_inplace}.0 Elemwise{add,no_inplace}.0
local_dimshuffle_lift DimShuffle{1,0}.0 Elemwise{add,no_inplace}.0
local_dimshuffle_lift DimShuffle{1,0}.0 DimShuffle{0,x}.0
local_add_canonizer Elemwise{add,no_inplace}.0 Elemwise{add,no_inplace}.0
local_dimshuffle_lift DimShuffle{1,0}.0 DimShuffle{x,0}.0
local_dimshuffle_lift DimShuffle{1,0}.0 <TensorType(float64, matrix)>
constant_folding DimShuffle{x,x}.0 TensorConstant{(1, 1) of 42.0}
dimshuffle_as_view DimShuffle{x,0}.0 InplaceDimShuffle{x,0}.0
```

The output after is as follows,
```
local_dimshuffle_lift DimShuffle{1,0}.0 Elemwise{add,no_inplace}.0
MergeOptimizer DimShuffle{x,x}.0 DimShuffle{x,x}.0
local_upcast_elemwise_constant_inputs Elemwise{add,no_inplace}.0 Elemwise{add,no_inplace}.0
MergeOptimizer TensorConstant{42} TensorConstant{42}
local_add_canonizer Elemwise{add,no_inplace}.0 Elemwise{add,no_inplace}.0
MergeOptimizer DimShuffle{x,0}.0 DimShuffle{x,0}.0
MergeOptimizer tan.0 tan.0
MergeOptimizer sqr.0 sqr.0
...... { MergeOptimizers for many times, ignored here}
MergeOptimizer true_div.0 true_div.0
MergeOptimizer tan.0 tan.0
constant_folding DimShuffle{x,x}.0 TensorConstant{(1, 1) of 42.0}
dimshuffle_as_view DimShuffle{x,0}.0 InplaceDimShuffle{x,0}.0
```
