### PR TITLE
Fix symbol visibility in cuda_ndarray on Windows

### DIFF
--- a/theano/gof/theano_mod_helper.h
+++ b/theano/gof/theano_mod_helper.h
@@ -6,7 +6,10 @@
 #ifndef _WIN32
 #define MOD_PUBLIC __attribute__((visibility ("default")))
 #else
-#define MOD_PUBLIC
+/* MOD_PUBLIC is only used in PyMODINIT_FUNC, which is declared
+ * and implemented in mod.cu/cpp, not in headers, so dllexport
+ * is always correct. */
+#define MOD_PUBLIC __declspec( dllexport )
 #endif
 
 #ifdef __cplusplus

--- a/theano/sandbox/cuda/cuda_ndarray.cuh
+++ b/theano/sandbox/cuda/cuda_ndarray.cuh
@@ -3,8 +3,6 @@
 
 #include <algorithm>
 
-#include "theano_mod_helper.h"
-
 // Defines for Python 2/3 compatibility.
 #if PY_MAJOR_VERSION >= 3
 // Py3k treats all ints as longs. This one is not caught by npy_3kcompat.h.
@@ -55,7 +53,7 @@
 # endif
 # define ALWAYS_INLINE
 #else //else _WIN32
-# define DllExport  MOD_PUBLIC
+# define DllExport __attribute__((visibility ("default")))
 # define ALWAYS_INLINE __attribute__((always_inline))
 #endif
 


### PR DESCRIPTION
This is a first try, I've not been able to test it on Windows yet.