### PR TITLE
Add theano.tensor.nnet.relu function

### DIFF
--- a/doc/library/tensor/nnet/nnet.txt
+++ b/doc/library/tensor/nnet/nnet.txt
@@ -18,6 +18,7 @@
 - Others
    - :func:`softplus`
    - :func:`softmax`
+   - :func:`relu() <theano.tensor.nnet.relu>`
    - :func:`binary_crossentropy`
    - :func:`.categorical_crossentropy`
 
@@ -135,6 +136,8 @@
        x,y,b = T.dvectors('x','y','b')
        W = T.dmatrix('W')
        y = T.nnet.softmax(T.dot(W,x) + b)
+
+.. autofunction:: theano.tensor.nnet.relu
 
 .. function:: binary_crossentropy(output,target)
 


### PR DESCRIPTION
As discussed in #2698, this adds a `theano.tensor.nnet.relu` function providing an optimized formulation of the linear rectifier and leaky linear rectifier at least for GPUs, with the potential to be extended with a different formulation for CPUs or even a ReLU Op in future.

/edit: I'm not sure about the docs, how can I test them?