### PR TITLE
Speed up Scan optimizations

### DIFF
--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -113,8 +113,8 @@ def remove_constants_and_unused_inputs_scan(node):
     op = node.op
     # We only need to take care of sequences and other arguments
     st = op.n_seqs
-    st += int(numpy.sum([len(x) for x in
-                         op.tap_array[:(op.n_mit_mot + op.n_mit_sot)]]))
+    st += int(sum([len(x) for x in
+                   op.tap_array[:(op.n_mit_mot + op.n_mit_sot)]]))
     st += op.n_sit_sot
     st += op.n_shared_outs
 
@@ -463,7 +463,7 @@ class PushOutSeqScan(gof.Optimizer):
                     depends_on_seqs = False
 
                     for x in nd.inputs:
-                        if x in inner_non_seqs:
+                        if x in inner_non_seqs_set:
                             _idx = inner_non_seqs_map[x]
                             outside_ins.append(outer_non_seqs[_idx])
                         elif x in inner_seqs_set:
@@ -609,7 +609,7 @@ class PushOutSeqScan(gof.Optimizer):
                     if out in op.inner_mitsot_outs(ls):
                         odx = op.inner_mitsot_outs(ls).index(out)
                         inp = op.outer_mitsot(node)[odx]
-                        st = abs(numpy.min(op.mitsot_taps()))
+                        st = abs(min(op.mitsot_taps()))
                         y = tensor.set_subtensor(inp[st:], _y)
                     elif out in op.inner_sitsot_outs(ls):
                         odx = op.inner_sitsot_outs(ls).index(out)
@@ -1081,7 +1081,7 @@ class ScanSaveMem(gof.Optimizer):
         c_outs = op.n_mit_mot + op.n_mit_sot + op.n_sit_sot + op.n_nit_sot
 
         init_l = [0 for x in xrange(op.n_mit_mot)]
-        init_l += [abs(numpy.min(v)) for v in op.tap_array[op.n_mit_mot:]]
+        init_l += [abs(min(v)) for v in op.tap_array[op.n_mit_mot:]]
         init_l += [0 for x in xrange(op.n_nit_sot)]
         # 2. Check the clients of each output and see for how many steps
         # does scan need to run

--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -61,7 +61,6 @@ import logging
 import copy
 from sys import maxsize
 import numpy
-from itertools import chain
 
 import theano
 from theano import tensor

--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -324,13 +324,13 @@ class PushOutNonSeqScan(gof.Optimizer):
         clean_replace_with_out = []
         existent_nodes = [nd for nd in local_fgraph_topo
                           if nd not in to_remove_set]
-
+        existent_nodes_set = set(existent_nodes)
         to_keep = []; [to_keep.extend(nd.inputs) for nd in existent_nodes]
         to_keep_set = set(to_keep)
 
         for out, idx in to_replace_map.iteritems():
             if (out in to_keep_set
-                    and out.owner not in existent_nodes
+                    and out.owner not in existent_nodes_set
                     # If types are different, conversion Op will be inserted,
                     # and it may trigger an infinite loop.
                     and replace_with_in[idx].type == out.type):
@@ -554,12 +554,13 @@ class PushOutSeqScan(gof.Optimizer):
 
         existent_nodes = [nd for nd in local_fgraph_topo
                           if nd not in to_remove_set]
+        existent_nodes_set = set(existent_nodes)
         to_keep = []; [to_keep.extend(nd.inputs) for nd in existent_nodes]
         to_keep_set = set(to_keep)
 
         for out, idx in to_replace_map.iteritems():
             if (out in to_keep_set
-                    and out.owner not in existent_nodes
+                    and out.owner not in existent_nodes_set
                     # If types are different, conversion Op will be inserted,
                     # and it may trigger an infinite loop.
                     and replace_with_in[idx].type == out.type):

--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -61,7 +61,6 @@ import logging
 import copy
 from sys import maxsize
 import numpy
-from itertools import izip
 
 import theano
 from theano import tensor
@@ -269,13 +268,13 @@ class PushOutNonSeqScan(gof.Optimizer):
                                (x.owner in to_remove_set) or
                                isinstance(x, tensor.Constant)
                                for x in nd.inputs]) and
-                        # we can do this because the assumption is that a
-                        # viewOp or deepCopyOp will be just at the end of the
-                        # function and not somewhere in the middle ..
-                        not isinstance(nd.op, theano.compile.ViewOp) and
-                        not isinstance(nd.op, theano.compile.DeepCopyOp) and
-                        # and we didn't already looked at this node
-                        nd not in to_remove_set):
+                               # we can do this because the assumption is that a
+                               # viewOp or deepCopyOp will be just at the end of the
+                               # function and not somewhere in the middle ..
+                               not isinstance(nd.op, theano.compile.ViewOp) and
+                               not isinstance(nd.op, theano.compile.DeepCopyOp) and
+                               # and we didn't already looked at this node
+                               nd not in to_remove_set):
 
                     # We have a candidate node to removable
                     # Step 1. Reconstruct it on outside
@@ -297,7 +296,7 @@ class PushOutNonSeqScan(gof.Optimizer):
                                  'which is not allowed to move. Report '
                                  'this on theano-users list'), x)
                     outside_ins = [x.type.filter_variable(y) for x, y in
-                                   izip(nd.inputs, outside_ins)]
+                                   zip(nd.inputs, outside_ins)]
 
                     # Do not call make_node for test_value
                     nw_outer_node = nd.op(*outside_ins,
@@ -345,7 +344,7 @@ class PushOutNonSeqScan(gof.Optimizer):
             givens = OrderedDict()
             nw_outer = []
             nw_inner = []
-            for to_repl, repl_in, repl_out in izip(clean_to_replace,
+            for to_repl, repl_in, repl_out in zip(clean_to_replace,
                                                   clean_replace_with_in,
                                                   clean_replace_with_out):
                 if isinstance(repl_out, theano.Constant):
@@ -467,7 +466,7 @@ class PushOutSeqScan(gof.Optimizer):
                                isinstance(x, tensor.Constant) or
                                (x in inner_seqs_set)
                                for x in nd.inputs]) and
-                    not nd in to_remove_set):
+                               nd not in to_remove_set):
                     to_remove_add(nd)
                     outside_ins = []
                     depends_on_seqs = False
@@ -580,7 +579,7 @@ class PushOutSeqScan(gof.Optimizer):
             givens = OrderedDict()
             nw_outer = []
             nw_inner = []
-            for to_repl, repl_in, repl_out in izip(clean_to_replace,
+            for to_repl, repl_in, repl_out in zip(clean_to_replace,
                                                   clean_replace_with_in,
                                                   clean_replace_with_out):
                 if isinstance(repl_out, theano.Constant):
@@ -621,7 +620,7 @@ class PushOutSeqScan(gof.Optimizer):
                     if out in op.inner_mitsot_outs(ls):
                         odx = op.inner_mitsot_outs(ls).index(out)
                         inp = op.outer_mitsot(node)[odx]
-                        st = abs(min(op.mitsot_taps()))
+                        st = abs(numpy.min(op.mitsot_taps()))
                         y = tensor.set_subtensor(inp[st:], _y)
                     elif out in op.inner_sitsot_outs(ls):
                         odx = op.inner_sitsot_outs(ls).index(out)

--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -229,7 +229,7 @@ class PushOutNonSeqScan(gof.Optimizer):
         local_fgraph = gof.FunctionGraph(clean_inputs, clean_outputs, clone=False)
         local_fgraph_topo = local_fgraph.toposort()
         local_fgraph_outs_set = set(local_fgraph.outputs)
-        local_fgraph_outs_map = dict({v:k for k,v in enumerate(local_fgraph.outputs)})
+        local_fgraph_outs_map = dict([(v, k) for k,v in enumerate(local_fgraph.outputs)])
 
         max_iterations = 2 * len(local_fgraph_topo) + 3
         counts = 0
@@ -250,7 +250,7 @@ class PushOutNonSeqScan(gof.Optimizer):
         # Construct the list of non_sequences to simplify a few things
         inner_non_seqs = op.inner_non_seqs(clean_inputs)
         inner_non_seqs_set = set(inner_non_seqs)
-        inner_non_seqs_map = dict({v:k for k,v in enumerate(inner_non_seqs)})
+        inner_non_seqs_map = dict([(v,k) for k,v in enumerate(inner_non_seqs)])
 
         outer_non_seqs = op.outer_non_seqs(node.inputs)
 
@@ -275,7 +275,7 @@ class PushOutNonSeqScan(gof.Optimizer):
                         not isinstance(nd.op, theano.compile.ViewOp) and
                         not isinstance(nd.op, theano.compile.DeepCopyOp) and
                         # and we didn't already looked at this node
-                        not nd in to_remove_set):
+                        nd not in to_remove_set):
 
                     # We have a candidate node to removable
                     # Step 1. Reconstruct it on outside
@@ -308,7 +308,7 @@ class PushOutNonSeqScan(gof.Optimizer):
                         y_place_holder = scan_utils.safe_new(y, '_replace')
                         nto_replace = add_to_replace(y, nto_replace)
                         replace_with_in.append(y_place_holder)
-                        assert type(y) == type(nw_outer_node.outputs[idx])
+                        assert isinstance(y, type(nw_outer_node.outputs[idx]))
                         replace_with_out.append(nw_outer_node.outputs[idx])
 
                     changed = True
@@ -421,7 +421,7 @@ class PushOutSeqScan(gof.Optimizer):
         local_fgraph = gof.FunctionGraph(clean_inputs, clean_outputs, clone=False)
         local_fgraph_topo = local_fgraph.toposort()
         local_fgraph_outs_set = set(local_fgraph.outputs)
-        local_fgraph_outs_map = dict({v:k for k,v in enumerate(local_fgraph.outputs)})
+        local_fgraph_outs_map = dict([(v,k) for k,v in enumerate(local_fgraph.outputs)])
 
         max_iterations = 2 * len(local_fgraph_topo) + 3
         counts = 0
@@ -445,12 +445,12 @@ class PushOutSeqScan(gof.Optimizer):
         # Construct the list of non_sequences to simplify a few things
         inner_non_seqs = op.inner_non_seqs(clean_inputs)
         inner_non_seqs_set = set(inner_non_seqs)
-        inner_non_seqs_map = dict({v:k for k,v in enumerate(inner_non_seqs)})
+        inner_non_seqs_map = dict([(v,k) for k,v in enumerate(inner_non_seqs)])
 
         outer_non_seqs = op.outer_non_seqs(node.inputs)
         inner_seqs = op.inner_seqs(clean_inputs)
         inner_seqs_set = set(inner_seqs)
-        inner_seqs_map = dict({v:k for k,v in enumerate(inner_seqs)})
+        inner_seqs_map = dict([(v,k) for k,v in enumerate(inner_seqs)])
 
         outer_seqs = op.outer_seqs(node.inputs)
         assert len(inner_non_seqs) == len(outer_non_seqs)
@@ -564,7 +564,7 @@ class PushOutSeqScan(gof.Optimizer):
         to_keep = []; [to_keep.extend(nd.inputs) for nd in existent_nodes]
         to_keep_set = set(to_keep)
 
-        for out, idx in to_replace_map.iteritems():
+        for out, idx in to_replace_map.items():
             if (out in to_keep_set
                     and out.owner not in existent_nodes_set
                     # If types are different, conversion Op will be inserted,
@@ -613,7 +613,7 @@ class PushOutSeqScan(gof.Optimizer):
               not op.outer_mitmot(node)):
             # Nothing in the inner graph should be kept
             replace_with = OrderedDict()
-            for out, idx in to_replace_map.iteritems():
+            for out, idx in to_replace_map.items():
                 if out in local_fgraph_outs_set:
                     x = node.outputs[local_fgraph_outs_map[out]]
                     _y = replace_with_out[idx]

--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -248,7 +248,6 @@ class PushOutNonSeqScan(gof.Optimizer):
                 enumerate(local_fgraph.outputs)])
 
         to_remove_set = set()
-        to_remove_add = to_remove_set.add
         to_replace_set = set()
         to_replace_add = to_replace_set.add
         to_replace_map = OrderedDict()
@@ -291,7 +290,7 @@ class PushOutNonSeqScan(gof.Optimizer):
 
                 # We have a candidate node to removable
                 # Step 1. Reconstruct it on outside
-                to_remove_add(nd)
+                to_remove_set.add(nd)
                 outside_ins = []
                 for x in nd.inputs:
                     if x in inner_non_seqs_set:
@@ -441,7 +440,6 @@ class PushOutSeqScan(gof.Optimizer):
                                      enumerate(local_fgraph.outputs)])
 
         to_remove_set = set()
-        to_remove_add = to_remove_set.add
         to_replace_set = set()
         to_replace_add = to_replace_set.add
         to_replace_map = OrderedDict()
@@ -478,7 +476,7 @@ class PushOutSeqScan(gof.Optimizer):
                (x in inner_seqs_set) for x in nd.inputs]) and
                isinstance(nd.op, theano.tensor.Elemwise)):
 
-                to_remove_add(nd)
+                to_remove_set.add(nd)
                 outside_ins = []
                 depends_on_seqs = False
 
@@ -527,7 +525,7 @@ class PushOutSeqScan(gof.Optimizer):
                   (nd.inputs[0] in inner_seqs_set or
                   nd.inputs[0].owner in to_remove_set)):
 
-                to_remove_add(nd)
+                to_remove_set.add(nd)
                 x = nd.inputs[0]
                 if x in inner_seqs_set:
                     outside_ins = outer_seqs[inner_seqs_map[x]]

--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -229,10 +229,10 @@ class PushOutNonSeqScan(gof.Optimizer):
 
     def process_node(self, fgraph, node):
         """
-        Important note: This function uses set and dictionary data structure.
+        IMPORTANT NOTE: This function uses set and dictionary data structures.
         By default they are not ordered for efficiency reasons. Take care
-        and make sure of changing them to Ordered versions if you need to
-        iterate over those variables.
+        and make sure of changing them with their Ordered counterparts if you
+        need to iterate over these variables.
         """
         # this flag tells if there was any change during the last iterations
         clean_inputs, clean_outputs = scan_utils.reconstruct_graph(

--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -284,9 +284,8 @@ class PushOutNonSeqScan(gof.Optimizer):
                             outside_ins.append(outer_non_seqs[_idx])
                         elif x in to_replace_set:
                             outside_ins.append(replace_with_out[to_replace_map[x]])
-
                         elif isinstance(x, theano.Constant):
-                            outside_ins += [x.clone()]
+                            outside_ins.append(x.clone())
                         else:
                             raise Exception(
                                 ('Error in the `scan_pushout_non_seq_'
@@ -349,8 +348,8 @@ class PushOutNonSeqScan(gof.Optimizer):
                 if isinstance(repl_out, theano.Constant):
                     repl_in = repl_out.clone()
                 else:
-                    nw_inner += [repl_in]
-                    nw_outer += [repl_out]
+                    nw_inner.append(repl_in)
+                    nw_outer.append(repl_out)
                 givens[to_repl] = repl_in
 
             _op_outs = scan_utils.clone(clean_outputs,


### PR DESCRIPTION
@lamblin @carriepl @nouiz 
I have done some easy optimizations in the scan_opt.py. Most of the operations that can be done in constant time by using set or dictionary, previously was being done in linear time inside the loop. It was a bit slow because of that. 

There are a few other changes that I want to do as well. 

These changes speedup by more than 100 secs for a computational graph that was taking more than 900 secs to compile.