### PR TITLE
OpFromGraph.infer_shape()

### DIFF
--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -145,6 +145,10 @@ class OpFromGraph(gof.Op):
         shape = theano.scan_module.scan_utils.infer_shape(self.new_outputs, 
                                                           self.new_inputs,
                                                           shapes)
+
+        import pdb
+        pdb.set_trace()
+
         return shape
 
     def grad(self, inputs, output_grads):

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -142,14 +142,13 @@ class OpFromGraph(gof.Op):
         return io_connection_pattern(self.new_inputs, self.new_outputs)
 
     def infer_shape(self, node, shapes):
-        shape = theano.scan_module.scan_utils.infer_shape(self.new_outputs, 
+        out_shp = theano.scan_module.scan_utils.infer_shape(self.new_outputs,
                                                           self.new_inputs,
                                                           shapes)
+        replacement = dict([(ori, rpl) for ori, rpl
+                            in izip(self.new_inputs, node.inputs)])
 
-        import pdb
-        pdb.set_trace()
-
-        return shape
+        return [theano.clone(shape, replace=replacement) for shape in out_shp]
 
     def grad(self, inputs, output_grads):
         # OpFromGraph doesn't implement a connection_pattern, so for
@@ -183,5 +182,3 @@ class OpFromGraph(gof.Op):
 # Since OpFromGraph contains a Theano compiled function, we should let
 # DebugMode know about it
 ops_with_inner_function[OpFromGraph] = 'fn'
-
-

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -6,6 +6,8 @@ from theano.compile import SharedVariable, rebuild_collect_shared
 from theano.gof import ops_with_inner_function
 from theano.gof.graph import io_connection_pattern
 
+from functools import reduce
+
 
 class OpFromGraph(gof.Op):
     """This creates an `Op` from inputs and outputs lists of variables.
@@ -145,8 +147,6 @@ class OpFromGraph(gof.Op):
         out_shp = theano.scan_module.scan_utils.infer_shape(self.new_outputs,
                                                             self.new_inputs,
                                                             shapes)
-        replacement = dict([(ori, rpl) for ori, rpl
-                            in izip(self.new_inputs, node.inputs)])
 
         # Clone the output shape so that shape are computed from outer inputs.
         # Note:

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -4,12 +4,11 @@ from theano.compat import izip
 from theano.compile.function_module import orig_function
 from theano.compile import SharedVariable, rebuild_collect_shared
 from theano.gof import ops_with_inner_function
-<<<<<<< HEAD
 from theano.gof.graph import io_connection_pattern
 
-=======
 from theano.gof import graph, FunctionGraph
->>>>>>> draft of infer_shape
+from theano.gof import FunctionGraph
+
 
 class OpFromGraph(gof.Op):
     """This creates an `Op` from inputs and outputs lists of variables.
@@ -166,9 +165,9 @@ class OpFromGraph(gof.Op):
             assert all([var in shape_map.keys() for var in node.inputs])
 
             # calculate output shape
-            in_shapes = [ shape_map[var] for var in node.inputs]
+            in_shapes = [shape_map[var] for var in node.inputs]
             out_shapes = node.op.infer_shape(node, in_shapes)
-            
+
             # store the shape of that variable
             for out_var, shape in zip(node.outputs, out_shapes):
                 shape_map.setdefault(out_var, shape)

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -6,9 +6,6 @@ from theano.compile import SharedVariable, rebuild_collect_shared
 from theano.gof import ops_with_inner_function
 from theano.gof.graph import io_connection_pattern
 
-from theano.gof import graph, FunctionGraph
-from theano.gof import FunctionGraph
-
 
 class OpFromGraph(gof.Op):
     """This creates an `Op` from inputs and outputs lists of variables.

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -146,15 +146,35 @@ class OpFromGraph(gof.Op):
         return io_connection_pattern(self.new_inputs, self.new_outputs)
 
     def infer_shape(self, node, shapes):
-        # Construct a new fgraph
-        equiv = graph.clone_get_equiv(self.new_inputs, self.new_outputs)
-        replacement = dict((equiv[var], var) for var in self.new_inputs)
-        out_cpy = theano.clone([equiv[var] for var in self.new_outputs], replace=replacement)
-        fg = FunctionGraph(self.new_inputs, out_cpy)
+        fg = FunctionGraph(self.new_inputs, self.new_outputs)
+        order = fg.toposort()
 
-        in_shapes = dict([(v, shp) for v, shp in zip(fg.inputs, shapes)])
-        all_shapes = theano.tensor.utils.shape_of_variables(fg, in_shapes)
-        return [all_shapes[var] for var in fg.outputs]
+        # A dict that map variable to its shape
+        shape_map = {}
+
+        # set the input shapes of the fgraph
+        for in_var, shape in zip(fg.inputs, shapes):
+            shape_map.setdefault(in_var, shape)
+
+        # calculate the output shape from input shape
+        for node in order:
+            # deal with constant
+            for var in node.inputs:
+                if isinstance(var, theano.Constant):
+                    shape_map.setdefault(var, var.shape)
+            # assert we already have the shape of necessary inputs
+            assert all([var in shape_map.keys() for var in node.inputs])
+
+            # calculate output shape
+            in_shapes = [ shape_map[var] for var in node.inputs]
+            out_shapes = node.op.infer_shape(node, in_shapes)
+            
+            # store the shape of that variable
+            for out_var, shape in zip(node.outputs, out_shapes):
+                shape_map.setdefault(out_var, shape)
+
+        # extract output shape
+        return tuple([shape_map[var] for var in fg.outputs])
 
     def grad(self, inputs, output_grads):
         # OpFromGraph doesn't implement a connection_pattern, so for

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -142,16 +142,10 @@ class OpFromGraph(gof.Op):
         return io_connection_pattern(self.new_inputs, self.new_outputs)
 
     def infer_shape(self, node, shapes):
-        # clone fgraph
-        equiv = clone_get_equiv(self.new_inputs, self.new_outputs)
-        in_v = [equiv[var] for var in self.new_inputs]
-        out_v = [equiv[var] for var in self.new_outputs]
-
-        shape = theano.scan_module.scan_utils.infer_shape(out_v, in_v,
+        shape = theano.scan_module.scan_utils.infer_shape(self.new_outputs, 
+                                                          self.new_inputs,
                                                           shapes)
-
-        replacement = dict([(ori, rpl) for ori, rpl in izip(in_v, node.inputs)])
-        return [theano.clone(shape[0], replace=replacement)]
+        return shape
 
     def grad(self, inputs, output_grads):
         # OpFromGraph doesn't implement a connection_pattern, so for
@@ -185,3 +179,5 @@ class OpFromGraph(gof.Op):
 # Since OpFromGraph contains a Theano compiled function, we should let
 # DebugMode know about it
 ops_with_inner_function[OpFromGraph] = 'fn'
+
+

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -158,7 +158,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         op_graph = OpFromGraph([x], [y], mode='FAST_RUN')
         self._compile_and_check([x],
                                 [op_graph(x)],
-                                [numpy.ones([3,4])],
+                                [numpy.ones([3,4], dtype=config.floatX)],
                                 OpFromGraph)
 
 if __name__ == '__main__':

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -12,146 +12,145 @@ from theano.compile.builders import OpFromGraph
 
 from theano.tests import unittest_tools
 
-import unittest
 
 class T_OpFromGraph(unittest_tools.InferShapeTester):
 
-    # def test_straightforward(self):
-    #     x, y, z = T.matrices('xyz')
-    #     e = x + y * z
-    #     op = OpFromGraph([x, y, z], [e])
-    #     # (1+3*5=array of 16) - (3+1*5=array of 8)
-    #     f = op(x, y, z) - op(y, z, x)
+    def test_straightforward(self):
+        x, y, z = T.matrices('xyz')
+        e = x + y * z
+        op = OpFromGraph([x, y, z], [e])
+        # (1+3*5=array of 16) - (3+1*5=array of 8)
+        f = op(x, y, z) - op(y, z, x)
 
-    #     fn = function([x, y, z], f)
-    #     xv = numpy.ones((2, 2), dtype=config.floatX)
-    #     yv = numpy.ones((2, 2), dtype=config.floatX)*3
-    #     zv = numpy.ones((2, 2), dtype=config.floatX)*5
-    #     # print function, function.__module__
-    #     # print fn.maker.fgraph.toposort()
-    #     fn(xv, yv, zv)
-    #     assert numpy.all(8.0 == fn(xv, yv, zv))
-    #     assert numpy.all(8.0 == fn(xv, yv, zv))
+        fn = function([x, y, z], f)
+        xv = numpy.ones((2, 2), dtype=config.floatX)
+        yv = numpy.ones((2, 2), dtype=config.floatX)*3
+        zv = numpy.ones((2, 2), dtype=config.floatX)*5
+        # print function, function.__module__
+        # print fn.maker.fgraph.toposort()
+        fn(xv, yv, zv)
+        assert numpy.all(8.0 == fn(xv, yv, zv))
+        assert numpy.all(8.0 == fn(xv, yv, zv))
 
-    # def test_size_changes(self):
-    #     x, y, z = T.matrices('xyz')
-    #     e = T.dot(x, y)
-    #     op = OpFromGraph([x, y], [e])
-    #     f = op(x, op(y, z))
-    #     fn = function([x, y, z], f)
-    #     xv = numpy.ones((2, 3), dtype=config.floatX)
-    #     yv = numpy.ones((3, 4), dtype=config.floatX)*3
-    #     zv = numpy.ones((4, 5), dtype=config.floatX)*5
-    #     res = fn(xv, yv, zv)
-    #     assert res.shape == (2, 5)
-    #     assert numpy.all(180.0 == res)
-    #     res = fn(xv, yv, zv)
-    #     assert res.shape == (2, 5)
-    #     assert numpy.all(180.0 == res)
+    def test_size_changes(self):
+        x, y, z = T.matrices('xyz')
+        e = T.dot(x, y)
+        op = OpFromGraph([x, y], [e])
+        f = op(x, op(y, z))
+        fn = function([x, y, z], f)
+        xv = numpy.ones((2, 3), dtype=config.floatX)
+        yv = numpy.ones((3, 4), dtype=config.floatX)*3
+        zv = numpy.ones((4, 5), dtype=config.floatX)*5
+        res = fn(xv, yv, zv)
+        assert res.shape == (2, 5)
+        assert numpy.all(180.0 == res)
+        res = fn(xv, yv, zv)
+        assert res.shape == (2, 5)
+        assert numpy.all(180.0 == res)
 
-    # def test_grad(self):
-    #     x, y, z = T.matrices('xyz')
-    #     e = x + y * z
-    #     op = OpFromGraph([x, y, z], [e])
-    #     f = op(x, y, z)
-    #     f = f - T.grad(T.sum(f), y)
-    #     fn = function([x, y, z], f)
-    #     xv = numpy.ones((2, 2), dtype=config.floatX)
-    #     yv = numpy.ones((2, 2), dtype=config.floatX)*3
-    #     zv = numpy.ones((2, 2), dtype=config.floatX)*5
-    #     assert numpy.all(11.0 == fn(xv, yv, zv))
+    def test_grad(self):
+        x, y, z = T.matrices('xyz')
+        e = x + y * z
+        op = OpFromGraph([x, y, z], [e])
+        f = op(x, y, z)
+        f = f - T.grad(T.sum(f), y)
+        fn = function([x, y, z], f)
+        xv = numpy.ones((2, 2), dtype=config.floatX)
+        yv = numpy.ones((2, 2), dtype=config.floatX)*3
+        zv = numpy.ones((2, 2), dtype=config.floatX)*5
+        assert numpy.all(11.0 == fn(xv, yv, zv))
 
-    # def test_grad_grad(self):
-    #     x, y, z = T.matrices('xyz')
-    #     e = x + y * z
-    #     op = OpFromGraph([x, y, z], [e])
-    #     f = op(x, y, z)
-    #     f = f - T.grad(T.sum(f), y)
-    #     f = f - T.grad(T.sum(f), y)
-    #     fn = function([x, y, z], f)
-    #     xv = numpy.ones((2, 2), dtype=config.floatX)
-    #     yv = numpy.ones((2, 2), dtype=config.floatX)*3
-    #     zv = numpy.ones((2, 2), dtype=config.floatX)*5
-    #     assert numpy.allclose(6.0, fn(xv, yv, zv))
+    def test_grad_grad(self):
+        x, y, z = T.matrices('xyz')
+        e = x + y * z
+        op = OpFromGraph([x, y, z], [e])
+        f = op(x, y, z)
+        f = f - T.grad(T.sum(f), y)
+        f = f - T.grad(T.sum(f), y)
+        fn = function([x, y, z], f)
+        xv = numpy.ones((2, 2), dtype=config.floatX)
+        yv = numpy.ones((2, 2), dtype=config.floatX)*3
+        zv = numpy.ones((2, 2), dtype=config.floatX)*5
+        assert numpy.allclose(6.0, fn(xv, yv, zv))
 
-    # def test_shared(self):
-    #     x, y, z = T.matrices('xyz')
-    #     s = shared(numpy.random.rand(2, 2).astype(config.floatX))
-    #     e = x + y * z + s
-    #     op = OpFromGraph([x, y, z], [e])
-    #     # (1+3*5=array of 16) - (3+1*5=array of 8)
-    #     f = op(x, y, z) - op(y, z, x)
+    def test_shared(self):
+        x, y, z = T.matrices('xyz')
+        s = shared(numpy.random.rand(2, 2).astype(config.floatX))
+        e = x + y * z + s
+        op = OpFromGraph([x, y, z], [e])
+        # (1+3*5=array of 16) - (3+1*5=array of 8)
+        f = op(x, y, z) - op(y, z, x)
 
-    #     fn = function([x, y, z], f)
-    #     xv = numpy.ones((2, 2), dtype=config.floatX)
-    #     yv = numpy.ones((2, 2), dtype=config.floatX)*3
-    #     zv = numpy.ones((2, 2), dtype=config.floatX)*5
-    #     # print function, function.__module__
-    #     # print fn.maker.fgraph.toposort()
-    #     assert numpy.allclose(8.0, fn(xv, yv, zv))
-    #     assert numpy.allclose(8.0, fn(xv, yv, zv))
+        fn = function([x, y, z], f)
+        xv = numpy.ones((2, 2), dtype=config.floatX)
+        yv = numpy.ones((2, 2), dtype=config.floatX)*3
+        zv = numpy.ones((2, 2), dtype=config.floatX)*5
+        # print function, function.__module__
+        # print fn.maker.fgraph.toposort()
+        assert numpy.allclose(8.0, fn(xv, yv, zv))
+        assert numpy.allclose(8.0, fn(xv, yv, zv))
 
-    # def test_shared_grad(self):
-    #     x, y, z = T.matrices('xyz')
-    #     s = shared(numpy.random.rand(2, 2).astype(config.floatX))
-    #     e = x + y * z + s
-    #     op = OpFromGraph([x, y, z], [e])
-    #     f = op(x, y, z)
-    #     f = f - T.grad(T.sum(f), y)
-    #     fn = function([x, y, z], f)
-    #     xv = numpy.ones((2, 2), dtype=config.floatX)
-    #     yv = numpy.ones((2, 2), dtype=config.floatX) * 3
-    #     zv = numpy.ones((2, 2), dtype=config.floatX) * 5
-    #     assert numpy.allclose(11.0 + s.get_value(), fn(xv, yv, zv))
+    def test_shared_grad(self):
+        x, y, z = T.matrices('xyz')
+        s = shared(numpy.random.rand(2, 2).astype(config.floatX))
+        e = x + y * z + s
+        op = OpFromGraph([x, y, z], [e])
+        f = op(x, y, z)
+        f = f - T.grad(T.sum(f), y)
+        fn = function([x, y, z], f)
+        xv = numpy.ones((2, 2), dtype=config.floatX)
+        yv = numpy.ones((2, 2), dtype=config.floatX) * 3
+        zv = numpy.ones((2, 2), dtype=config.floatX) * 5
+        assert numpy.allclose(11.0 + s.get_value(), fn(xv, yv, zv))
 
-    #     # grad again the shared variable
-    #     f = op(x, y, z)
-    #     f = f - T.grad(T.sum(f), s)
-    #     fn = function([x, y, z], f)
-    #     assert numpy.allclose(15.0 + s.get_value(),
-    #                           fn(xv, yv, zv))
+        # grad again the shared variable
+        f = op(x, y, z)
+        f = f - T.grad(T.sum(f), s)
+        fn = function([x, y, z], f)
+        assert numpy.allclose(15.0 + s.get_value(),
+                              fn(xv, yv, zv))
     
-    # def test_connection_pattern(self):
-    #     # Basic case 
-    #     x, y, z = T.matrices('xyz')
-    #     out1 = x * y
-    #     out2 = y * z
+    def test_connection_pattern(self):
+        # Basic case 
+        x, y, z = T.matrices('xyz')
+        out1 = x * y
+        out2 = y * z
 
-    #     op1 = OpFromGraph([x ,y, z], [out1, out2])
-    #     results = op1.connection_pattern(None)
-    #     expect_result = [[True, False],
-    #                      [True, True],
-    #                      [False, True]]
-    #     assert results == expect_result
+        op1 = OpFromGraph([x ,y, z], [out1, out2])
+        results = op1.connection_pattern(None)
+        expect_result = [[True, False],
+                         [True, True],
+                         [False, True]]
+        assert results == expect_result
 
-    #     # Graph with ops that don't have a 'full' connection pattern
-    #     # and with ops that have multiple outputs 
-    #     m, n, p, q = T.matrices('mnpq')
-    #     o1, o2 = op1(m, n, p)
-    #     out1, out2 = op1(o1, q, o2)
-    #     op2 = OpFromGraph([m, n, p, q], [out1, out2])
+        # Graph with ops that don't have a 'full' connection pattern
+        # and with ops that have multiple outputs 
+        m, n, p, q = T.matrices('mnpq')
+        o1, o2 = op1(m, n, p)
+        out1, out2 = op1(o1, q, o2)
+        op2 = OpFromGraph([m, n, p, q], [out1, out2])
 
-    #     results = op2.connection_pattern(None)
-    #     expect_result = [[True, False],
-    #                      [True, True],
-    #                      [False, True],
-    #                      [True, True]]
-    #     assert results == expect_result
+        results = op2.connection_pattern(None)
+        expect_result = [[True, False],
+                         [True, True],
+                         [False, True],
+                         [True, True]]
+        assert results == expect_result
 
-    #     # Inner graph where some computation doesn't rely on explicit inputs
-    #     srng = RandomStreams(seed=234)
-    #     rv_u = srng.uniform((2,2))
-    #     x, y = T.matrices('xy')
-    #     out1 = x + rv_u
-    #     out2 = y + 3
-    #     out3 = 3 + rv_u
-    #     op3 = OpFromGraph([x, y], [out1, out2, out3])
+        # Inner graph where some computation doesn't rely on explicit inputs
+        srng = RandomStreams(seed=234)
+        rv_u = srng.uniform((2,2))
+        x, y = T.matrices('xy')
+        out1 = x + rv_u
+        out2 = y + 3
+        out3 = 3 + rv_u
+        op3 = OpFromGraph([x, y], [out1, out2, out3])
 
-    #     results = op3.connection_pattern(None)
-    #     expect_result = [[True, False, False],
-    #                      [False, True, False],
-    #                      [True, False, True]]
-    #     assert results == expect_result
+        results = op3.connection_pattern(None)
+        expect_result = [[True, False, False],
+                         [False, True, False],
+                         [True, False, True]]
+        assert results == expect_result
 
     def test_infer_shape(self):
         x = T.matrix('x')
@@ -164,9 +163,6 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         p = T.matrix('p')
         self._compile_and_check([q,p],
                                 [op_graph(q,p)[0],op_graph(q,p)[1]],
-                                [numpy.ones([3,4], dtype=config.floatX)],
+                                [numpy.ones([3,4], dtype=config.floatX),
+                                 numpy.ones([3,4], dtype=config.floatX)],
                                 OpFromGraph)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -12,6 +12,7 @@ from theano.compile.builders import OpFromGraph
 
 from theano.tests import unittest_tools
 
+import unittest
 
 class T_OpFromGraph(unittest_tools.InferShapeTester):
 
@@ -155,8 +156,15 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
     def test_infer_shape(self):
         x = T.matrix('x')
         y = x+x
-        op_graph = OpFromGraph([x], [y])
-        self._compile_and_check([x],
-                                [op_graph(x)],
+        z = x*x
+        op_graph = OpFromGraph([x], [y,z])
+
+        q = T.matrix('q')
+        self._compile_and_check([q],
+                                [op_graph(q)[0],op_graph(q)[1]],
                                 [numpy.ones([3,4], dtype=config.floatX)],
                                 OpFromGraph)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -11,8 +11,10 @@ from theano.tensor.shared_randomstreams import RandomStreams
 
 from theano.compile.builders import OpFromGraph
 
+from theano.tests import unittest_tools
 
-class T_OpFromGraph(unittest.TestCase):
+
+class T_OpFromGraph(unittest_tools.InferShapeTester):
 
     def test_straightforward(self):
         x, y, z = T.matrices('xyz')
@@ -155,9 +157,10 @@ class T_OpFromGraph(unittest.TestCase):
         x = T.matrix('x')
         y = x+x
         op_graph = OpFromGraph([x], [y], mode='FAST_RUN')
-        shapes = op_graph.infer_shape(None, [(5, 5)])
-        assert shapes[0] == (5, 5)
-
+        self._compile_and_check([x],
+                                [op_graph(x)],
+                                [numpy.ones([3,4])],
+                                OpFromGraph)
 
 if __name__ == '__main__':
     unittest.main()

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -18,7 +18,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
     def test_straightforward(self):
         x, y, z = T.matrices('xyz')
         e = x + y * z
-        op = OpFromGraph([x, y, z], [e], mode='FAST_RUN')
+        op = OpFromGraph([x, y, z], [e])
         # (1+3*5=array of 16) - (3+1*5=array of 8)
         f = op(x, y, z) - op(y, z, x)
 
@@ -35,7 +35,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
     def test_size_changes(self):
         x, y, z = T.matrices('xyz')
         e = T.dot(x, y)
-        op = OpFromGraph([x, y], [e], mode='FAST_RUN')
+        op = OpFromGraph([x, y], [e])
         f = op(x, op(y, z))
         fn = function([x, y, z], f)
         xv = numpy.ones((2, 3), dtype=config.floatX)
@@ -51,7 +51,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
     def test_grad(self):
         x, y, z = T.matrices('xyz')
         e = x + y * z
-        op = OpFromGraph([x, y, z], [e], mode='FAST_RUN')
+        op = OpFromGraph([x, y, z], [e])
         f = op(x, y, z)
         f = f - T.grad(T.sum(f), y)
         fn = function([x, y, z], f)
@@ -63,7 +63,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
     def test_grad_grad(self):
         x, y, z = T.matrices('xyz')
         e = x + y * z
-        op = OpFromGraph([x, y, z], [e], mode='FAST_RUN')
+        op = OpFromGraph([x, y, z], [e])
         f = op(x, y, z)
         f = f - T.grad(T.sum(f), y)
         f = f - T.grad(T.sum(f), y)
@@ -77,7 +77,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         x, y, z = T.matrices('xyz')
         s = shared(numpy.random.rand(2, 2).astype(config.floatX))
         e = x + y * z + s
-        op = OpFromGraph([x, y, z], [e], mode='FAST_RUN')
+        op = OpFromGraph([x, y, z], [e])
         # (1+3*5=array of 16) - (3+1*5=array of 8)
         f = op(x, y, z) - op(y, z, x)
 
@@ -94,7 +94,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         x, y, z = T.matrices('xyz')
         s = shared(numpy.random.rand(2, 2).astype(config.floatX))
         e = x + y * z + s
-        op = OpFromGraph([x, y, z], [e], mode='FAST_RUN')
+        op = OpFromGraph([x, y, z], [e])
         f = op(x, y, z)
         f = f - T.grad(T.sum(f), y)
         fn = function([x, y, z], f)
@@ -116,7 +116,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         out1 = x * y
         out2 = y * z
 
-        op1 = OpFromGraph([x ,y, z], [out1, out2], mode='FAST_RUN')
+        op1 = OpFromGraph([x ,y, z], [out1, out2])
         results = op1.connection_pattern(None)
         expect_result = [[True, False],
                          [True, True],
@@ -128,7 +128,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         m, n, p, q = T.matrices('mnpq')
         o1, o2 = op1(m, n, p)
         out1, out2 = op1(o1, q, o2)
-        op2 = OpFromGraph([m, n, p, q], [out1, out2], mode='FAST_RUN')
+        op2 = OpFromGraph([m, n, p, q], [out1, out2])
 
         results = op2.connection_pattern(None)
         expect_result = [[True, False],
@@ -144,7 +144,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         out1 = x + rv_u
         out2 = y + 3
         out3 = 3 + rv_u
-        op3 = OpFromGraph([x, y], [out1, out2, out3], mode='FAST_RUN')
+        op3 = OpFromGraph([x, y], [out1, out2, out3])
 
         results = op3.connection_pattern(None)
         expect_result = [[True, False, False],
@@ -155,7 +155,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
     def test_infer_shape(self):
         x = T.matrix('x')
         y = x+x
-        op_graph = OpFromGraph([x], [y], mode='FAST_RUN')
+        op_graph = OpFromGraph([x], [y])
         self._compile_and_check([x],
                                 [op_graph(x)],
                                 [numpy.ones([3,4], dtype=config.floatX)],

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -1,5 +1,4 @@
 import numpy
-import unittest
 
 from theano import config, shared
 

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -151,6 +151,13 @@ class T_OpFromGraph(unittest.TestCase):
                          [True, False, True]]
         assert results == expect_result
 
+    def test_infer_shape(self):
+        x = T.matrix('x')
+        y = x+x
+        op_graph = OpFromGraph([x], [y], mode='FAST_RUN')
+        shapes = op_graph.infer_shape(None, [(5, 5)])
+        assert shapes[0] == (5, 5)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -16,152 +16,154 @@ import unittest
 
 class T_OpFromGraph(unittest_tools.InferShapeTester):
 
-    def test_straightforward(self):
-        x, y, z = T.matrices('xyz')
-        e = x + y * z
-        op = OpFromGraph([x, y, z], [e])
-        # (1+3*5=array of 16) - (3+1*5=array of 8)
-        f = op(x, y, z) - op(y, z, x)
+    # def test_straightforward(self):
+    #     x, y, z = T.matrices('xyz')
+    #     e = x + y * z
+    #     op = OpFromGraph([x, y, z], [e])
+    #     # (1+3*5=array of 16) - (3+1*5=array of 8)
+    #     f = op(x, y, z) - op(y, z, x)
 
-        fn = function([x, y, z], f)
-        xv = numpy.ones((2, 2), dtype=config.floatX)
-        yv = numpy.ones((2, 2), dtype=config.floatX)*3
-        zv = numpy.ones((2, 2), dtype=config.floatX)*5
-        # print function, function.__module__
-        # print fn.maker.fgraph.toposort()
-        fn(xv, yv, zv)
-        assert numpy.all(8.0 == fn(xv, yv, zv))
-        assert numpy.all(8.0 == fn(xv, yv, zv))
+    #     fn = function([x, y, z], f)
+    #     xv = numpy.ones((2, 2), dtype=config.floatX)
+    #     yv = numpy.ones((2, 2), dtype=config.floatX)*3
+    #     zv = numpy.ones((2, 2), dtype=config.floatX)*5
+    #     # print function, function.__module__
+    #     # print fn.maker.fgraph.toposort()
+    #     fn(xv, yv, zv)
+    #     assert numpy.all(8.0 == fn(xv, yv, zv))
+    #     assert numpy.all(8.0 == fn(xv, yv, zv))
 
-    def test_size_changes(self):
-        x, y, z = T.matrices('xyz')
-        e = T.dot(x, y)
-        op = OpFromGraph([x, y], [e])
-        f = op(x, op(y, z))
-        fn = function([x, y, z], f)
-        xv = numpy.ones((2, 3), dtype=config.floatX)
-        yv = numpy.ones((3, 4), dtype=config.floatX)*3
-        zv = numpy.ones((4, 5), dtype=config.floatX)*5
-        res = fn(xv, yv, zv)
-        assert res.shape == (2, 5)
-        assert numpy.all(180.0 == res)
-        res = fn(xv, yv, zv)
-        assert res.shape == (2, 5)
-        assert numpy.all(180.0 == res)
+    # def test_size_changes(self):
+    #     x, y, z = T.matrices('xyz')
+    #     e = T.dot(x, y)
+    #     op = OpFromGraph([x, y], [e])
+    #     f = op(x, op(y, z))
+    #     fn = function([x, y, z], f)
+    #     xv = numpy.ones((2, 3), dtype=config.floatX)
+    #     yv = numpy.ones((3, 4), dtype=config.floatX)*3
+    #     zv = numpy.ones((4, 5), dtype=config.floatX)*5
+    #     res = fn(xv, yv, zv)
+    #     assert res.shape == (2, 5)
+    #     assert numpy.all(180.0 == res)
+    #     res = fn(xv, yv, zv)
+    #     assert res.shape == (2, 5)
+    #     assert numpy.all(180.0 == res)
 
-    def test_grad(self):
-        x, y, z = T.matrices('xyz')
-        e = x + y * z
-        op = OpFromGraph([x, y, z], [e])
-        f = op(x, y, z)
-        f = f - T.grad(T.sum(f), y)
-        fn = function([x, y, z], f)
-        xv = numpy.ones((2, 2), dtype=config.floatX)
-        yv = numpy.ones((2, 2), dtype=config.floatX)*3
-        zv = numpy.ones((2, 2), dtype=config.floatX)*5
-        assert numpy.all(11.0 == fn(xv, yv, zv))
+    # def test_grad(self):
+    #     x, y, z = T.matrices('xyz')
+    #     e = x + y * z
+    #     op = OpFromGraph([x, y, z], [e])
+    #     f = op(x, y, z)
+    #     f = f - T.grad(T.sum(f), y)
+    #     fn = function([x, y, z], f)
+    #     xv = numpy.ones((2, 2), dtype=config.floatX)
+    #     yv = numpy.ones((2, 2), dtype=config.floatX)*3
+    #     zv = numpy.ones((2, 2), dtype=config.floatX)*5
+    #     assert numpy.all(11.0 == fn(xv, yv, zv))
 
-    def test_grad_grad(self):
-        x, y, z = T.matrices('xyz')
-        e = x + y * z
-        op = OpFromGraph([x, y, z], [e])
-        f = op(x, y, z)
-        f = f - T.grad(T.sum(f), y)
-        f = f - T.grad(T.sum(f), y)
-        fn = function([x, y, z], f)
-        xv = numpy.ones((2, 2), dtype=config.floatX)
-        yv = numpy.ones((2, 2), dtype=config.floatX)*3
-        zv = numpy.ones((2, 2), dtype=config.floatX)*5
-        assert numpy.allclose(6.0, fn(xv, yv, zv))
+    # def test_grad_grad(self):
+    #     x, y, z = T.matrices('xyz')
+    #     e = x + y * z
+    #     op = OpFromGraph([x, y, z], [e])
+    #     f = op(x, y, z)
+    #     f = f - T.grad(T.sum(f), y)
+    #     f = f - T.grad(T.sum(f), y)
+    #     fn = function([x, y, z], f)
+    #     xv = numpy.ones((2, 2), dtype=config.floatX)
+    #     yv = numpy.ones((2, 2), dtype=config.floatX)*3
+    #     zv = numpy.ones((2, 2), dtype=config.floatX)*5
+    #     assert numpy.allclose(6.0, fn(xv, yv, zv))
 
-    def test_shared(self):
-        x, y, z = T.matrices('xyz')
-        s = shared(numpy.random.rand(2, 2).astype(config.floatX))
-        e = x + y * z + s
-        op = OpFromGraph([x, y, z], [e])
-        # (1+3*5=array of 16) - (3+1*5=array of 8)
-        f = op(x, y, z) - op(y, z, x)
+    # def test_shared(self):
+    #     x, y, z = T.matrices('xyz')
+    #     s = shared(numpy.random.rand(2, 2).astype(config.floatX))
+    #     e = x + y * z + s
+    #     op = OpFromGraph([x, y, z], [e])
+    #     # (1+3*5=array of 16) - (3+1*5=array of 8)
+    #     f = op(x, y, z) - op(y, z, x)
 
-        fn = function([x, y, z], f)
-        xv = numpy.ones((2, 2), dtype=config.floatX)
-        yv = numpy.ones((2, 2), dtype=config.floatX)*3
-        zv = numpy.ones((2, 2), dtype=config.floatX)*5
-        # print function, function.__module__
-        # print fn.maker.fgraph.toposort()
-        assert numpy.allclose(8.0, fn(xv, yv, zv))
-        assert numpy.allclose(8.0, fn(xv, yv, zv))
+    #     fn = function([x, y, z], f)
+    #     xv = numpy.ones((2, 2), dtype=config.floatX)
+    #     yv = numpy.ones((2, 2), dtype=config.floatX)*3
+    #     zv = numpy.ones((2, 2), dtype=config.floatX)*5
+    #     # print function, function.__module__
+    #     # print fn.maker.fgraph.toposort()
+    #     assert numpy.allclose(8.0, fn(xv, yv, zv))
+    #     assert numpy.allclose(8.0, fn(xv, yv, zv))
 
-    def test_shared_grad(self):
-        x, y, z = T.matrices('xyz')
-        s = shared(numpy.random.rand(2, 2).astype(config.floatX))
-        e = x + y * z + s
-        op = OpFromGraph([x, y, z], [e])
-        f = op(x, y, z)
-        f = f - T.grad(T.sum(f), y)
-        fn = function([x, y, z], f)
-        xv = numpy.ones((2, 2), dtype=config.floatX)
-        yv = numpy.ones((2, 2), dtype=config.floatX) * 3
-        zv = numpy.ones((2, 2), dtype=config.floatX) * 5
-        assert numpy.allclose(11.0 + s.get_value(), fn(xv, yv, zv))
+    # def test_shared_grad(self):
+    #     x, y, z = T.matrices('xyz')
+    #     s = shared(numpy.random.rand(2, 2).astype(config.floatX))
+    #     e = x + y * z + s
+    #     op = OpFromGraph([x, y, z], [e])
+    #     f = op(x, y, z)
+    #     f = f - T.grad(T.sum(f), y)
+    #     fn = function([x, y, z], f)
+    #     xv = numpy.ones((2, 2), dtype=config.floatX)
+    #     yv = numpy.ones((2, 2), dtype=config.floatX) * 3
+    #     zv = numpy.ones((2, 2), dtype=config.floatX) * 5
+    #     assert numpy.allclose(11.0 + s.get_value(), fn(xv, yv, zv))
 
-        # grad again the shared variable
-        f = op(x, y, z)
-        f = f - T.grad(T.sum(f), s)
-        fn = function([x, y, z], f)
-        assert numpy.allclose(15.0 + s.get_value(),
-                              fn(xv, yv, zv))
+    #     # grad again the shared variable
+    #     f = op(x, y, z)
+    #     f = f - T.grad(T.sum(f), s)
+    #     fn = function([x, y, z], f)
+    #     assert numpy.allclose(15.0 + s.get_value(),
+    #                           fn(xv, yv, zv))
     
-    def test_connection_pattern(self):
-        # Basic case 
-        x, y, z = T.matrices('xyz')
-        out1 = x * y
-        out2 = y * z
+    # def test_connection_pattern(self):
+    #     # Basic case 
+    #     x, y, z = T.matrices('xyz')
+    #     out1 = x * y
+    #     out2 = y * z
 
-        op1 = OpFromGraph([x ,y, z], [out1, out2])
-        results = op1.connection_pattern(None)
-        expect_result = [[True, False],
-                         [True, True],
-                         [False, True]]
-        assert results == expect_result
+    #     op1 = OpFromGraph([x ,y, z], [out1, out2])
+    #     results = op1.connection_pattern(None)
+    #     expect_result = [[True, False],
+    #                      [True, True],
+    #                      [False, True]]
+    #     assert results == expect_result
 
-        # Graph with ops that don't have a 'full' connection pattern
-        # and with ops that have multiple outputs 
-        m, n, p, q = T.matrices('mnpq')
-        o1, o2 = op1(m, n, p)
-        out1, out2 = op1(o1, q, o2)
-        op2 = OpFromGraph([m, n, p, q], [out1, out2])
+    #     # Graph with ops that don't have a 'full' connection pattern
+    #     # and with ops that have multiple outputs 
+    #     m, n, p, q = T.matrices('mnpq')
+    #     o1, o2 = op1(m, n, p)
+    #     out1, out2 = op1(o1, q, o2)
+    #     op2 = OpFromGraph([m, n, p, q], [out1, out2])
 
-        results = op2.connection_pattern(None)
-        expect_result = [[True, False],
-                         [True, True],
-                         [False, True],
-                         [True, True]]
-        assert results == expect_result
+    #     results = op2.connection_pattern(None)
+    #     expect_result = [[True, False],
+    #                      [True, True],
+    #                      [False, True],
+    #                      [True, True]]
+    #     assert results == expect_result
 
-        # Inner graph where some computation doesn't rely on explicit inputs
-        srng = RandomStreams(seed=234)
-        rv_u = srng.uniform((2,2))
-        x, y = T.matrices('xy')
-        out1 = x + rv_u
-        out2 = y + 3
-        out3 = 3 + rv_u
-        op3 = OpFromGraph([x, y], [out1, out2, out3])
+    #     # Inner graph where some computation doesn't rely on explicit inputs
+    #     srng = RandomStreams(seed=234)
+    #     rv_u = srng.uniform((2,2))
+    #     x, y = T.matrices('xy')
+    #     out1 = x + rv_u
+    #     out2 = y + 3
+    #     out3 = 3 + rv_u
+    #     op3 = OpFromGraph([x, y], [out1, out2, out3])
 
-        results = op3.connection_pattern(None)
-        expect_result = [[True, False, False],
-                         [False, True, False],
-                         [True, False, True]]
-        assert results == expect_result
+    #     results = op3.connection_pattern(None)
+    #     expect_result = [[True, False, False],
+    #                      [False, True, False],
+    #                      [True, False, True]]
+    #     assert results == expect_result
 
     def test_infer_shape(self):
         x = T.matrix('x')
-        y = x+x
-        z = x*x
-        op_graph = OpFromGraph([x], [y,z])
+        y = T.matrix('y')
+        o1 = x+y
+        o2 = x*y
+        op_graph = OpFromGraph([x,y], [o1,o2])
 
         q = T.matrix('q')
-        self._compile_and_check([q],
-                                [op_graph(q)[0],op_graph(q)[1]],
+        p = T.matrix('p')
+        self._compile_and_check([q,p],
+                                [op_graph(q,p)[0],op_graph(q,p)[1]],
                                 [numpy.ones([3,4], dtype=config.floatX)],
                                 OpFromGraph)
 

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -160,6 +160,3 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
                                 [op_graph(x)],
                                 [numpy.ones([3,4], dtype=config.floatX)],
                                 OpFromGraph)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -162,7 +162,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         q = T.matrix('q')
         p = T.matrix('p')
         self._compile_and_check([q,p],
-                                [op_graph(q,p)[0],op_graph(q,p)[1]],
+                                op_graph(q,p),
                                 [numpy.ones([3,4], dtype=config.floatX),
                                  numpy.ones([3,4], dtype=config.floatX)],
                                 OpFromGraph)


### PR DESCRIPTION
Only a draft.  Simple test pass but have many warning.

```Python
WARNING (theano.tensor.opt): Failed to infer_shape from Op <theano.compile.builders.OpFromGraph object at 0x10c5bb590>.
Input shapes: [(Shape_i{0}.0, Shape_i{1}.0), (Shape_i{0}.0, Shape_i{1}.0), (Shape_i{0}.0, Shape_i{1}.0)]
Exception encountered during infer_shape: <type 'exceptions.TypeError'>
Exception message: ('Bad input argument to theano function with name "/Users/ChienliMa/Code/Theano/theano/tensor/utils.py:87"  at index 0(0-based)', 'Expected an array-like object, but found a Variable: maybe you are trying to call a function on a (possibly shared) variable instead of a numeric array?')
Traceback: Traceback (most recent call last):
  File "/Users/ChienliMa/Code/Theano/theano/tensor/opt.py", line 1079, in on_import
    [self.shape_of[r] for r in node.inputs])
  File "/Users/ChienliMa/Code/Theano/theano/compile/builders.py", line 144, in infer_shape
    all_shapes = theano.tensor.utils.shape_of_variables(fg, in_shapes)
  File "/Users/ChienliMa/Code/Theano/theano/tensor/utils.py", line 97, in shape_of_variables
    numeric_output_dims = compute_shapes(*numeric_input_dims)
  File "/Users/ChienliMa/Code/Theano/theano/compile/function_module.py", line 531, in __call__
    allow_downcast=s.allow_downcast)
  File "/Users/ChienliMa/Code/Theano/theano/tensor/type.py", line 77, in filter
    'Expected an array-like object, but found a Variable: '
TypeError: ('Bad input argument to theano function with name "/Users/ChienliMa/Code/Theano/theano/tensor/utils.py:87"  at index 0(0-based)', 'Expected an array-like object, but found a Variable: maybe you are trying to call a function on a (possibly shared) variable instead of a numeric array?')
```
