### PR TITLE
Fix memory leak of descriptors in cudnn bindings.

### DIFF
--- a/theano/gof/type.py
+++ b/theano/gof/type.py
@@ -630,7 +630,7 @@ if (py_%(name)s == NULL) { %(freefunc)s(%(name)s); }
         return ""
 
     def c_code_cache_version(self):
-        return (2,)
+        return (2, self.ctype, self.freefunc)
 
     def __str__(self):
         return "%s{%s}" % (self.__class__.__name__, self.ctype)

--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -256,7 +256,8 @@ class GpuDnnConvDesc(GpuOp):
             raise TypeError('kern must be 1D shape tensor')
 
         return Apply(self, [img_shape, kern_shape],
-                     [CDataType("cudnnConvolutionDescriptor_t")()])
+                     [CDataType("cudnnConvolutionDescriptor_t",
+                                freefunc="cudnnDestroyConvolutionDescriptor")()])
 
     def c_code(self, node, name, inputs, outputs, sub):
         img_shape, kern_shape = inputs
@@ -773,7 +774,8 @@ class GpuDnnPoolDesc(GpuOp):
             raise RuntimeError("CuDNN pooling with padding requires CuDNN v2")
 
         return Apply(self, [],
-                     [CDataType("cudnnPoolingDescriptor_t")()])
+                     [CDataType("cudnnPoolingDescriptor_t",
+                                freefunc="cudnnDestroyPoolingDescriptor")()])
 
     def c_code(self, node, name, inputs, outputs, sub):
         desc, = outputs

--- a/theano/sandbox/gpuarray/dnn.py
+++ b/theano/sandbox/gpuarray/dnn.py
@@ -294,7 +294,8 @@ class GpuDnnConvDesc(Op):
             raise TypeError('kern must be 1D shape tensor')
 
         return Apply(self, [img_shape, kern_shape],
-                     [CDataType("cudnnConvolutionDescriptor_t")()])
+                     [CDataType("cudnnConvolutionDescriptor_t",
+                                freefunc="cudnnDestroyConvolutionDescriptor")()])
 
     def c_code(self, node, name, inputs, outputs, sub):
         img_shape, kern_shape = inputs
@@ -794,7 +795,8 @@ class GpuDnnPoolDesc(Op):
             raise RuntimeError("CuDNN pooling with padding requires CuDNN v2")
 
         return Apply(self, [],
-                     [CDataType("cudnnPoolingDescriptor_t")()])
+                     [CDataType("cudnnPoolingDescriptor_t",
+                                freefunc="cudnnDestroyPoolingDescriptor")()])
 
     def c_code(self, node, name, inputs, outputs, sub):
         desc, = outputs


### PR DESCRIPTION
This fixes the memory leak observed at https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/lasagne-users/8iXu7NcAxuY/eI72oHkslGcJ and another one involving pooling descriptors.

There seems to be another leak in cuda-convnet, which this does not fix.