### PR TITLE
added the shared variable zero fn.

### DIFF
--- a/theano/compile/sharedvalue.py
+++ b/theano/compile/sharedvalue.py
@@ -113,6 +113,22 @@ class SharedVariable(Variable):
         else:
             self.container.value = copy.deepcopy(new_value)
 
+    def zero(self, borrow=False):
+        """Set the values of a shared variable to 0.
+
+        :param borrow:
+            True to modify the value of a shared variable directly by using
+            its previous value. Potentially this can cause problems
+            regarding to the aliased memory.
+
+        Changes done with this function will be visible to all functions using
+        this SharedVariable.
+        """
+        if borrow:
+            self.container.value = 0 * self.container.value
+        else:
+            self.container.value = 0 * copy.deepcopy(self.container.value)
+
     def clone(self):
         cp = self.__class__(
             name=self.name,

--- a/theano/compile/sharedvalue.py
+++ b/theano/compile/sharedvalue.py
@@ -125,9 +125,9 @@ class SharedVariable(Variable):
         this SharedVariable.
         """
         if borrow:
-            self.container.value = 0 * self.container.value
+            self.container.value[...] = 0
         else:
-            self.container.value = 0 * copy.deepcopy(self.container.value)
+            self.container.value = 0 * self.container.value
 
     def clone(self):
         cp = self.__class__(


### PR DESCRIPTION
I was using this function for a while for myself. It is very similar to what torch.tensor:zero function does:
https://github.com/torch/torch7/blob/master/doc/tensor.md#self-zero

This is just a syntactic sugar. I find this more readable than doing get_value and then set_value to reset a shared variable to zero in my code. 

If that PR gets through, I have a few other functions like that which I can make PR for too.