### PR TITLE
Remove the restriction on zero target dimensions when reshaping a CudaNdarray

### DIFF
--- a/theano/sandbox/cuda/cuda_ndarray.cu
+++ b/theano/sandbox/cuda/cuda_ndarray.cu
@@ -871,8 +871,8 @@ PyObject * CudaNdarray_Reshape(CudaNdarray * self, PyObject * shape)
                 free(rval_dims);
                 return NULL;
             }
-            if(rval_dims[i]<=0){
-                PyErr_Format(PyExc_ValueError, "Reshape has invalid dimension %i (must be >0)",rval_dims[i]);
+            if(rval_dims[i]<0){
+                PyErr_Format(PyExc_ValueError, "Reshape has invalid dimension %i (must be >=0)",rval_dims[i]);
                 free(rval_dims);
                 return NULL;
             }

--- a/theano/sandbox/cuda/tests/test_basic_ops.py
+++ b/theano/sandbox/cuda/tests/test_basic_ops.py
@@ -374,6 +374,11 @@ def test_reshape():
     except ValueError:
         pass
 
+    # Test zero dimensions are allowed
+    x = T.vector('x')
+    f_reshp = theano.function([x], x.reshape((0,100)), mode=mode_with_gpu)
+    assert f_reshp(numpy.ndarray((0,), dtype='float32')).shape == (0,100)
+
 
 def test_alloc_empty():
     # Test that we allocated correctly


### PR DESCRIPTION
Fixes #3175 for me.

I couldn't see any obvious problems with removing this restriction (which isn't applied by the CPU backend). But perhaps there was some cuda-specific reason for the stricter restriction here?

There was a commit (https://github.com/Theano/Theano/commit/23fa09f02d731ca0a5437772cf6118ca16c542c9) made to permit reshaping of zero-size arrays before, which looks like it fixed this issue but was partially undone again at some point in a merge.