### PR TITLE
Allow slicing of tensor variables to return symbolic shape refs

### DIFF
--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -7729,6 +7729,13 @@ def test_allocempty():
     assert out.shape == (2, 3)
     assert out.dtype == 'float32'
 
+
+def test_symbolic_slice():
+    x = theano.tensor.tensor4('x')
+    a, b = x.shape[:2]
+    output = a.eval({x: numpy.zeros((5, 4, 3, 2), dtype=theano.config.floatX)})
+    assert output == numpy.array(5)
+
 """
 
 if __name__ == '__main__':


### PR DESCRIPTION
This addresses https://groups.google.com/forum/#!topic/theano-users/AUuHNstlVYY.  It allows for this kind of stuff to work:

```Python
>>> import theano
>>> import numpy as np
>>> import theano.tensor as T
>>> x = T.tensor4('x')
>>> a, b = x.shape[:2]
>>> a.eval({x: np.zeros((5, 4, 3, 2), dtype=theano.config.floatX)})
array(5)
>>> a = x.shape[3:10]
>>> a.eval({x: np.zeros((5, 4, 3, 2), dtype=theano.config.floatX)})
array([2])
```