### PR TITLE
ENH: allow numpy.*(theano_var) to build a graph

### DIFF
--- a/theano/tensor/tests/test_var.py
+++ b/theano/tensor/tests/test_var.py
@@ -9,7 +9,13 @@ def test_numpy_method():
     # This type of code is used frequently by PyMC3 users
     x = tt.dmatrix('x')
     data = np.random.rand(5, 5)
-    for fct in [np.exp]:
+    x.tag.test_value = data
+    for fct in [np.arccos, np.arccosh, np.arcsin, np.arcsinh,
+                np.arctan, np.arctanh, np.ceil, np.cos, np.cosh, np.deg2rad,
+                np.exp, np.exp2, np.expm1, np.floor, np.log,
+                np.log10, np.log1p, np.log2, np.rad2deg,
+                np.sin, np.sinh, np.sqrt, np.tan, np.tanh, np.trunc]:
         y = fct(x)
         f = theano.function([x], y)
-        utt.assert_allclose(f(data), fct(data))
+        utt.assert_allclose(np.nan_to_num(f(data)),
+                            np.nan_to_num(fct(data)))

--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -355,8 +355,80 @@ class _tensor_py_operators:
         return theano.tensor.basic.diagonal(self, offset, axis1, axis2)
 
     # Elemwise
+    def arccos(self):
+        return theano.tensor.arccos(self)
+
+    def arccosh(self):
+        return theano.tensor.arccosh(self)
+
+    def arcsin(self):
+        return theano.tensor.arcsin(self)
+
+    def arcsinh(self):
+        return theano.tensor.arcsinh(self)
+
+    def arctan(self):
+        return theano.tensor.arctan(self)
+
+    def arctanh(self):
+        return theano.tensor.arctanh(self)
+
+    def ceil(self):
+        return theano.tensor.ceil(self)
+
+    def cos(self):
+        return theano.tensor.cos(self)
+
+    def cosh(self):
+        return theano.tensor.cosh(self)
+
+    def deg2rad(self):
+        return theano.tensor.deg2rad(self)
+
     def exp(self):
         return theano.tensor.exp(self)
+
+    def exp2(self):
+        return theano.tensor.exp2(self)
+
+    def expm1(self):
+        return theano.tensor.expm1(self)
+
+    def floor(self):
+        return theano.tensor.floor(self)
+
+    def log(self):
+        return theano.tensor.log(self)
+
+    def log10(self):
+        return theano.tensor.log10(self)
+
+    def log1p(self):
+        return theano.tensor.log1p(self)
+
+    def log2(self):
+        return theano.tensor.log2(self)
+
+    def rad2deg(self):
+        return theano.tensor.rad2deg(self)
+
+    def sin(self):
+        return theano.tensor.sin(self)
+
+    def sinh(self):
+        return theano.tensor.sinh(self)
+
+    def sqrt(self):
+        return theano.tensor.sqrt(self)
+
+    def tan(self):
+        return theano.tensor.tan(self)
+
+    def tanh(self):
+        return theano.tensor.tanh(self)
+
+    def trunc(self):
+        return theano.tensor.trunc(self)
 
     # CASTING
     def astype(self, dtype):


### PR DESCRIPTION
This PR follows the pattern demonstrated in #3112 to allow more numpy functions to build a graph in a manner that is convenient for PyMC3 users. 

This includes everything listed in https://github.com/Theano/Theano/issues/3040#issuecomment-114097347 except for the following: `degrees, fabs, radians, rint`.  I suspect that these will not be missed, since they all have simple alternatives.

I think that this can close issue #3040.