### PR TITLE
Integrate the latest version of CNMEM

### DIFF
--- a/theano/sandbox/cuda/cnmem.cpp
+++ b/theano/sandbox/cuda/cnmem.cpp
@@ -381,6 +381,8 @@ public:
         mStream = stream; 
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
         mIsStreamBlocking = false;
+#elif CUDART_VERSION < 5050
+        mIsStreamBlocking = true;
 #else
         unsigned flags = 0;
         CNMEM_CHECK_CUDA(cudaStreamGetFlags(mStream, &flags));

--- a/theano/sandbox/cuda/cnmem.h
+++ b/theano/sandbox/cuda/cnmem.h
@@ -253,7 +253,7 @@ cnmemStatus_t CNMEM_API cnmemPrintMemoryState(FILE *file, cudaStream_t stream);
 /**
  * \brief Converts a cnmemStatus_t value to a string.
  */
-const char* CNMEM_API cnmemGetErrorString(cnmemStatus_t status);
+const char CNMEM_API * cnmemGetErrorString(cnmemStatus_t status);
 
 /* ********************************************************************************************* */
 


### PR DESCRIPTION
This version comes with two fixes.

1/ Fix a warning due to the visibility attribute needed by Theano.
We changed const char* CNMEM_API to const char CNMEM_API* in the
declaration of cnmemGetErrorString to have the attribute between
char and star. It fixes the warning.

2/ Fix a compilation issue with CUDA 5.0 due to the missing
cudaStreamGetFlags function. It is #defined out when the Runtime
is less than 5.5 (5050 version).