### PR TITLE
[ENH] Scan PushOutSeqScan

### DIFF
--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -116,6 +116,10 @@ def change_flags(**kwargs):
                          if v.fullname == k]
                     assert len(l) == 1
                     l[0].__set__(None, old_val[k])
+
+        # Make sure that the name of the decorated function remains the same.
+        inner.__name__ = f.__name__
+
         return inner
     return change_flags_exec
 

--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -478,7 +478,6 @@ class PushOutSeqScan(gof.Optimizer):
                      (x in inner_seqs_set) for x in nd.inputs]) and
                 isinstance(nd.op, theano.tensor.Elemwise)):
 
-                to_remove_set.add(nd)
                 outside_ins = []
                 depends_on_seqs = False
 
@@ -510,6 +509,8 @@ class PushOutSeqScan(gof.Optimizer):
                     # to pull sequence-dependant computation out of
                     # scan.
                     continue
+
+                to_remove_set.add(nd)
 
                 # Do not call make_node for test_value
                 nw_outer_node = nd.op(*outside_ins,

--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -472,11 +472,11 @@ class PushOutSeqScan(gof.Optimizer):
 
         for nd in local_fgraph_topo:
             if (nd not in to_remove_set and
-               all([(x in inner_non_seqs_set) or
-               (x.owner in to_remove_set) or
-               isinstance(x, tensor.Constant) or
-               (x in inner_seqs_set) for x in nd.inputs]) and
-               isinstance(nd.op, theano.tensor.Elemwise)):
+                all([(x in inner_non_seqs_set) or
+                     (x.owner in to_remove_set) or
+                     isinstance(x, tensor.Constant) or
+                     (x in inner_seqs_set) for x in nd.inputs]) and
+                isinstance(nd.op, theano.tensor.Elemwise)):
 
                 to_remove_set.add(nd)
                 outside_ins = []

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -2696,6 +2696,7 @@ class T_Scan(unittest.TestCase):
         utt.assert_allclose(expected_output, scan_output)
         utt.assert_allclose(expected_output, jacobian_outputs)
 
+    @theano.configparser.change_flags(on_opt_error='raise')
     def test_pushout_seqs2(self):
         # This test for a bug with PushOutSeqScan that was reported on the
         # theano-user mailing list where the optimization raised an exception
@@ -2710,12 +2711,7 @@ class T_Scan(unittest.TestCase):
 
         # Compile a theano function where any optimization error will lead to
         # an exception being raised
-        on_opt_error = theano.config.on_opt_error
-        theano.config.on_opt_error = 'raise'
-        try:
-            theano.function([x], outputs, updates=updates)
-        finally:
-            theano.config.on_opt_error = on_opt_error
+        theano.function([x], outputs, updates=updates)
 
     def test_sequence_dict(self):
         # Test that we can specify sequences as a dictionary with


### PR DESCRIPTION
This fixes the optimization issue raised recently raised on the theano-users mailing list :
https://groups.google.com/forum/#!topic/theano-users/_GKQXt-WPOk

This make an opt applied more frequently and remove useless warning shown to the user.