### PR TITLE
fix bug in ConvOp.getOutputShape with border_mode 'valid'

### DIFF
--- a/theano/tensor/nnet/conv.py
+++ b/theano/tensor/nnet/conv.py
@@ -266,7 +266,7 @@ class ConvOp(OpenMPOp):
         # with s=1 for mode=='full' and s=-1 for mode=='valid'.
         # To support symbolic shapes, we express this with integer arithmetics.
         return tuple(None if i is None or k is None
-                     else ((i - k) // d + 1) if mode == 'valid'
+                     else ((i - k + 1) // d) if mode == 'valid'
                      else ((i + k + d - 2) // d)
                      for i, k, d in zip(inshp, kshp, stride))
 

--- a/theano/tensor/nnet/tests/test_conv.py
+++ b/theano/tensor/nnet/tests/test_conv.py
@@ -543,8 +543,15 @@ class TestConv2D(utt.InferShapeTester):
                 [conv.conv2d(adtens, bdtens, aivec_val, bivec_val,
                 border_mode='full')], [adtens_val, bdtens_val], conv.ConvOp)
 
+    def test_get_output_shape(self):
+        output_shape = conv.ConvOp.getOutputShape(
+            inshp=(3, 3), kshp=(1, 1), stride=(2, 2),
+            mode='valid')
+        self.assertEqual(output_shape, (1, 1))
+
 
 if __name__ == '__main__':
+    TestConv2D("test_get_output_shape").debug()
 
     t = TestConv2D('setUp')
     t.setUp()


### PR DESCRIPTION
Commit 0c3ab9a56b1870e6ae0b7accf11bfd9f19b42776 inadvertently introduced a bug into `ConvOp.getOutputShape()`.  This PR fixes it and adds a regression test.