### PR TITLE
Clearer error message for missing pydot/graphviz.

### DIFF
--- a/theano/printing.py
+++ b/theano/printing.py
@@ -697,7 +697,7 @@ def pydotprint(fct, outfile=None,
         topo = fct.toposort()
     if not pydot_imported:
         raise RuntimeError("Failed to import pydot. You must install pydot"
-                           " for `pydotprint` to work.")
+                           " and graphviz for `pydotprint` to work.")
         return
 
     g = pd.Dot()


### PR DESCRIPTION
Very minor, but I was puzzled by the error message since I had `pydot` installed, but not `graphviz`.