### PR TITLE
fix dnn_conv() direction_hint check

### DIFF
--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -1138,7 +1138,8 @@ def dnn_conv(img, kerns, border_mode='valid', subsample=(1, 1),
         algo = workmem
 
     # Ensure the value of direction_hint is supported
-    assert direction_hint in [None, 'bprop weights', 'forward']
+    assert direction_hint in [None, 'bprop weights', 'bprop inputs',
+                              'forward', 'forward!']
 
     fgraph = getattr(img, 'fgraph', None) or getattr(kerns, 'fgraph', None)
     if (border_mode == 'valid' and subsample == (1, 1) and


### PR DESCRIPTION
Commit 05dc20d introduced a check for `direction_hint` in `dnn_conv()` that is too strict. `dnn_conv()` is regularly called with `direction_hint='bprop inputs'`, and the meta-optimizer may also call it with `direction_hint='forward!'` (the latter was supposed to change, but in discussing it we decided to wait until #2665 is finished, which seemed to be within a few weeks at that time).