### PR TITLE
Fix metaoptimizer for cudnn

### DIFF
--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -884,7 +884,8 @@ class LocalMetaOptimizer(LocalOptimizer):
             outputs = opt.transform(node)
             if outputs:
                 try:
-                    fn = theano.function([], outputs, givens=givens)
+                    fn = theano.function([], outputs, givens=givens,
+                                         on_unused_input='ignore')
                     timing = min(self.time_call(fn) for _ in range(3))
                 except Exception as e:
                     if self.verbose:


### PR DESCRIPTION
The convolution meta-optimizer currently fails for cuDNN with: `theano.function was asked to create a function computing outputs given certain inputs, but the provided input variable at index 0 is not part of the computational graph needed to compute the outputs: <CudaNdarrayType(float32, 4D)>.`
That's because it collects required inputs from the original GpuConv Op prior to applying any optimizers, and it may happen that the optimizers render one of the inputs unneeded (I haven't looked into this, but I assume it could be due to the output shape computation or something).
This PR fixes this by allowing the function compiled for timing the replaced Op to accept inputs it doesn't actually need (`on_unused_input='ignore'`).