### PR TITLE
enable dots in section names

### DIFF
--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -144,7 +144,7 @@ def fetch_val_for_key(key):
     # next try to find it in the config file
 
     # config file keys can be of form option, or section.option
-    key_tokens = key.split('.')
+    key_tokens = key.rsplit('.', 1)
     if len(key_tokens) > 2:
         raise KeyError(key)
 


### PR DESCRIPTION
Config parameters in CUDNN v3 have more than one hierarchy level
(i.e. dnn.conv.algo_fwd). At the moment these values cannot by changed by .theanorc.
This patch corrects these issue.