### PR TITLE
AdvancedSubtensor should instantiate a Variable of Scalar type when indexing a 1-dim tensor.

### DIFF
--- a/theano/tensor/subtensor.py
+++ b/theano/tensor/subtensor.py
@@ -2033,10 +2033,14 @@ class AdvancedSubtensor(Op):
 
         index = tuple(map(as_index_variable, index))
         bcast = adv_index_broadcastable_pattern(x, index)
-        return gof.Apply(self,
-                         (x,) + index,
-                         [theano.tensor.tensor(dtype=x.type.dtype,
-                                               broadcastable=bcast)])
+
+        if bcast:
+            variable = theano.tensor.tensor(
+                dtype=x.type.dtype, broadcastable=bcast)
+        else:
+            variable = theano.scalar.Scalar(dtype=x.type.dtype)()
+
+        return gof.Apply(self, (x,) + index, [variable])
 
     def R_op(self, inputs, eval_points):
         if eval_points[0] is None:


### PR DESCRIPTION
Currently when indexing a 1-dimensional tensor AdvancedSubtensor instantiates a Variable of a 0-dim TensorType as output. However, the underlying implementation generates a primitive value (i.e. np.<dtype>) instead of a np.ndarray.

This causes confusing behaviour if this value is used as input to another Op: during runtime the `ValueError: expected an ndarray` exception is raised.

The generation of a primitive is as expected (i.e. numpy has the same behaviour: `type(numpy.ones(5)[0]) == numpy.float64`), but the Op should create a variable of the correct type.