### PR TITLE
Prevent ScanSaveMem from creating 0-steps scans.

### DIFF
--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -1258,6 +1258,14 @@ class ScanSaveMem(gof.Optimizer):
                 real_steps = None
             nw_steps = select_min(select_max(sym_steps, real_steps),
                                   node.inputs[0])
+
+            # Make sure the ScanSaveMem optimization never makes the new
+            # number of steps to be 0 (this could happen, for instance, if
+            # the optimization detects that the outputs of the Scan go through
+            # subtensor nodes that end up taking no elements) because Scan with
+            # 0 iterations are not supported. Make sure the new number of steps
+            # is at least 1.
+            nw_steps = select_max(nw_steps, 1)
         else:
             nw_steps = node.inputs[0]
             global_nsteps = None


### PR DESCRIPTION
After discussion with @lamblin and @abergeron, we agreed on the fix being to prevent ScanSaveMem to reduce below 1 the number of steps a Scan will run. 

The alternative was making Scan support having 0 steps at execution time but that would still involve running the Scan for at least one iteration so that the output shapes would be known : even if the scan is supposed to run 0 steps and return empty outputs, these outputs still need to have the right shape. For recurrent states, the shape can be obtained from the initial states but for non-recurrent states, the inner function has to be executed at least once to know their shapes.