### PR TITLE
Do not read infinite value from output in advanced setsubtensor1

### DIFF
--- a/theano/gof/cutils.py
+++ b/theano/gof/cutils.py
@@ -41,13 +41,16 @@ def compile_cutils_code():
     #endif
     """
 
-    floatadd = ("((%(type)s*)mit->dataptr)[0] = inc_or_set * "
-                "((%(type)s*)mit->dataptr)[0] + ((%(type)s*)it->dataptr)[0];")
+    floatadd = ("((%(type)s*)mit->dataptr)[0] = "
+                "(inc_or_set ? ((%(type)s*)mit->dataptr)[0] : 0)"
+                " + ((%(type)s*)it->dataptr)[0];")
     complexadd = """
-    ((%(type)s*)mit->dataptr)[0].real = inc_or_set *
-       ((%(type)s*)mit->dataptr)[0].real + ((%(type)s*)it->dataptr)[0].real;
-    ((%(type)s*)mit->dataptr)[0].imag = inc_or_set *
-       ((%(type)s*)mit->dataptr)[0].imag + ((%(type)s*)it->dataptr)[0].imag;
+    ((%(type)s*)mit->dataptr)[0].real =
+        (inc_or_set ? ((%(type)s*)mit->dataptr)[0].real : 0)
+        + ((%(type)s*)it->dataptr)[0].real;
+    ((%(type)s*)mit->dataptr)[0].imag =
+        (inc_or_set ? ((%(type)s*)mit->dataptr)[0].imag : 0)
+        + ((%(type)s*)it->dataptr)[0].imag;
     """
 
     fns = ''.join([inplace_map_template % {'type': t, 'typen': t.upper(),


### PR DESCRIPTION
This fixes #3291 after a clean-up of the existing cutils_ext.
Is there a way to force its recompilation?