### PR TITLE
Correct config.lib.cnmem name in documentation

### DIFF
--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -370,7 +370,7 @@ import theano and print the config variable, as in:
     `amdlibm <http://developer.amd.com/cpu/libraries/libm/>`__
     library, which is faster than the standard libm.
 
-.. attribute:: lib.cnmem
+.. attribute:: config.lib.cnmem
 
     Float value: >= 0
 


### PR DESCRIPTION
It's a trivial change, but the CNMeM configuration option was named `lib.cnmem` instead of `config.lib.cnmem` in the documentation. As I hadn't heard about the `lib` prefix before, I thought it should mean `config.cnmem` and thus my first attempt was to use `THEANO_FLAGS=cnmem=.3`, which didn't work. This PR makes it unambiguous.