### PR TITLE
remove 'merge3'

### DIFF
--- a/theano/compile/mode.py
+++ b/theano/compile/mode.py
@@ -226,9 +226,10 @@ optdb.register('add_no_output_from_inplace', AddNoOutputFromInplace(),
 optdb.register('add_destroy_handler', AddDestroyHandler(),
                49.5, 'fast_run', 'inplace')
 
+# 'merge3' seems useless
 # final pass just to make sure
-optdb.register('merge3', gof.MergeOptimizer(),
-               100, 'fast_run', 'merge')
+# optdb.register('merge3', gof.MergeOptimizer(),
+#                100, 'fast_run', 'merge')
 
 
 class Mode(object):


### PR DESCRIPTION
For the user case I have (https://gist.github.com/t13m/64383eec4aead5e1aea8#file-merge-assert , line 148), optimizer `merge3` is useless (all its attempts to merge fail). 
So it is removed here.