### PR TITLE
Use the libgpuarray APIs to manage GPU code compilation, execution, etc.

### DIFF
--- a/theano/sandbox/gpuarray/basic_ops.py
+++ b/theano/sandbox/gpuarray/basic_ops.py
@@ -144,19 +144,21 @@ class GpuKernelBase(object):
     def _generate_kernel_vars(self, k):
         return """static GpuKernel %(kname)s;""" % dict(kname=k.objvar)
 
-    def c_support_code_apply(self, node, name):
-        ceil_intdiv = """
+    def c_support_code(self):
+        return """
         template <typename T>
         static T ceil_intdiv(T a, T b)
         {
             return (a/b) + ((a % b) ? 1: 0);
         }
         """
+
+    def c_support_code_apply(self, node, name):
         kernels = self.gpu_kernels(node, name)
         bins = '\n'.join(self._generate_kernel_bin(k) for k in kernels)
         codes = '\n'.join(self._generate_kernel_code(k) for k in kernels)
         vars = '\n'.join(self._generate_kernel_vars(k) for k in kernels)
-        return '\n'.join([ceil_intdiv, bins, codes, vars])
+        return '\n'.join([bins, codes, vars])
 
     def _generate_kernel_init(self, k, err):
         if PY3:

--- a/theano/sandbox/gpuarray/basic_ops.py
+++ b/theano/sandbox/gpuarray/basic_ops.py
@@ -145,11 +145,18 @@ class GpuKernelBase(object):
         return """static GpuKernel %(kname)s;""" % dict(kname=k.objvar)
 
     def c_support_code_apply(self, node, name):
+        ceil_intdiv = """
+        template <typename T>
+        static T ceil_intdiv(T a, T b)
+        {
+            return (a/b) + ((a % b) ? 1: 0);
+        }
+        """
         kernels = self.gpu_kernels(node, name)
         bins = '\n'.join(self._generate_kernel_bin(k) for k in kernels)
         codes = '\n'.join(self._generate_kernel_code(k) for k in kernels)
         vars = '\n'.join(self._generate_kernel_vars(k) for k in kernels)
-        return '\n'.join([bins, codes, vars])
+        return '\n'.join([ceil_intdiv, bins, codes, vars])
 
     def _generate_kernel_init(self, k, err):
         if PY3:

--- a/theano/sandbox/gpuarray/conv.cu
+++ b/theano/sandbox/gpuarray/conv.cu
@@ -203,11 +203,8 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
                   int, int, int, int,
                   int, int);
 
-#define CONV_PATCH_SPECIAL(kern_wid) \
-            if(threads.y==out_len) f=conv_patch<true,kern_wid,false>;\
-            else f=conv_patch<true,kern_wid,true>;
-
-        CONV_PATCH_SPECIAL(THEANO_KERN_WID);
+        if(threads.y==out_len) f=conv_patch_2;
+        else f=conv_patch_3;
 
          f<<< grid, threads, shared_size>>>
              (cuda_get_ptr(img), cuda_get_ptr(kern), cuda_get_ptr(out),
@@ -267,41 +264,39 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
                   int, int, int, int,
                   int, int);
 
-#define CONV_PATCH_STACK_SPECIAL(kern_wid) \
-        if(preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,true,true,false,true,true>;} \
-        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,true,false,false,true,true>;} \
-        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,false,true,false,true,true>;}\
-        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,false,false,false,true,true>;}\
-        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,true,true,true,true,true>;}\
-        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,true,false,true,true,true>;}\
-        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,false,true,true,true,true>;}\
-        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,false,false,true,true,true>;}\
-        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,true,true,false,false,true>;}\
-        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,true,false,false,false,true>;}\
-        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,false,true,false,false,true>;}\
-        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,false,false,false,false,true>;}\
-        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,true,true,true,false,true>;} \
-        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,true,false,true,false,true>;} \
-        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,false,true,true,false,true>;} \
-        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack<true,false,kern_wid,false,false,true,false,true>;} \
-        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,true,true,false,true,false>;} \
-        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,true,false,false,true,false>;} \
-        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,false,true,false,true,false>;}\
-        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,false,false,false,true,false>;}\
-        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,true,true,true,true,false>;}\
-        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,true,false,true,true,false>;}\
-        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,false,true,true,true,false>;}\
-        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,false,false,true,true,false>;}\
-        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,true,true,false,false,false>;}\
-        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,true,false,false,false,false>;}\
-        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,false,true,false,false,false>;}\
-        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,false,false,false,false,false>;}\
-        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,true,true,true,false,false>;} \
-        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,true,false,true,false,false>;} \
-        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,false,true,true,false,false>;} \
-        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack<true,false,kern_wid,false,false,true,false,false>;}
+        if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_64;}
+        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_65;}
+        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_66;}
+        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_67;}
+        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_68;}
+        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_69;}
+        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_70;}
+        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_71;}
+        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_72;}
+        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_73;}
+        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_74;}
+        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_75;}
+        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_76;}
+        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_77;}
+        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_78;}
+        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_79;}
+        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_80;}
+        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_81;}
+        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_82;}
+        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_83;}
+        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_84;}
+        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_85;}
+        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_86;}
+        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_87;}
+        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_88;}
+        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_89;}
+        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_90;}
+        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_91;}
+        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_92;}
+        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_93;}
+        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_94;}
+        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_95;}
 
-        CONV_PATCH_STACK_SPECIAL(THEANO_KERN_WID);
         f<<< grid, threads, shared_size>>>
             (cuda_get_ptr(img), cuda_get_ptr(kern), cuda_get_ptr(out),
               img_len, img_wid, kern_len, kern_wid, 
@@ -380,11 +375,9 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
                   int, int, int, int,
                   int, int);
 
-#define CONV_ROWS_SPECIAL(kern_wid) \
-        if(!img_contiguous_2d || !kern_contiguous_2d) f = conv_rows<kern_wid, false>;\
-        else f = conv_rows<kern_wid, true>;\
+        if(!img_contiguous_2d || !kern_contiguous_2d) f = conv_rows_0;
+        else f = conv_rows_1;
 
-        CONV_ROWS_SPECIAL(THEANO_KERN_WID);
         f<<< grid, threads, shared_size >>>
             (cuda_get_ptr(img), cuda_get_ptr(kern), cuda_get_ptr(out),
            img_len, img_wid, kern_len, kern_wid, nkern, nstack,
@@ -450,10 +443,10 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
 
         if(!img_contiguous_2d || !kern_contiguous_2d) {
             //fprintf(stderr, "using false version\n");
-            f = conv_rows_stack<THEANO_KERN_WID, false>;
+            f = conv_rows_stack_0;
         } else {
             //fprintf(stderr, "using true version\n");
-            f = conv_rows_stack<THEANO_KERN_WID, true>;
+            f = conv_rows_stack_1;
         }
 
         f<<< grid, threads, shared_size >>>
@@ -535,13 +528,10 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
                   int, int, int, int,
                   int, int);
 
-#define CONV_ROWS_STACK2_SPECIAL(kern_wid) \
-        if((!img_contiguous_2d || !kern_contiguous_2d)&&version==9) f = conv_rows_stack2<kern_wid, false,true>;\
-        else if(version==9) f = conv_rows_stack2<kern_wid, true,true>;\
-        else if(!img_contiguous_2d || !kern_contiguous_2d) f = conv_rows_stack2<kern_wid, false, false>;\
-        else f = conv_rows_stack2<kern_wid, true, false>;
-
-        CONV_ROWS_STACK2_SPECIAL(THEANO_KERN_WID);
+        if((!img_contiguous_2d || !kern_contiguous_2d)&&version==9) f = conv_rows_stack2_1;
+        else if(version==9) f = conv_rows_stack2_3;
+        else if(!img_contiguous_2d || !kern_contiguous_2d) f = conv_rows_stack2_0;
+        else f = conv_rows_stack2_2;
 
         f<<< grid, threads, shared_size >>>
             (cuda_get_ptr(img),
@@ -663,24 +653,23 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
 
             //printf("kern_flipped=%d, ccontig=%d, split=%d, full_kern=%d\n",kern_flipped,ccontig,split,full_kern);
             //We will always be split when we don't load the full kernel
-#define CONV_PATCH_STACK_REDUCE_SPECIAL(kern_wid) \
-                if     (kern_flipped  && ccontig  && !split && full_kern) f=conv_patch_stack_reduce<true,kern_wid,true, false, true>;\
-                else if(kern_flipped  && !ccontig && !split && full_kern) f=conv_patch_stack_reduce<true,kern_wid,false, false, true>;\
-                else if(kern_flipped  && ccontig  && split && full_kern) f=conv_patch_stack_reduce<true,kern_wid,true, true, true>;\
-                else if(kern_flipped  && !ccontig && split && full_kern) f=conv_patch_stack_reduce<true,kern_wid,false, true, true>;\
-                else if(!kern_flipped && ccontig  && !split && full_kern) f=conv_patch_stack_reduce<false,kern_wid,true, false, true>;\
-                else if(!kern_flipped && !ccontig && !split && full_kern) f=conv_patch_stack_reduce<false,kern_wid,false, false, true>;\
-                else if(!kern_flipped && ccontig  && split && full_kern) f=conv_patch_stack_reduce<false,kern_wid,true, true, true>;\
-                else if(!kern_flipped && !ccontig  && split && full_kern) f=conv_patch_stack_reduce<false,kern_wid,false, true, true>;\
-                /*else if(kern_flipped  && ccontig  && !split && !full_kern) f=conv_patch_stack_reduce<true,kern_wid,true, false, false>;*/\
-                /*else if(kern_flipped  && !ccontig && !split && !full_kern) f=conv_patch_stack_reduce<true,kern_wid,false, false, false>;*/\
-                else if(kern_flipped  && ccontig  && split && !full_kern) f=conv_patch_stack_reduce<true,kern_wid,true, true, false>;\
-                else if(kern_flipped  && !ccontig && split && !full_kern) f=conv_patch_stack_reduce<true,kern_wid,false, true, false>;\
-                /*else if(!kern_flipped && ccontig  && !split && !full_kern) f=conv_patch_stack_reduce<false,kern_wid,true, false, false>;*/\
-                /*else if(!kern_flipped && !ccontig && !split && !full_kern) f=conv_patch_stack_reduce<false,kern_wid,false, false, false>;*/\
-                else if(!kern_flipped && ccontig  && split && !full_kern) f=conv_patch_stack_reduce<false,kern_wid,true, true, false>;\
-                else if(!kern_flipped && !ccontig  && split && !full_kern) f=conv_patch_stack_reduce<false,kern_wid,false, true, false>;
-            CONV_PATCH_STACK_REDUCE_SPECIAL(THEANO_KERN_WID);
+
+            /* if(!kern_flipped && !ccontig && !split && !full_kern) f=conv_patch_stack_reduce_0;*/
+            /*else*/ if(!kern_flipped && !ccontig && !split && full_kern) f=conv_patch_stack_reduce_1;
+            else if(!kern_flipped && !ccontig  && split && !full_kern) f=conv_patch_stack_reduce_2;
+            else if(!kern_flipped && !ccontig  && split && full_kern) f=conv_patch_stack_reduce_3;
+            /*else if(!kern_flipped && ccontig  && !split && !full_kern) f=conv_patch_stack_reduce_4;*/
+            else if(!kern_flipped && ccontig  && !split && full_kern) f=conv_patch_stack_reduce_5;
+            else if(!kern_flipped && ccontig  && split && !full_kern) f=conv_patch_stack_reduce_6;
+            else if(!kern_flipped && ccontig  && split && full_kern) f=conv_patch_stack_reduce_7;
+            /*else if(kern_flipped  && !ccontig && !split && !full_kern) f=conv_patch_stack_reduce_8;*/
+            else if(kern_flipped  && !ccontig && !split && full_kern) f=conv_patch_stack_reduce_9;
+            else if(kern_flipped  && !ccontig && split && !full_kern) f=conv_patch_stack_reduce_10;
+            else if(kern_flipped  && !ccontig && split && full_kern) f=conv_patch_stack_reduce_11;
+            /*else if(kern_flipped  && ccontig  && !split && !full_kern) f=conv_patch_stack_reduce_12;*/
+            else if(kern_flipped  && ccontig  && !split && full_kern) f=conv_patch_stack_reduce_13;
+            else if(kern_flipped  && ccontig  && split && !full_kern) f=conv_patch_stack_reduce_14;
+            else if(kern_flipped  && ccontig  && split && full_kern) f=conv_patch_stack_reduce_15;
 
             f<<< grid, threads, shared_size>>>(cuda_get_ptr(img), kern_data_unflipped, cuda_get_ptr(out),
                                                img_len, img_wid, kern_len, kern_wid,
@@ -770,9 +759,9 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
         //std::cerr << "kerns " << nstack << " " << kern_len << "\n";
         //std::cerr << "n_reduce_buf/sizeof(float) " << n_reduce_buf / sizeof(float) << "\n";
         if(block_nstack==nstack)
-          f=conv_valid_row_reduce<false>;
+          f=conv_valid_row_reduce_0;
         else
-          f=conv_valid_row_reduce<true>;
+          f=conv_valid_row_reduce_1;
         f<<<n_blocks, n_threads, n_reduce_buf>>>(
                 nbatch, nkern, PyGpuArray_DIMS(img)[1],
                 img_len, img_wid,
@@ -1105,22 +1094,19 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
                   int, int, int, int,
                   int, int);
 
-#define CONV_FULL_PATCH_STACK_PADDED_SPECIAL(kern_wid) \
-             if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==3 && kern_flipped) f=conv_full_patch_stack_padded<true,kern_wid,true,false,false>;\
-        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==4 && kern_flipped) f=conv_full_patch_stack_padded<true,kern_wid,true,true,false>;\
-        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==5 && kern_flipped) f=conv_full_patch_stack_padded<true,kern_wid,true,false,true>;\
-        else if(version==3 && kern_flipped) f=conv_full_patch_stack_padded<true,kern_wid,false,false,false>;\
-        else if(version==4 && kern_flipped)f=conv_full_patch_stack_padded<true,kern_wid,false,true,false>;\
-        else if(version==5 && kern_flipped)f=conv_full_patch_stack_padded<true,kern_wid,false,false,true>;\
-        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==3) f=conv_full_patch_stack_padded<false,kern_wid,true,false,false>;\
-        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==4) f=conv_full_patch_stack_padded<false,kern_wid,true,true,false>;\
-        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==5) f=conv_full_patch_stack_padded<false,kern_wid,true,false,true>;\
-        else if(version==3) f=conv_full_patch_stack_padded<false,kern_wid,false,false,false>;\
-        else if(version==4) f=conv_full_patch_stack_padded<false,kern_wid,false,true,false>;\
-        else if(version==5) f=conv_full_patch_stack_padded<false,kern_wid,false,false,true>;\
+        if(version==3) f=conv_full_patch_stack_padded_0;
+        else if(version==5) f=conv_full_patch_stack_padded_1;
+        else if(version==4) f=conv_full_patch_stack_padded_2;
+        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==3) f=conv_full_patch_stack_padded_4;
+        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==5) f=conv_full_patch_stack_padded_5;
+        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==4) f=conv_full_patch_stack_padded_6;
+        else if(version==3 && kern_flipped) f=conv_full_patch_stack_padded_8;
+        else if(version==5 && kern_flipped)f=conv_full_patch_stack_padded_9;
+        else if(version==4 && kern_flipped)f=conv_full_patch_stack_padded_10;
+        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==3 && kern_flipped) f=conv_full_patch_stack_padded_12;
+        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==5 && kern_flipped) f=conv_full_patch_stack_padded_13;
+        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==4 && kern_flipped) f=conv_full_patch_stack_padded_14;
         else assert(false);
-
-        CONV_FULL_PATCH_STACK_PADDED_SPECIAL(THEANO_KERN_WID);
 
         f<<< grid, threads, shared_size>>>
             (cuda_get_ptr(img), kern_data_unflipped, cuda_get_ptr(out),
@@ -1225,9 +1211,7 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
         //typeof(conv_full_load_everything<0>) f = ;
         void (*f)(const float*, const float*, float*,
                   int, int, int, int, int, int,
-                  int, int, int, int, int, int, int, int) = conv_full_load_everything<0>;
-
-        f = conv_full_load_everything<THEANO_KERN_WID>;
+                  int, int, int, int, int, int, int, int) = conv_full_load_everything;
 
         f<<< grid, threads, shared_size>>>
             (cuda_get_ptr(img),
@@ -1284,10 +1268,10 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
                   int, int, int, int,
                   int, int, int, int);
 
-        if(img_contiguous_2d && kern_contiguous_2d) f=conv_full_patch_stack<true,true>;\
-        else if(img_contiguous_2d && !kern_contiguous_2d) f=conv_full_patch_stack<true,false>;\
-        else if(!img_contiguous_2d && kern_contiguous_2d) f=conv_full_patch_stack<false,true>;\
-        else if(!img_contiguous_2d && !kern_contiguous_2d) f=conv_full_patch_stack<false,false>;
+        if(!img_contiguous_2d && !kern_contiguous_2d) f=conv_full_patch_stack_0;
+        else if(!img_contiguous_2d && kern_contiguous_2d) f=conv_full_patch_stack_1;
+        else if(img_contiguous_2d && !kern_contiguous_2d) f=conv_full_patch_stack_2;
+        else if(img_contiguous_2d && kern_contiguous_2d) f=conv_full_patch_stack_3;
 
         f<<< grid, threads, shared_size>>>(
                 cuda_get_ptr(img),

--- a/theano/sandbox/gpuarray/conv.cu
+++ b/theano/sandbox/gpuarray/conv.cu
@@ -10,12 +10,6 @@ PyObject * PyGpuArray_Conv(PyGpuArrayObject *img, PyGpuArrayObject * kern,
                            const size_t subsample_cols,
                            const int version, const int verbose);
 
-template <typename T>
-static T ceil_intdiv(T a, T b)
-{
-    return (a/b) + ((a % b) ? 1: 0);
-}
-
 /*
  * version: -1, autodetect, >=0 a specific version to use.
  *          If it can't be executed, we revert to the reference implementation
@@ -108,6 +102,7 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
     //TODO: make a parameter the number of division
     //TODO: Should we make them in separate grid block instead?
  
+    const int stack_len = PyGpuArray_DIMS(img)[1];
     const int nstack=PyGpuArray_DIMS(kern)[1];
     const int nbatch=PyGpuArray_DIMS(img)[0];
     const int nkern=PyGpuArray_DIMS(kern)[0];
@@ -126,6 +121,10 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
     const int kern_stride_row=PyGpuArray_STRIDES(kern)[2]/4;
     const int kern_stride_stack= PyGpuArray_STRIDES(kern)[1]/4;
     const int kern_stride_nkern=PyGpuArray_STRIDES(kern)[0]/4;
+    const int out_stride_col = PyGpuArray_STRIDES(out)[3]/4;
+    const int out_stride_row = PyGpuArray_STRIDES(out)[2]/4;
+    const int out_stride_nkern = PyGpuArray_STRIDES(out)[1]/4;
+    const int out_stride_batch = PyGpuArray_STRIDES(out)[0]/4;
 
     const int img_size=img_len*img_wid;
     const int kern_size=kern_len*kern_wid;
@@ -156,16 +155,10 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
     //we don't need to unflip it, but have the new value when we unflip it.
     bool kern_flipped=true;
     bool kern_contiguous_2d_unflipped = kern_contiguous_2d;
-    const float * kern_data_unflipped = cuda_get_ptr(kern);
-    int kern_stride_col_unflipped=kern_stride_col;
-    int kern_stride_row_unflipped=kern_stride_row;
-    if(kern_stride_col_unflipped==-1 && kern_stride_row_unflipped==-kern_wid){
+    if(kern_stride_col==-1 && kern_stride_row==-kern_wid){
       //the last two dimensions are c_contiguous but flipped!
-      kern_stride_col_unflipped=1;
-      kern_stride_row_unflipped=kern_wid;
       kern_flipped=false;
       kern_contiguous_2d_unflipped = true;
-      kern_data_unflipped=&(cuda_get_ptr(kern)[(kern_wid-1)*kern_stride_col + (kern_len-1)*kern_stride_row]);
     }
 
     //if we remove the restriction
@@ -195,43 +188,47 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
         //we pass by ceil_intdiv in case the out_len is not a multiple of nb_split, we want nb_split the number of iteration.
         while (ceil_intdiv(out_len,nb_split)*out_wid>max_threads_dim0)
             nb_split++;
-        dim3 threads(out_wid, ceil_intdiv(out_len,nb_split));
+        size_t threads_per_block[3] = {(size_t)out_wid,
+                               ceil_intdiv((size_t)out_len,(size_t)nb_split),
+                               (size_t)1};
+        size_t n_blocks[3] = {(size_t)nbatch, (size_t)nkern, (size_t)1};
 
-        dim3 grid(nbatch, nkern);
-        int shared_size=(img_size + kern_size)*sizeof(float);
-        void (*f)(const float*, const float*, float*,
-                  int, int, int, int,
-                  int, int);
+        size_t shmem_sz = (img_size + kern_size)*sizeof(float);
 
-        if(threads.y==out_len) f=conv_patch_2;
-        else f=conv_patch_3;
+        GpuKernel *k = NULL;
+        if(threads_per_block[1]==out_len) k=&conv_patch_2_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else k=&conv_patch_3_node_<<<<HASH_PLACEHOLDER>>>>_0;
 
-         f<<< grid, threads, shared_size>>>
-             (cuda_get_ptr(img), cuda_get_ptr(kern), cuda_get_ptr(out),
-              img_len, img_wid, kern_len, kern_wid, nkern, nstack);
+        void *kernel_params[] = {(void *)img->ga.data, (void *)&img->ga.offset,
+                                 (void *)kern->ga.data, (void *)&kern->ga.offset,
+                                 (void *)out->ga.data, (void *)&out->ga.offset,
+                                 (void *)&img_len, (void *)&img_wid,
+                                 (void *)&kern_len, (void *)&kern_wid,
+                                 (void *)&nkern, (void *)&nstack};
+        int err = GpuKernel_call(k, 3, threads_per_block, n_blocks, shmem_sz, kernel_params);
 
-        cudaError_t sts = cudaGetLastError();
-        if (cudaSuccess == sts)
+        if (err == GA_NO_ERROR)
         {
             if (verbose)
               fprintf(stderr,
                       "INFO: used 'conv_patch' version %s nb_split=%d\n",
-                      threads.y==out_len ? "no split": "split", nb_split);
+                      threads_per_block[1]==out_len ? "no split": "split", nb_split);
             work_complete = true;
         }
         else
         {
             if (verbose)
               fprintf(stderr,
-                      "threads.x=%i, threads.y=%i, grid.x=%i, grid.y=%i,"
-                      " shared_size=%i, nb_threads=%i, nb_split=%i\n",
-                      threads.x, threads.y, grid.x, grid.y,
-                      shared_size, threads.x * threads.y, nb_split);
+                      "threads_per_block[0]=%i, threads_per_block[1]=%i,"
+                      " n_blocks[0]=%i, n_blocks[1]=%i,"
+                      " shmem_sz=%i, nb_threads=%i, nb_split=%i\n",
+                      threads_per_block[0], threads_per_block[1], n_blocks[0], n_blocks[1],
+                      shmem_sz, threads_per_block[0] * threads_per_block[1], nb_split);
             if (verbose)
               fprintf(stderr,
                       "INFO: impl 'conv_patch' failed (%s),"
                       " trying next implementation\n",
-                      cudaGetErrorString(sts));
+                      GpuKernel_error(k, err));
         }
     }
 
@@ -250,75 +247,77 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
         if((version==3||version==12) && out_len>1)nb_split++;//to force the use of split=true when testing.
         //we pass by ceil_intdiv in case the out_len is not a multiple of nb_split, we want nb_split the number of iteration.
         while (ceil_intdiv(out_len,nb_split)*out_wid>max_threads_dim0) nb_split++;
-        dim3 threads(out_wid, ceil_intdiv(out_len,nb_split));
+        size_t threads_per_block[3] = {(size_t)out_wid,
+                               (size_t)ceil_intdiv(out_len,nb_split),
+                               (size_t)1};
 
         bool preload_full_kernel = (img_size_byte + kern_size_byte) <shared_avail;
         if(version==11 || version==12) preload_full_kernel=false;
-        dim3 grid(nbatch,nkern);
-        int shared_size=(img_size + (preload_full_kernel?kern_size:kern_wid))*sizeof(float);
+        size_t n_blocks[3] = {(size_t)nbatch, (size_t)nkern, (size_t)1};
+        size_t shmem_sz = (img_size + (preload_full_kernel?kern_size:kern_wid))*sizeof(float);
 
-        void (*f)(const float*, const float*, float*,
-                  int, int, int, int,
-                  int, int, int, int,
-                  int, int, int, int,
-                  int, int, int, int,
-                  int, int);
+        GpuKernel *k = NULL;
+        if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ k=&conv_patch_stack_64_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ k=&conv_patch_stack_65_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ k=&conv_patch_stack_66_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ k=&conv_patch_stack_67_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ k=&conv_patch_stack_68_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ k=&conv_patch_stack_69_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ k=&conv_patch_stack_70_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ k=&conv_patch_stack_71_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ k=&conv_patch_stack_72_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ k=&conv_patch_stack_73_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ k=&conv_patch_stack_74_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ k=&conv_patch_stack_75_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ k=&conv_patch_stack_76_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ k=&conv_patch_stack_77_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ k=&conv_patch_stack_78_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ k=&conv_patch_stack_79_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ k=&conv_patch_stack_80_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ k=&conv_patch_stack_81_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ k=&conv_patch_stack_82_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ k=&conv_patch_stack_83_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ k=&conv_patch_stack_84_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ k=&conv_patch_stack_85_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ k=&conv_patch_stack_86_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ k=&conv_patch_stack_87_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ k=&conv_patch_stack_88_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && subsample){ k=&conv_patch_stack_89_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ k=&conv_patch_stack_90_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && subsample){ k=&conv_patch_stack_91_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ k=&conv_patch_stack_92_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && subsample){ k=&conv_patch_stack_93_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ k=&conv_patch_stack_94_node_<<<<HASH_PLACEHOLDER>>>>_0;}
+        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && subsample){ k=&conv_patch_stack_95_node_<<<<HASH_PLACEHOLDER>>>>_0;}
 
-        if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_64;}
-        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_65;}
-        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_66;}
-        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_67;}
-        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_68;}
-        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_69;}
-        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_70;}
-        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_71;}
-        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_72;}
-        else if(!preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_73;}
-        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_74;}
-        else if(preload_full_kernel && nb_split==1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_75;}
-        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_76;}
-        else if(!preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_77;}
-        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_78;}
-        else if(preload_full_kernel && nb_split!=1 && !img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_79;}
-        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_80;}
-        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_81;}
-        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_82;}
-        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_83;}
-        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_84;}
-        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_85;}
-        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && !subsample){ f=conv_patch_stack_86;}
-        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && !kern_contiguous_2d && subsample){ f=conv_patch_stack_87;}
-        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_88;}
-        else if(!preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_89;}
-        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_90;}
-        else if(preload_full_kernel && nb_split==1 && img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_91;}
-        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_92;}
-        else if(!preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_93;}
-        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && !subsample){ f=conv_patch_stack_94;}
-        else if(preload_full_kernel && nb_split!=1 && img_contiguous_2d && kern_contiguous_2d && subsample){ f=conv_patch_stack_95;}
+        void *kernel_params[] = {(void *)img->ga.data, (void *)&img->ga.offset,
+                                 (void *)kern->ga.data, (void *)&kern->ga.offset,
+                                 (void *)out->ga.data, (void *)&out->ga.offset,
+                                 (void *)&img_len, (void *)&img_wid,
+                                 (void *)&kern_len, (void *)&kern_wid,
+                                 (void *)&out_len, (void *)&out_wid,
+                                 (void *)&nkern, (void *)&nstack,
+                                 (void *)&img_stride_col, (void *)&img_stride_row,
+                                 (void *)&img_stride_stack, (void *)&img_stride_batch,
+                                 (void *)&kern_stride_col, (void *)&kern_stride_row,
+                                 (void *)&kern_stride_stack, (void *)&kern_stride_nkern,
+                                 (void *)&subsample_rows, (void *)&subsample_cols};
 
-        f<<< grid, threads, shared_size>>>
-            (cuda_get_ptr(img), cuda_get_ptr(kern), cuda_get_ptr(out),
-              img_len, img_wid, kern_len, kern_wid, 
-              out_len, out_wid, nkern, nstack,
-              img_stride_col, img_stride_row, img_stride_stack,
-              img_stride_batch, kern_stride_col, kern_stride_row,
-              kern_stride_stack, kern_stride_nkern, subsample_rows, subsample_cols);
+        int err = GpuKernel_call(k, 3, threads_per_block, n_blocks, shmem_sz, kernel_params);
 
-        cudaError_t sts = cudaGetLastError();
-        if (cudaSuccess == sts)
+        if (err == GA_NO_ERROR)
         {
             if (verbose>1)
               fprintf(stderr,
-                      "threads.x=%i, threads.y=%i, grid.x=%i, grid.y=%i,"
-                      " shared_size=%i, nb_threads=%i,"
+                      "threads_per_block[0]=%i, threads_per_block[1]=%i, n_blocks[0]=%i, n_blocks[1]=%i,"
+                      " shmem_sz=%i, nb_threads=%i,"
                       " kern_flipped=true, accumulate=false, kern_width=%i,"
                       " img_c_contiguous_2d=%i,"
                       " kern_c_contiguous_2d=%i, nb_split=%i,"
                       " preload_full_kernel=%i,"
                       " subsample_rows=%llu, subsample_cols=%llu\n",
-                      threads.x, threads.y, grid.x, grid.y,
-                      shared_size, threads.x * threads.y,
+                      threads_per_block[0], threads_per_block[1], n_blocks[0], n_blocks[1],
+                      shmem_sz, threads_per_block[0] * threads_per_block[1],
                       THEANO_KERN_WID, img_contiguous_2d, kern_contiguous_2d,
                       nb_split, preload_full_kernel,
                       (unsigned long long)subsample_rows,
@@ -337,15 +336,15 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
         {
             if (verbose)
               fprintf(stderr,
-                      "threads.x=%i, threads.y=%i, grid.x=%i, grid.y=%i,"
-                      " shared_size=%i, nb_threads=%i,"
+                      "threads_per_block[0]=%i, threads_per_block[1]=%i, n_blocks[0]=%i, n_blocks[1]=%i,"
+                      " shmem_sz=%i, nb_threads=%i,"
                       " kern_flipped=true, accumulate=false,"
                       " kern_width=%i, img_c_contiguous_2d=%i,"
                       " kern_c_contiguous_2d=%i, nb_split=%i,"
                       " preload_full_kernel=%i,"
                       " subsample_rows=%llu, subsample_cols=%llu\n",
-                      threads.x, threads.y, grid.x, grid.y,
-                      shared_size, threads.x * threads.y,
+                      threads_per_block[0], threads_per_block[1], n_blocks[0], n_blocks[1],
+                      shmem_sz, threads_per_block[0] * threads_per_block[1],
                       THEANO_KERN_WID, img_contiguous_2d, kern_contiguous_2d,
                       nb_split, preload_full_kernel,
                       (unsigned long long)subsample_rows,
@@ -354,7 +353,7 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
               fprintf(stderr,
                       "INFO: impl 'conv_patch_stack' failed (%s),"
                       " trying next implementation\n",
-                      cudaGetErrorString(sts));
+                      GpuKernel_error(k, err));
         }
     }
 
@@ -366,28 +365,28 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
         !work_complete) //conv_rows
 
     {
-        dim3 threads(out_wid);
-        dim3 grid(out_len, nbatch*nkern);
-        int shared_size=(kern_len*img_wid + kern_size)*sizeof(float);
-        void (*f)(const float*, const float*, float*,
-                  int, int, int, int,
-                  int, int, int, int,
-                  int, int, int, int,
-                  int, int);
+        size_t threads_per_block[3] = {(size_t)out_wid, (size_t)1, (size_t)1};
+        size_t n_blocks[3] = {(size_t)out_len, (size_t)nbatch*nkern, (size_t)1};
+        size_t shmem_sz = (kern_len*img_wid + kern_size)*sizeof(float);
 
-        if(!img_contiguous_2d || !kern_contiguous_2d) f = conv_rows_0;
-        else f = conv_rows_1;
+        GpuKernel *k = NULL;
+        if(!img_contiguous_2d || !kern_contiguous_2d) k=&conv_rows_0_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else k=&conv_rows_1_node_<<<<HASH_PLACEHOLDER>>>>_0;
 
-        f<<< grid, threads, shared_size >>>
-            (cuda_get_ptr(img), cuda_get_ptr(kern), cuda_get_ptr(out),
-           img_len, img_wid, kern_len, kern_wid, nkern, nstack,
-           img_stride_col, img_stride_row,
-           img_stride_stack,img_stride_batch,
-           kern_stride_col, kern_stride_row,
-           kern_stride_stack, kern_stride_nkern);
+        void *kernel_params[] = {
+            (void *)img->ga.data, (void *)&img->ga.offset,
+            (void *)kern->ga.data, (void *)&kern->ga.offset,
+            (void *)out->ga.data, (void *)&out->ga.offset,
+            (void *)&img_len, (void *)&img_wid,
+            (void *)&kern_len, (void *)&kern_wid,
+            (void *)&nkern, (void *)&nstack,
+            (void *)&img_stride_col, (void *)&img_stride_row,
+            (void *)&img_stride_stack, (void *)&img_stride_batch,
+            (void *)&kern_stride_col, (void *)&kern_stride_row,
+            (void *)&kern_stride_stack, (void *)&kern_stride_nkern};
+        int err = GpuKernel_call(k, 3, threads_per_block, n_blocks, shmem_sz, kernel_params);
 
-        cudaError_t sts = cudaGetLastError();
-        if (cudaSuccess == sts)
+        if (err == GA_NO_ERROR)
         {
             work_complete = true;
             if (verbose)
@@ -397,15 +396,15 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
         {
             if (verbose)
               fprintf(stderr,
-                      "threads.x=%i, threads.y=%i, grid.x=%i, grid.y=%i,"
-                      " shared_size=%i, nb_threads=%i\n",
-                      threads.x, threads.y, grid.x, grid.y,
-                      shared_size, threads.x * threads.y);
+                      "threads_per_block[0]=%i, threads_per_block[1]=%i, n_blocks[0]=%i, n_blocks[1]=%i,"
+                      " shmem_sz=%i, nb_threads=%i\n",
+                      threads_per_block[0], threads_per_block[1], n_blocks[0], n_blocks[1],
+                      shmem_sz, threads_per_block[0] * threads_per_block[1]);
             if (verbose)
               fprintf(stderr,
                       "INFO: impl 'conv_rows' failed (%s),"
                       " trying next implementation\n",
-                      cudaGetErrorString(sts));
+                      GpuKernel_error(k, err));
         }
     }
     if (!subsample && out_contiguous &&
@@ -423,52 +422,50 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
             nb_row=i;
         }
 
-        dim3 threads(out_wid,nb_row);
-        dim3 grid(ceil_intdiv(out_len,nb_row), nbatch*nkern);
+        size_t threads_per_block[3] = {(size_t)out_wid, (size_t)nb_row, (size_t)1};
+        size_t n_blocks[3] = {(size_t)ceil_intdiv(out_len,nb_row),
+                              (size_t)nbatch*nkern, (size_t)1};
 
-        int shared_size=((kern_len+nb_row-1)*img_wid + kern_size)*sizeof(float);
-
-        void (*f)(const float*, const float*, float*,
-                  int, int, int, int,
-                  int, int, int, int,
-                  int, int, int, int,
-                  int, int);
+        size_t shmem_sz =((kern_len+nb_row-1)*img_wid + kern_size)*sizeof(float);
 
         if (0)
           fprintf(stderr,
                   "IMG CONTIG %i KERN_CONTIG %i (%i %i %i) (%i %i %i)\n",
                   img_contiguous_2d, kern_contiguous_2d,
-                  threads.x, threads.y, threads.z,
-                  grid.x, grid.y, grid.z);
+                  threads_per_block[0], threads_per_block[1], threads_per_block[2],
+                  n_blocks[0], n_blocks[1], n_blocks[2]);
 
+        GpuKernel *k = NULL;
         if(!img_contiguous_2d || !kern_contiguous_2d) {
             //fprintf(stderr, "using false version\n");
-            f = conv_rows_stack_0;
+            k=&conv_rows_stack_0_node_<<<<HASH_PLACEHOLDER>>>>_0;
         } else {
             //fprintf(stderr, "using true version\n");
-            f = conv_rows_stack_1;
+            k=&conv_rows_stack_1_node_<<<<HASH_PLACEHOLDER>>>>_0;
         }
 
-        f<<< grid, threads, shared_size >>>
-            (cuda_get_ptr(img),
-             cuda_get_ptr(kern),
-             cuda_get_ptr(out),
-           img_len, img_wid, kern_len, kern_wid, nkern, nstack,
-           img_stride_col, img_stride_row,
-           img_stride_stack,img_stride_batch,
-           kern_stride_col, kern_stride_row,
-           kern_stride_stack, kern_stride_nkern);
+        void *kernel_params[] = {
+            (void *)img->ga.data, (void *)&img->ga.offset,
+            (void *)kern->ga.data, (void *)&kern->ga.offset,
+            (void *)out->ga.data, (void *)&out->ga.offset,
+            (void *)&img_len, (void *)&img_wid,
+            (void *)&kern_len, (void *)&kern_wid,
+            (void *)&nkern, (void *)&nstack,
+            (void *)&img_stride_col, (void *)&img_stride_row,
+            (void *)&img_stride_stack, (void *)&img_stride_batch,
+            (void *)&kern_stride_col, (void *)&kern_stride_row,
+            (void *)&kern_stride_stack, (void *)&kern_stride_nkern};
+        int err = GpuKernel_call(k, 3, threads_per_block, n_blocks, shmem_sz, kernel_params);
 
-        cudaError_t sts = cudaGetLastError();
-        if (cudaSuccess == sts)
+        if (err == GA_NO_ERROR)
         {
             work_complete = true;
             if (verbose>1)
               fprintf(stderr,
-                      "threads.x=%i, threads.y=%i, grid.x=%i, grid.y=%i,"
-                      " shared_size=%i, nb_threads=%i\n",
-                      threads.x, threads.y, grid.x, grid.y,
-                      shared_size, threads.x * threads.y);
+                      "threads_per_block[0]=%i, threads_per_block[1]=%i, n_blocks[0]=%i, n_blocks[1]=%i,"
+                      " shmem_sz=%i, nb_threads=%i\n",
+                      threads_per_block[0], threads_per_block[1], n_blocks[0], n_blocks[1],
+                      shmem_sz, threads_per_block[0] * threads_per_block[1]);
             if (verbose)
               fprintf(stderr, "INFO: used 'conv_rows_stack' version\n");
         }
@@ -476,15 +473,15 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
         {
             if (verbose)
               fprintf(stderr,
-                      "threads.x=%i, threads.y=%i, grid.x=%i, grid.y=%i,"
-                      " shared_size=%i, nb_threads=%i\n",
-                      threads.x, threads.y, grid.x, grid.y,
-                      shared_size, threads.x * threads.y);
+                      "threads_per_block[0]=%i, threads_per_block[1]=%i, n_blocks[0]=%i, n_blocks[1]=%i,"
+                      " shmem_sz=%i, nb_threads=%i\n",
+                      threads_per_block[0], threads_per_block[1], n_blocks[0], n_blocks[1],
+                      shmem_sz, threads_per_block[0] * threads_per_block[1]);
             if (verbose)
               fprintf(stderr,
                       "INFO: impl 'conv_rows_stack' failed (%s),"
                       " trying next implementation\n",
-                      cudaGetErrorString(sts));
+                      GpuKernel_error(k, err));
         }
     }
 
@@ -517,42 +514,41 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
         //to test the case when we don't have a thread by output pixel.
         if((version_back!=-1)&& nb_row>1) nb_row--;
 
-        dim3 threads(out_wid,nb_row);
-        dim3 grid(ceil_intdiv(out_len,nb_row), nbatch*nkern);
+
+        size_t threads_per_block[3] = {(size_t)out_wid, (size_t)nb_row, (size_t)1};
+        size_t n_blocks[3] = {(size_t)ceil_intdiv(out_len,nb_row),
+                              (size_t)nbatch*nkern, (size_t)1};
           
-        int shared_size=(threads.y*img_wid + k_size)*sizeof(float);
+        size_t shmem_sz =((kern_len+nb_row-1)*img_wid + kern_size)*sizeof(float);
 
-        void (*f)(const float*, const float*, float*,
-                  int, int, int, int,
-                  int, int, int, int,
-                  int, int, int, int,
-                  int, int);
+        GpuKernel *k = NULL;
+        if((!img_contiguous_2d || !kern_contiguous_2d)&&version==9) k=&conv_rows_stack2_1_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(version==9) k=&conv_rows_stack2_3_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(!img_contiguous_2d || !kern_contiguous_2d) k=&conv_rows_stack2_0_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else k=&conv_rows_stack2_2_node_<<<<HASH_PLACEHOLDER>>>>_0;
 
-        if((!img_contiguous_2d || !kern_contiguous_2d)&&version==9) f = conv_rows_stack2_1;
-        else if(version==9) f = conv_rows_stack2_3;
-        else if(!img_contiguous_2d || !kern_contiguous_2d) f = conv_rows_stack2_0;
-        else f = conv_rows_stack2_2;
+        void *kernel_params[] = {
+            (void *)img->ga.data, (void *)&img->ga.offset,
+            (void *)kern->ga.data, (void *)&kern->ga.offset,
+            (void *)out->ga.data, (void *)&out->ga.offset,
+            (void *)&img_len, (void *)&img_wid,
+            (void *)&kern_len, (void *)&kern_wid,
+            (void *)&nkern, (void *)&nstack,
+            (void *)&img_stride_col, (void *)&img_stride_row,
+            (void *)&img_stride_stack, (void *)&img_stride_batch,
+            (void *)&kern_stride_col, (void *)&kern_stride_row,
+            (void *)&kern_stride_stack, (void *)&kern_stride_nkern};
+        int err = GpuKernel_call(k, 3, threads_per_block, n_blocks, shmem_sz, kernel_params);
 
-        f<<< grid, threads, shared_size >>>
-            (cuda_get_ptr(img),
-             cuda_get_ptr(kern),
-             cuda_get_ptr(out),
-           img_len, img_wid, kern_len, kern_wid, nkern, nstack,
-           img_stride_col, img_stride_row,
-           img_stride_stack,img_stride_batch,
-           kern_stride_col, kern_stride_row,
-           kern_stride_stack, kern_stride_nkern);
-
-        cudaError_t sts = cudaGetLastError();
-        if (cudaSuccess == sts) 
+        if (err == GA_NO_ERROR)
         {
             work_complete = true;
             if (verbose>1)
               fprintf(stderr,
-                      "threads.x=%i, threads.y=%i, grid.x=%i, grid.y=%i,"
-                      " shared_size=%i, nb_threads=%i\n",
-                      threads.x, threads.y, grid.x, grid.y,
-                      shared_size, threads.x * threads.y);
+                      "threads_per_block[0]=%i, threads_per_block[1]=%i, n_blocks[0]=%i, n_blocks[1]=%i,"
+                      " shmem_sz=%i, nb_threads=%i\n",
+                      threads_per_block[0], threads_per_block[1], n_blocks[0], n_blocks[1],
+                      shmem_sz, threads_per_block[0] * threads_per_block[1]);
             if (verbose)
               fprintf(stderr,
                       "INFO: used 'conv_rows_stack2' version %s with"
@@ -564,15 +560,15 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
         {
             if (verbose)
               fprintf(stderr,
-                      "threads.x=%i, threads.y=%i, grid.x=%i, grid.y=%i,"
-                      " shared_size=%i, nb_threads=%i version=%d\n",
-                      threads.x, threads.y, grid.x, grid.y,
-                      shared_size, threads.x * threads.y,(version==9?2:3));
+                      "threads_per_block[0]=%i, threads_per_block[1]=%i, n_blocks[0]=%i, n_blocks[1]=%i,"
+                      " shmem_sz=%i, nb_threads=%i version=%d\n",
+                      threads_per_block[0], threads_per_block[1], n_blocks[0], n_blocks[1],
+                      shmem_sz, threads_per_block[0] * threads_per_block[1],(version==9?2:3));
             if (verbose)
               fprintf(stderr,
                       "INFO: impl 'conv_rows_stack2' failed (%s),"
                       " trying next implementation\n",
-                      cudaGetErrorString(sts));
+                      GpuKernel_error(k, err));
         }
     }
 
@@ -619,18 +615,18 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
             nb_split++;
 
         // tentative estimates (prior to contraint c)
-        int thread_z=ceil_intdiv(kern_len,nb_split);
-        int shared_size = sizeof(float)*(full_kern
-                ? std::max(img_size + kern_size, out_size*thread_z)
-                : std::max(img_size + thread_z*kern_wid, out_size*thread_z));
+        size_t thread_z=ceil_intdiv(kern_len,nb_split);
+        size_t shmem_sz = sizeof(float)*(full_kern
+                ? std::max((size_t)img_size + kern_size, out_size*thread_z)
+                : std::max((size_t)img_size + thread_z*kern_wid, out_size*thread_z));
 
         // constraint (c)
-        while ((shared_size >= shared_avail) && (nb_split <= kern_len)){
+        while ((shmem_sz >= shared_avail) && (nb_split <= kern_len)){
             //if we can't fit the kernel in shared memory, we must split it more.
             nb_split++;
             thread_z=ceil_intdiv(kern_len,nb_split);
-            shared_size = sizeof(float)*(full_kern
-                ? std::max(img_size + kern_size, out_size*thread_z)
+            shmem_sz = sizeof(float)*(full_kern
+                ? std::max((size_t)img_size + kern_size, out_size*thread_z)
                 : std::max(img_size + thread_z*kern_wid, out_size*thread_z));
         }
         if (nb_split <= kern_len)
@@ -638,15 +634,12 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
             assert(thread_z>0);//should not happen, but in case...
             if(!full_kern) assert(thread_z!=kern_len);
 
-            dim3 threads(out_wid, out_len, thread_z);
-            dim3 grid(nbatch,nkern);
+            size_t threads_per_block[3] = {(size_t)out_wid,
+                                   (size_t)out_len,
+                                   (size_t)thread_z};
+            size_t n_blocks[3] = {(size_t)nbatch, (size_t)nkern, (size_t)1};
 
-            void (*f)(const float*, const float*, float*,
-                      int, int, int, int,
-                      int, int, int, int,
-                      int, int,
-                      int, int,
-                      int, int);
+            GpuKernel *k = NULL;
 
             const bool split=thread_z!=kern_len;
             const bool ccontig=img_contiguous_2d && kern_contiguous_2d_unflipped;
@@ -654,40 +647,46 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
             //printf("kern_flipped=%d, ccontig=%d, split=%d, full_kern=%d\n",kern_flipped,ccontig,split,full_kern);
             //We will always be split when we don't load the full kernel
 
-            /* if(!kern_flipped && !ccontig && !split && !full_kern) f=conv_patch_stack_reduce_0;*/
-            /*else*/ if(!kern_flipped && !ccontig && !split && full_kern) f=conv_patch_stack_reduce_1;
-            else if(!kern_flipped && !ccontig  && split && !full_kern) f=conv_patch_stack_reduce_2;
-            else if(!kern_flipped && !ccontig  && split && full_kern) f=conv_patch_stack_reduce_3;
-            /*else if(!kern_flipped && ccontig  && !split && !full_kern) f=conv_patch_stack_reduce_4;*/
-            else if(!kern_flipped && ccontig  && !split && full_kern) f=conv_patch_stack_reduce_5;
-            else if(!kern_flipped && ccontig  && split && !full_kern) f=conv_patch_stack_reduce_6;
-            else if(!kern_flipped && ccontig  && split && full_kern) f=conv_patch_stack_reduce_7;
-            /*else if(kern_flipped  && !ccontig && !split && !full_kern) f=conv_patch_stack_reduce_8;*/
-            else if(kern_flipped  && !ccontig && !split && full_kern) f=conv_patch_stack_reduce_9;
-            else if(kern_flipped  && !ccontig && split && !full_kern) f=conv_patch_stack_reduce_10;
-            else if(kern_flipped  && !ccontig && split && full_kern) f=conv_patch_stack_reduce_11;
-            /*else if(kern_flipped  && ccontig  && !split && !full_kern) f=conv_patch_stack_reduce_12;*/
-            else if(kern_flipped  && ccontig  && !split && full_kern) f=conv_patch_stack_reduce_13;
-            else if(kern_flipped  && ccontig  && split && !full_kern) f=conv_patch_stack_reduce_14;
-            else if(kern_flipped  && ccontig  && split && full_kern) f=conv_patch_stack_reduce_15;
+            /* if(!kern_flipped && !ccontig && !split && !full_kern) k=&conv_patch_stack_reduce_0_node_<<<<HASH_PLACEHOLDER>>>>_0;*/
+            /*else*/ if(!kern_flipped && !ccontig && !split && full_kern) k=&conv_patch_stack_reduce_1_node_<<<<HASH_PLACEHOLDER>>>>_0;
+            else if(!kern_flipped && !ccontig  && split && !full_kern) k=&conv_patch_stack_reduce_2_node_<<<<HASH_PLACEHOLDER>>>>_0;
+            else if(!kern_flipped && !ccontig  && split && full_kern) k=&conv_patch_stack_reduce_3_node_<<<<HASH_PLACEHOLDER>>>>_0;
+            /*else if(!kern_flipped && ccontig  && !split && !full_kern) k=&conv_patch_stack_reduce_4_node_<<<<HASH_PLACEHOLDER>>>>_0;*/
+            else if(!kern_flipped && ccontig  && !split && full_kern) k=&conv_patch_stack_reduce_5_node_<<<<HASH_PLACEHOLDER>>>>_0;
+            else if(!kern_flipped && ccontig  && split && !full_kern) k=&conv_patch_stack_reduce_6_node_<<<<HASH_PLACEHOLDER>>>>_0;
+            else if(!kern_flipped && ccontig  && split && full_kern) k=&conv_patch_stack_reduce_7_node_<<<<HASH_PLACEHOLDER>>>>_0;
+            /*else if(kern_flipped  && !ccontig && !split && !full_kern) k=&conv_patch_stack_reduce_8_node_<<<<HASH_PLACEHOLDER>>>>_0;*/
+            else if(kern_flipped  && !ccontig && !split && full_kern) k=&conv_patch_stack_reduce_9_node_<<<<HASH_PLACEHOLDER>>>>_0;
+            else if(kern_flipped  && !ccontig && split && !full_kern) k=&conv_patch_stack_reduce_10_node_<<<<HASH_PLACEHOLDER>>>>_0;
+            else if(kern_flipped  && !ccontig && split && full_kern) k=&conv_patch_stack_reduce_11_node_<<<<HASH_PLACEHOLDER>>>>_0;
+            /*else if(kern_flipped  && ccontig  && !split && !full_kern) k=&conv_patch_stack_reduce_12_node_<<<<HASH_PLACEHOLDER>>>>_0;*/
+            else if(kern_flipped  && ccontig  && !split && full_kern) k=&conv_patch_stack_reduce_13_node_<<<<HASH_PLACEHOLDER>>>>_0;
+            else if(kern_flipped  && ccontig  && split && !full_kern) k=&conv_patch_stack_reduce_14_node_<<<<HASH_PLACEHOLDER>>>>_0;
+            else if(kern_flipped  && ccontig  && split && full_kern) k=&conv_patch_stack_reduce_15_node_<<<<HASH_PLACEHOLDER>>>>_0;
 
-            f<<< grid, threads, shared_size>>>(cuda_get_ptr(img), kern_data_unflipped, cuda_get_ptr(out),
-                                               img_len, img_wid, kern_len, kern_wid,
-                                               nkern, nstack,
-                                               img_stride_col, img_stride_row, img_stride_stack, img_stride_batch,
-                                               kern_stride_col_unflipped, kern_stride_row_unflipped,
-                                               kern_stride_stack, kern_stride_nkern);
+            void *kernel_params[] = {
+                (void *)img->ga.data, (void *)&img->ga.offset,
+                (void *)kern->ga.data, (void *)&kern->ga.offset,
+                (void *)out->ga.data, (void *)&out->ga.offset,
+                (void *)&img_len, (void *)&img_wid,
+                (void *)&kern_len, (void *)&kern_wid,
+                (void *)&nkern, (void *)&nstack,
+                (void *)&img_stride_col, (void *)&img_stride_row,
+                (void *)&img_stride_stack, (void *)&img_stride_batch,
+                (void *)&kern_stride_col,
+                (void *)&kern_stride_row,
+                (void *)&kern_stride_stack, (void *)&kern_stride_nkern};
+            int err = GpuKernel_call(k, 3, threads_per_block, n_blocks, shmem_sz, kernel_params);
 
-            cudaError_t sts = cudaGetLastError();
-            if (cudaSuccess == sts)
+            if (err == GA_NO_ERROR)
             {
                 if (verbose>1)
                     fprintf(stderr,
-                            "threads.x=%i, threads.y=%i, threads.z=%i, "
-                            "grid.x=%i, grid.y=%i, shared_size=%i,"
+                            "threads_per_block[0]=%i, threads_per_block[1]=%i, threads_per_block[2]=%i, "
+                            "n_blocks[0]=%i, n_blocks[1]=%i, shmem_sz=%i,"
                             " nb_threads=%i\n",
-                            threads.x, threads.y, threads.z, grid.x, grid.y,
-                            shared_size, threads.x * threads.y * threads.z);
+                            threads_per_block[0], threads_per_block[1], threads_per_block[2], n_blocks[0], n_blocks[1],
+                            shmem_sz, threads_per_block[0] * threads_per_block[1] * threads_per_block[2]);
                 if (verbose)
                     fprintf(stderr,
                             "INFO: used 'conv_patch_stack_reduce' version"
@@ -700,17 +699,17 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
             {
                 if (verbose)
                   fprintf(stderr,
-                          "threads.x=%i, threads.y=%i, threads.z=%i,"
-                          " grid.x=%i, grid.y=%i,shared_size=%i,"
+                          "threads_per_block[0]=%i, threads_per_block[1]=%i, threads_per_block[2]=%i,"
+                          " n_blocks[0]=%i, n_blocks[1]=%i,shmem_sz=%i,"
                           " nb_threads=%i\n",
-                          threads.x, threads.y, threads.z,
-                          grid.x, grid.y, shared_size,
-                          threads.x * threads.y * threads.z);
+                          threads_per_block[0], threads_per_block[1], threads_per_block[2],
+                          n_blocks[0], n_blocks[1], shmem_sz,
+                          threads_per_block[0] * threads_per_block[1] * threads_per_block[2]);
                 if (verbose)
                   fprintf(stderr,
                           "INFO: impl 'conv_patch_stack_reduce' failed (%s),"
                           " trying next implementation\n",
-                          cudaGetErrorString(sts));
+                          GpuKernel_error(k, err));
             }
         } // else no good nb_splits was found
     }
@@ -719,8 +718,9 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
         kern_len<=320 &&
         !work_complete) //conv_valid_row_reduce
     {
-        int outsize = PyGpuArray_SIZE(out);
-        int n_blocks = std::min(outsize, 4096);
+        size_t outsize = PyGpuArray_SIZE(out);
+        size_t n_blocks[3] = {std::min(outsize, (size_t)4096),
+                              (size_t)1, (size_t)1};
 
         int block_nstack=nstack;
         //Max of 512 threads per blocks.
@@ -728,9 +728,9 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
         //8k registers and the kernel use 23 register
         //TODO: check if we have 8k or 16k of register...
         while(block_nstack*kern_len>320)block_nstack--;
-        dim3 n_threads(block_nstack, kern_len, 1);
+        size_t threads_per_block[3] = {(size_t)block_nstack, (size_t)kern_len, (size_t)1};
 
-        int n_reduce_buf = block_nstack * kern_len * sizeof(float);
+        size_t n_reduce_buf = block_nstack * kern_len * sizeof(float);
         /* initial_reduce_boundary is the greatest power of two less than n_reduce_buf/ sizeof(float)
          *
          * if n_reduce_buf == sizeof(float), then initial_reduce_boundary == 0.
@@ -747,39 +747,34 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
             assert (initial_reduce_boundary < n_reduce_buf/sizeof(float));
         }
 
-
-        void (*f)(int, int, int, int,
-                  int, int, int, int, int,
-                  const float*, int, int, int, int,
-                  const float*, int, int, int, int,
-                  float*, int, int, int, int,
-                  int, int, int);
-
+        GpuKernel *k = NULL;
         //std::cerr << "initial_reduce_boundary " << initial_reduce_boundary << "\n";
         //std::cerr << "kerns " << nstack << " " << kern_len << "\n";
         //std::cerr << "n_reduce_buf/sizeof(float) " << n_reduce_buf / sizeof(float) << "\n";
         if(block_nstack==nstack)
-          f=conv_valid_row_reduce_0;
+          k=&conv_valid_row_reduce_0_node_<<<<HASH_PLACEHOLDER>>>>_0;
         else
-          f=conv_valid_row_reduce_1;
-        f<<<n_blocks, n_threads, n_reduce_buf>>>(
-                nbatch, nkern, PyGpuArray_DIMS(img)[1],
-                img_len, img_wid,
-                kern_len, kern_wid,
-                out_len, out_wid,
-                cuda_get_ptr(img),
-                PyGpuArray_STRIDES(img)[0]/4, PyGpuArray_STRIDES(img)[1]/4, 
-                img_stride_row, img_stride_col,
-                cuda_get_ptr(kern),
-                PyGpuArray_STRIDES(kern)[0]/4, PyGpuArray_STRIDES(kern)[1]/4,
-                PyGpuArray_STRIDES(kern)[2]/4, PyGpuArray_STRIDES(kern)[3]/4,
-                cuda_get_ptr(out),
-                PyGpuArray_STRIDES(out)[0]/4, PyGpuArray_STRIDES(out)[1]/4,
-                PyGpuArray_STRIDES(out)[2]/4, PyGpuArray_STRIDES(out)[3]/4,
-                subsample_rows, subsample_cols, initial_reduce_boundary);
+          k=&conv_valid_row_reduce_1_node_<<<<HASH_PLACEHOLDER>>>>_0;
 
-        cudaError_t sts = cudaGetLastError();
-        if (cudaSuccess == sts) 
+        void *kernel_params[] = {
+            (void *)&nbatch, (void *)&nkern, (void *)&stack_len,
+            (void *)&img_len, (void *)&img_wid,
+            (void *)&kern_len, (void *)&kern_wid,
+            (void *)&out_len, (void *)&out_wid,
+            (void *)img->ga.data, (void *)&img->ga.offset,
+            (void *)&img_stride_batch, (void *)&img_stride_stack,
+            (void *)&img_stride_row, (void *)&img_stride_col,
+            (void *)kern->ga.data, (void *)&kern->ga.offset,
+            (void *)&kern_stride_nkern, (void *)&kern_stride_stack,
+            (void *)&kern_stride_row, (void *)&kern_stride_col,
+            (void *)out->ga.data, (void *)&out->ga.offset,
+            (void *)&out_stride_batch, (void *)&out_stride_nkern,
+            (void *)&out_stride_row, (void *)&out_stride_col,
+            (void *)&subsample_rows, (void *)&subsample_cols,
+            (void *)&initial_reduce_boundary};
+        int err = GpuKernel_call(k, 3, threads_per_block, n_blocks, n_reduce_buf, kernel_params);
+
+        if (err == GA_NO_ERROR)
         {
             work_complete = true;
             if (verbose)
@@ -789,24 +784,27 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
         {
             if (verbose)
               fprintf(stderr,
-                      "threads.x=%i, threads.y=%i, grid.x=%i,"
-                      " shared_size=%i, nb_threads=%i\n",
-                      n_threads.x, n_threads.y, n_blocks,
-                      n_reduce_buf, n_threads.x * n_threads.y);
+                      "threads_per_block[0]=%i, threads_per_block[1]=%i, n_blocks[0]=%i,"
+                      " shmem_sz=%i, nb_threads=%i\n",
+                      threads_per_block[0], threads_per_block[1], n_blocks[0],
+                      n_reduce_buf, threads_per_block[0] * threads_per_block[1]);
             if (verbose)
               fprintf(stderr,
                       "INFO: impl 'conv_valid_row_reduce' failed (%s),"
                       " trying next implementation\n",
-                      cudaGetErrorString(sts));
+                      GpuKernel_error(k, err));
         }
     }
 
     if (1 && !work_complete) //conv_reference_valid
     {
-        int outsize = PyGpuArray_SIZE(out);
-        int n_blocks = std::min(outsize, 4096);
-        int n_threads = std::min(ceil_intdiv(outsize, n_blocks),
-                                 256);
+        size_t outsize = PyGpuArray_SIZE(out);
+        size_t n_blocks[3] = {std::min(outsize, (size_t)4096),
+                              (size_t)1, (size_t)1};
+        size_t threads_per_block[3] = {std::min(ceil_intdiv(outsize, n_blocks[0]),
+                                        (size_t)256),
+                               (size_t)1, (size_t)1};
+
         if (1)
         {
             if (verbose)
@@ -814,61 +812,56 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
             if (verbose>1)
               fprintf(stderr, "      img : %i %llu %i %i %p  "
                       "%lld %lld %lld %lld\n",
-                      nbatch, (unsigned long long)PyGpuArray_DIMS(img)[1],
-                      img_len, img_wid,
-                      cuda_get_ptr(img),
-                      (long long)PyGpuArray_STRIDES(img)[0]/4,
-                      (long long)PyGpuArray_STRIDES(img)[1]/4,
-                      (long long)PyGpuArray_STRIDES(img)[2]/4,
-                      (long long)PyGpuArray_STRIDES(img)[3]/4);
+                      nbatch, (unsigned long long)stack_len, img_len, img_wid,
+                      (void *)(cuda_get_ptr(img->ga.data) + img->ga.offset),
+                      (long long)img_stride_batch,
+                      (long long)img_stride_stack,
+                      (long long)img_stride_row,
+                      (long long)img_stride_col);
             if (verbose>1)
               fprintf(stderr, "      kern: %i %i %i %i %p  "
                       "%lld %lld %lld %lld\n",
                       nkern, nstack, kern_len, kern_wid,
-                      cuda_get_ptr(kern),
-                      (long long)PyGpuArray_STRIDES(kern)[0]/4,
-                      (long long)PyGpuArray_STRIDES(kern)[1]/4,
-                      (long long)PyGpuArray_STRIDES(kern)[2]/4,
-                      (long long)PyGpuArray_STRIDES(kern)[3]/4);
+                      (void *)(cuda_get_ptr(kern->ga.data) + kern->ga.offset),
+                      (long long)kern_stride_nkern,
+                      (long long)kern_stride_stack,
+                      (long long)kern_stride_row,
+                      (long long)kern_stride_col);
             if (verbose>1)
                 fprintf(stderr, "      out : %llu %llu %i %i %p  "
                         "%lld %lld %lld %lld\n",
                       (unsigned long long)PyGpuArray_DIMS(out)[0],
                       (unsigned long long)PyGpuArray_DIMS(out)[1],
                       out_len, out_wid,
-                      cuda_get_ptr(out),
-                      (long long)PyGpuArray_STRIDES(out)[0]/4,
-                      (long long)PyGpuArray_STRIDES(out)[1]/4,
-                      (long long)PyGpuArray_STRIDES(out)[2]/4,
-                      (long long)PyGpuArray_STRIDES(out)[3]/4);
+                      (void *)(cuda_get_ptr(out->ga.data) + out->ga.offset),
+                      (long long)out_stride_batch,
+                      (long long)out_stride_nkern,
+                      (long long)out_stride_row,
+                      (long long)out_stride_col);
             if (verbose>1)
               fprintf(stderr, "   launch params: %i %i %i\n",
-                      outsize, n_blocks, n_threads);
+                      outsize, n_blocks[0], threads_per_block[0]);
         }
-        conv_reference_valid<<<n_blocks, n_threads>>>(nbatch, nkern,
-                PyGpuArray_DIMS(img)[1],
-                img_len, img_wid,
-                kern_len, kern_wid,
-                out_len, out_wid,
-                cuda_get_ptr(img),
-                PyGpuArray_STRIDES(img)[0]/4,
-                PyGpuArray_STRIDES(img)[1]/4,
-                PyGpuArray_STRIDES(img)[2]/4,
-                PyGpuArray_STRIDES(img)[3]/4,
-                cuda_get_ptr(kern),
-                PyGpuArray_STRIDES(kern)[0]/4,
-                PyGpuArray_STRIDES(kern)[1]/4,
-                PyGpuArray_STRIDES(kern)[2]/4,
-                PyGpuArray_STRIDES(kern)[3]/4,
-                cuda_get_ptr(out),
-                PyGpuArray_STRIDES(out)[0]/4,
-                PyGpuArray_STRIDES(out)[1]/4,
-                PyGpuArray_STRIDES(out)[2]/4,
-                PyGpuArray_STRIDES(out)[3]/4,
-                subsample_rows, subsample_cols);
 
-        cudaError_t sts = cudaGetLastError();
-        if (cudaSuccess == sts)
+        void *kernel_params[] = {
+            (void *)&nbatch, (void *)&nkern, (void *)&stack_len,
+            (void *)&img_len, (void *)&img_wid,
+            (void *)&kern_len, (void *)&kern_wid,
+            (void *)&out_len, (void *)&out_wid,
+            (void *)img->ga.data, (void *)&img->ga.offset,
+            (void *)&img_stride_batch, (void *)&img_stride_stack,
+            (void *)&img_stride_row, (void *)&img_stride_col,
+            (void *)kern->ga.data, (void *)&kern->ga.offset,
+            (void *)&kern_stride_nkern, (void *)&kern_stride_stack,
+            (void *)&kern_stride_row, (void *)&kern_stride_col,
+            (void *)out->ga.data, (void *)&out->ga.offset,
+            (void *)&out_stride_batch, (void *)&out_stride_nkern,
+            (void *)&out_stride_row, (void *)&out_stride_col,
+            (void *)&subsample_rows, (void *)&subsample_cols};
+        int err = GpuKernel_call(&conv_reference_valid_node_<<<<HASH_PLACEHOLDER>>>>_0,
+                                 3, threads_per_block, n_blocks, 0, kernel_params);
+
+        if (err == GA_NO_ERROR)
         {
             work_complete = true;
             if (verbose)
@@ -881,7 +874,7 @@ PyGpuArray_conv_valid(const PyGpuArrayObject *img,
             PyErr_Format(PyExc_RuntimeError,
                          "ERROR: all implementations failed for"
                          " PyGpuArray_conv_valid! (%s)",
-                         cudaGetErrorString(sts));
+                         GpuKernel_error(&conv_reference_valid_node_<<<<HASH_PLACEHOLDER>>>>_0, err));
             return -1;
         }
     }
@@ -930,6 +923,7 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
     assert (PyGpuArray_DIMS(out)[1] == PyGpuArray_DIMS(kern)[0]);
     assert (PyGpuArray_DIMS(img)[1] == PyGpuArray_DIMS(kern)[1]);
 
+    const int stack_len=PyGpuArray_DIMS(img)[1];
     const int nstack=PyGpuArray_DIMS(kern)[1];
     const int nbatch=PyGpuArray_DIMS(img)[0];
     const int nkern=PyGpuArray_DIMS(kern)[0];
@@ -948,6 +942,10 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
     const int kern_stride_row=PyGpuArray_STRIDES(kern)[2]/4;
     const int kern_stride_stack= PyGpuArray_STRIDES(kern)[1]/4;
     const int kern_stride_nkern=PyGpuArray_STRIDES(kern)[0]/4;
+    const int out_stride_col = PyGpuArray_STRIDES(out)[3]/4;
+    const int out_stride_row = PyGpuArray_STRIDES(out)[2]/4;
+    const int out_stride_nkern = PyGpuArray_STRIDES(out)[1]/4;
+    const int out_stride_batch = PyGpuArray_STRIDES(out)[0]/4;
 
     const int img_size=img_len*img_wid;
     const int kern_size=kern_len*kern_wid;
@@ -990,16 +988,10 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
     //we don't need to unflip it, but have the new value when we unflip it.
     bool kern_flipped=true;
     bool kern_contiguous_2d_unflipped = kern_contiguous_2d;
-    const float * kern_data_unflipped = cuda_get_ptr(kern);
-    int kern_stride_col_unflipped=kern_stride_col;
-    int kern_stride_row_unflipped=kern_stride_row;
-    if(kern_stride_col_unflipped==-1 && kern_stride_row_unflipped==-kern_wid){
+    if(kern_stride_col==-1 && kern_stride_row==-kern_wid){
       //the last two dimensions are c_contiguous but flipped!
-      kern_stride_col_unflipped=1;
-      kern_stride_row_unflipped=kern_wid;
       kern_flipped=false;
       kern_contiguous_2d_unflipped = true;
-      kern_data_unflipped=&(cuda_get_ptr(kern)[(kern_wid-1)*kern_stride_col + (kern_len-1)*kern_stride_row]);
     }
 
     if (verbose>1)
@@ -1008,34 +1000,34 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
                " MACRO kern_width=%d with inputs:\n", version, THEANO_KERN_WID);
         printf("INFO:   img  dim: %llu %llu %llu %llu  "
                "img  stride: %lld %lld %lld %lld\n",
-               (unsigned long long)PyGpuArray_DIMS(img)[0],
-               (unsigned long long)PyGpuArray_DIMS(img)[1],
-               (unsigned long long)PyGpuArray_DIMS(img)[2],
-               (unsigned long long)PyGpuArray_DIMS(img)[3],
-               (long long)PyGpuArray_STRIDES(img)[0]/4,
-               (long long)PyGpuArray_STRIDES(img)[1]/4,
-               (long long)PyGpuArray_STRIDES(img)[2]/4,
-               (long long)PyGpuArray_STRIDES(img)[3]/4);
+               (unsigned long long)nbatch,
+               (unsigned long long)stack_len,
+               (unsigned long long)img_len,
+               (unsigned long long)img_wid,
+               (long long)img_stride_batch,
+               (long long)img_stride_stack,
+               (long long)img_stride_row,
+               (long long)img_stride_col);
         printf("INFO:   kern dim: %llu %llu %llu %llu  "
                "kern stride: %lld %lld %lld %lld\n",
-               (unsigned long long)PyGpuArray_DIMS(kern)[0],
-               (unsigned long long)PyGpuArray_DIMS(kern)[1],
-               (unsigned long long)PyGpuArray_DIMS(kern)[2],
-               (unsigned long long)PyGpuArray_DIMS(kern)[3],
-               (long long)PyGpuArray_STRIDES(kern)[0]/4,
-               (long long)PyGpuArray_STRIDES(kern)[1]/4,
-               (long long)PyGpuArray_STRIDES(kern)[2]/4,
-               (long long)PyGpuArray_STRIDES(kern)[3]/4);
+               (unsigned long long)nkern,
+               (unsigned long long)nstack,
+               (unsigned long long)kern_len,
+               (unsigned long long)kern_wid,
+               (long long)kern_stride_nkern,
+               (long long)kern_stride_stack,
+               (long long)kern_stride_row,
+               (long long)kern_stride_col);
         printf("INFO:   out dim: %llu %llu %llu %llu  "
                "out stride: %lld %lld %lld %lld\n",
                (unsigned long long)PyGpuArray_DIMS(out)[0],
                (unsigned long long)PyGpuArray_DIMS(out)[1],
-               (unsigned long long)PyGpuArray_DIMS(out)[2],
-               (unsigned long long)PyGpuArray_DIMS(out)[3],
-               (long long)PyGpuArray_STRIDES(out)[0]/4,
-               (long long)PyGpuArray_STRIDES(out)[1]/4,
-               (long long)PyGpuArray_STRIDES(out)[2]/4,
-               (long long)PyGpuArray_STRIDES(out)[3]/4);
+               (unsigned long long)out_len,
+               (unsigned long long)out_wid,
+               (long long)out_stride_batch,
+               (long long)out_stride_nkern,
+               (long long)out_stride_row,
+               (long long)out_stride_col);
     }
 
     if (!subsample &&
@@ -1082,50 +1074,53 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
         assert(version!=5 || kern_len>1);
         assert(version!=-1);
 
-        dim3 threads(out_wid, ceil_intdiv(out_len,nb_split));
-        dim3 grid(nbatch,nkern);
+        size_t threads_per_block[3] = {(size_t)out_wid,
+                               ceil_intdiv((size_t)out_len,(size_t)nb_split),
+                               (size_t)1};
+        size_t n_blocks[3] = {(size_t)nbatch, (size_t)nkern, (size_t)1};
 
-        int shared_size=img_size_padded_byte + kern_size_byte;
+        size_t shmem_sz=img_size_padded_byte + kern_size_byte;
         if(version==5)
-          shared_size=((kern_len+threads.y-1)+2*kern_len-2)*img_wid_padded*sizeof(float) + kern_size_byte;
-        void (*f)(const float*, const float*, float*,
-                  int, int, int, int,
-                  int, int, int, int,
-                  int, int, int, int,
-                  int, int);
+          shmem_sz=((kern_len+threads_per_block[1]-1)+2*kern_len-2)*img_wid_padded*sizeof(float) + kern_size_byte;
 
-        if(version==3) f=conv_full_patch_stack_padded_0;
-        else if(version==5) f=conv_full_patch_stack_padded_1;
-        else if(version==4) f=conv_full_patch_stack_padded_2;
-        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==3) f=conv_full_patch_stack_padded_4;
-        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==5) f=conv_full_patch_stack_padded_5;
-        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==4) f=conv_full_patch_stack_padded_6;
-        else if(version==3 && kern_flipped) f=conv_full_patch_stack_padded_8;
-        else if(version==5 && kern_flipped)f=conv_full_patch_stack_padded_9;
-        else if(version==4 && kern_flipped)f=conv_full_patch_stack_padded_10;
-        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==3 && kern_flipped) f=conv_full_patch_stack_padded_12;
-        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==5 && kern_flipped) f=conv_full_patch_stack_padded_13;
-        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==4 && kern_flipped) f=conv_full_patch_stack_padded_14;
+        GpuKernel *k = NULL;
+        if(version==3) k=&conv_full_patch_stack_padded_0_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(version==5) k=&conv_full_patch_stack_padded_1_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(version==4) k=&conv_full_patch_stack_padded_2_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==3) k=&conv_full_patch_stack_padded_4_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==5) k=&conv_full_patch_stack_padded_5_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==4) k=&conv_full_patch_stack_padded_6_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(version==3 && kern_flipped) k=&conv_full_patch_stack_padded_8_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(version==5 && kern_flipped)k=&conv_full_patch_stack_padded_9_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(version==4 && kern_flipped)k=&conv_full_patch_stack_padded_10_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==3 && kern_flipped) k=&conv_full_patch_stack_padded_12_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==5 && kern_flipped) k=&conv_full_patch_stack_padded_13_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(img_contiguous_2d && kern_contiguous_2d_unflipped && version==4 && kern_flipped) k=&conv_full_patch_stack_padded_14_node_<<<<HASH_PLACEHOLDER>>>>_0;
         else assert(false);
 
-        f<<< grid, threads, shared_size>>>
-            (cuda_get_ptr(img), kern_data_unflipped, cuda_get_ptr(out),
-              img_len, img_wid, kern_len, kern_wid, nkern, nstack,
-              img_stride_col, img_stride_row, img_stride_stack,
-              img_stride_batch, kern_stride_col_unflipped, kern_stride_row_unflipped,
-              kern_stride_stack, kern_stride_nkern);
+        void *kernel_params[] = {
+            (void *)img->ga.data, (void *)&img->ga.offset,
+            (void *)kern->ga.data, (void *)&kern->ga.offset,
+            (void *)out->ga.data, (void *)&out->ga.offset,
+            (void *)&img_len, (void *)&img_wid,
+            (void *)&kern_len, (void *)&kern_wid,
+            (void *)&nkern, (void *)&nstack,
+            (void *)&img_stride_col, (void *)&img_stride_row,
+            (void *)&img_stride_stack, (void *)&img_stride_batch,
+            (void *)&kern_stride_col, (void *)&kern_stride_row,
+            (void *)&kern_stride_stack, (void *)&kern_stride_nkern};
+        int err = GpuKernel_call(k, 3, threads_per_block, n_blocks, shmem_sz, kernel_params);
 
-        cudaError_t sts = cudaGetLastError();
-        if (cudaSuccess == sts)
+        if (err == GA_NO_ERROR)
         {
           if (verbose>1)
             fprintf(stderr,
-                    "threads.x=%i, threads.y=%i, threads.z=%i,"
-                    " grid.x=%i, grid.y=%i, shared_size=%i, nb_threads=%i,"
+                    "threads_per_block[0]=%i, threads_per_block[1]=%i, threads_per_block[2]=%i,"
+                    " n_blocks[0]=%i, n_blocks[1]=%i, shmem_sz=%i, nb_threads=%i,"
                     " out_len=%i, nb_split=%i, version=%i\n",
-                    threads.x, threads.y, threads.z,
-                    grid.x, grid.y, shared_size,
-                    threads.x * threads.y * threads.z,
+                    threads_per_block[0], threads_per_block[1], threads_per_block[2],
+                    n_blocks[0], n_blocks[1], shmem_sz,
+                    threads_per_block[0] * threads_per_block[1] * threads_per_block[2],
                     out_len, nb_split, version);
             if (verbose)
               fprintf(stderr,
@@ -1138,12 +1133,12 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
         {
           if (verbose)
             fprintf(stderr,
-                    "threads.x=%i, threads.y=%i, threads.z=%i,"
-                    " grid.x=%i, grid.y=%i,shared_size=%i, nb_threads=%i,"
+                    "threads_per_block[0]=%i, threads_per_block[1]=%i, threads_per_block[2]=%i,"
+                    " n_blocks[0]=%i, n_blocks[1]=%i,shmem_sz=%i, nb_threads=%i,"
                     " out_len=%i, nb_split=%i, version=%i\n",
-                    threads.x, threads.y, threads.z,
-                    grid.x, grid.y, shared_size,
-                    threads.x * threads.y * threads.z,
+                    threads_per_block[0], threads_per_block[1], threads_per_block[2],
+                    n_blocks[0], n_blocks[1], shmem_sz,
+                    threads_per_block[0] * threads_per_block[1] * threads_per_block[2],
                     out_len, nb_split, version);
           if (verbose)
             fprintf(stderr,
@@ -1151,7 +1146,7 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
                     " failed (%s), trying next implementation\n",
                     version==3?"no split": "split",
                     (version==5?"low_mem":"not_low_mem"),
-                    cudaGetErrorString(sts));
+                    GpuKernel_error(k, err));
         }                         
     }
 
@@ -1162,21 +1157,22 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
         img_size_byte+kern_size_byte<shared_avail && //their is only 16k of shared memory
         !work_complete) //conv_full_patch
     {
-        dim3 threads(out_wid, out_len);
-        dim3 grid(nbatch,nkern);
-        int shared_size=(img_size + kern_size)*sizeof(float);
+        size_t threads_per_block[3] = {(size_t)out_wid, (size_t)out_len, (size_t)1};
+        size_t n_blocks[3] = {(size_t)nbatch, (size_t)nkern, (size_t)1};
+        size_t shmem_sz = (img_size + kern_size)*sizeof(float);
         //TODO assert c_continious for img, kern and out in the 2 inner dimensions.
 
-        conv_full_patch<<< grid, threads, shared_size>>>
-            (cuda_get_ptr(img),
-             cuda_get_ptr(kern),
-             cuda_get_ptr(out),
-           img_len, img_wid,
-           kern_len, kern_wid,
-           nkern, nstack);
+        void *kernel_params[] = {
+            (void *)img->ga.data, (void *)&img->ga.offset,
+            (void *)kern->ga.data, (void *)&kern->ga.offset,
+            (void *)out->ga.data, (void *)&out->ga.offset,
+            (void *)&img_len, (void *)&img_wid,
+            (void *)&kern_len, (void *)&kern_wid,
+            (void *)&nkern, (void *)&nstack};
+        int err = GpuKernel_call(&conv_full_patch_node_<<<<HASH_PLACEHOLDER>>>>_0,
+                                 3, threads_per_block, n_blocks, shmem_sz, kernel_params);
 
-        cudaError_t sts = cudaGetLastError();
-        if (cudaSuccess == sts) 
+        if (err == GA_NO_ERROR)
         {
             if (verbose) fprintf(stderr, "INFO: used 'conv_full_patch' version\n");
             work_complete = true;
@@ -1185,15 +1181,15 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
         {
             if (verbose)
               fprintf(stderr,
-                      "threads.x=%i, threads.y=%i, grid.x=%i, grid.y=%i,"
-                      " shared_size=%i, nb_threads=%i\n",
-                      threads.x, threads.y, grid.x, grid.y, shared_size,
-                      threads.x * threads.y);
+                      "threads_per_block[0]=%i, threads_per_block[1]=%i, n_blocks[0]=%i, n_blocks[1]=%i,"
+                      " shmem_sz=%i, nb_threads=%i\n",
+                      threads_per_block[0], threads_per_block[1], n_blocks[0], n_blocks[1], shmem_sz,
+                      threads_per_block[0] * threads_per_block[1]);
             if (verbose)
               fprintf(stderr,
                       "INFO: impl 'conv_full_patch' failed (%s),"
                       " trying next implementation\n",
-                      cudaGetErrorString(sts));
+                      GpuKernel_error(&conv_full_patch_node_<<<<HASH_PLACEHOLDER>>>>_0, err));
         }                         
     }
     if (false && !subsample && //disabled as test fail for this kernel
@@ -1203,35 +1199,26 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
         nstack*img_size_byte+nstack*kern_size_byte<shared_avail && //there is only 16k of shared memory
         !work_complete) //conv_full_load_everything
     {
-        dim3 threads(out_wid, out_len);
-        dim3 grid(nbatch);
-        int shared_size=(img_size + kern_size)*nstack*sizeof(float);
+        size_t threads_per_block[3] = {(size_t)out_wid, (size_t)out_len, (size_t)1};
+        size_t n_blocks[3] = {(size_t)nbatch, (size_t)1, (size_t)1};
+        size_t shmem_sz = (img_size + kern_size)*nstack*sizeof(float);
         //TODO assert c_continious for img, kern and out in the 2 inner dimensions.
 
-        //typeof(conv_full_load_everything<0>) f = ;
-        void (*f)(const float*, const float*, float*,
-                  int, int, int, int, int, int,
-                  int, int, int, int, int, int, int, int) = conv_full_load_everything;
+        void *kernel_params[] = {
+            (void *)img->ga.data, (void *)&img->ga.offset,
+            (void *)kern->ga.data, (void *)&kern->ga.offset,
+            (void *)out->ga.data, (void *)&out->ga.offset,
+            (void *)&img_len, (void *)&img_wid,
+            (void *)&kern_len, (void *)&kern_wid,
+            (void *)&nkern, (void *)&nstack,
+            (void *)&img_stride_col, (void *)&img_stride_row,
+            (void *)&img_stride_stack, (void *)&img_stride_batch,
+            (void *)&kern_stride_col, (void *)&kern_stride_row,
+            (void *)&kern_stride_stack, (void *)&kern_stride_nkern};
+        int err = GpuKernel_call(&conv_full_load_everything_node_<<<<HASH_PLACEHOLDER>>>>_0,
+                                 3, threads_per_block, n_blocks, shmem_sz, kernel_params);
 
-        f<<< grid, threads, shared_size>>>
-            (cuda_get_ptr(img),
-             cuda_get_ptr(kern),
-             cuda_get_ptr(out),
-           img_len, img_wid, 
-           kern_len, kern_wid,
-           nkern, nstack,
-           PyGpuArray_STRIDES(img)[3]/4,
-           PyGpuArray_STRIDES(img)[2]/4,
-           PyGpuArray_STRIDES(img)[1]/4,
-           PyGpuArray_STRIDES(img)[0]/4,
-           PyGpuArray_STRIDES(kern)[3]/4,
-           PyGpuArray_STRIDES(kern)[2]/4,
-           PyGpuArray_STRIDES(kern)[1]/4,
-           PyGpuArray_STRIDES(kern)[0]/4
-           );
-
-        cudaError_t sts = cudaGetLastError();
-        if (cudaSuccess == sts) 
+        if (err == GA_NO_ERROR)
         {
             if (verbose) fprintf(stderr, "INFO: used 'conv_full_load_everything' version\n");
             work_complete = true;
@@ -1240,14 +1227,14 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
         {
             if (verbose)
               fprintf(stderr,
-                      "threads.x=%i, threads.y=%i, grid.x=%i, grid.y=%i,"
-                      " shared_size=%i, nb_threads=%i\n",
-                      threads.x, threads.y, grid.x, grid.y, shared_size,
-                      threads.x * threads.y);
+                      "threads_per_block[0]=%i, threads_per_block[1]=%i, n_blocks[0]=%i, n_blocks[1]=%i,"
+                      " shmem_sz=%i, nb_threads=%i\n",
+                      threads_per_block[0], threads_per_block[1], n_blocks[0], n_blocks[1], shmem_sz,
+                      threads_per_block[0] * threads_per_block[1]);
             if (verbose)
               fprintf(stderr, "INFO: impl 'conv_full_load_everything'"
                       " failed (%s), trying next implementation\n",
-                      cudaGetErrorString(sts));
+                      GpuKernel_error(&conv_full_load_everything_node_<<<<HASH_PLACEHOLDER>>>>_0, err));
         }
     }
 
@@ -1259,32 +1246,29 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
         img_size_byte+kern_size_byte<shared_avail && //their is only 16k of shared memory
         !work_complete) //conv_full_patch_stack
     {
-        dim3 threads(out_wid, out_len);
-        dim3 grid(nbatch,nkern);
-        int shared_size=(img_size + kern_size)*sizeof(float);
+        size_t threads_per_block[3] = {(size_t)out_wid, (size_t)out_len, (size_t)1};
+        size_t n_blocks[3] = {(size_t)nbatch, (size_t)nkern, (size_t)1};
+        size_t shmem_sz = (img_size + kern_size)*sizeof(float);
 
-        void (*f)(const float*, const float*, float*,
-                  int, int, int, int,
-                  int, int, int, int,
-                  int, int, int, int);
+        GpuKernel *k = NULL;
+        if(!img_contiguous_2d && !kern_contiguous_2d) k=&conv_full_patch_stack_0_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(!img_contiguous_2d && kern_contiguous_2d) k=&conv_full_patch_stack_1_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(img_contiguous_2d && !kern_contiguous_2d) k=&conv_full_patch_stack_2_node_<<<<HASH_PLACEHOLDER>>>>_0;
+        else if(img_contiguous_2d && kern_contiguous_2d) k=&conv_full_patch_stack_3_node_<<<<HASH_PLACEHOLDER>>>>_0;
 
-        if(!img_contiguous_2d && !kern_contiguous_2d) f=conv_full_patch_stack_0;
-        else if(!img_contiguous_2d && kern_contiguous_2d) f=conv_full_patch_stack_1;
-        else if(img_contiguous_2d && !kern_contiguous_2d) f=conv_full_patch_stack_2;
-        else if(img_contiguous_2d && kern_contiguous_2d) f=conv_full_patch_stack_3;
+        void *kernel_params[] = {
+            (void *)img->ga.data, (void *)&img->ga.offset,
+            (void *)kern->ga.data, (void *)&kern->ga.offset,
+            (void *)out->ga.data, (void *)&out->ga.offset,
+            (void *)&img_len, (void *)&img_wid,
+            (void *)&kern_len, (void *)&kern_wid,
+            (void *)&nkern, (void *)&nstack,
+            (void *)&img_stride_col, (void *)&img_stride_row,
+            (void *)&kern_stride_col, (void *)&kern_stride_row,
+            (void *)&kern_stride_stack, (void *)&kern_stride_nkern};
+        int err = GpuKernel_call(k, 3, threads_per_block, n_blocks, shmem_sz, kernel_params);
 
-        f<<< grid, threads, shared_size>>>(
-                cuda_get_ptr(img),
-                cuda_get_ptr(kern),
-                cuda_get_ptr(out),
-                img_len, img_wid,
-                kern_len, kern_wid,
-                nkern, nstack,img_stride_col, img_stride_row,
-                kern_stride_col, kern_stride_row,
-                kern_stride_stack, kern_stride_nkern);
-
-        cudaError_t sts = cudaGetLastError();
-        if (cudaSuccess == sts) 
+        if (err == GA_NO_ERROR)
         {
             if (verbose)
               fprintf(stderr, "INFO: used 'conv_full_patch_stack' version\n");
@@ -1294,23 +1278,26 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
         {
             if (verbose)
               fprintf(stderr,
-                      "threads.x=%i, threads.y=%i, grid.x=%i, grid.y=%i,"
-                      " shared_size=%i, nb_threads=%i\n",
-                      threads.x, threads.y, grid.x, grid.y,
-                      shared_size, threads.x * threads.y);
+                      "threads_per_block[0]=%i, threads_per_block[1]=%i, n_blocks[0]=%i, n_blocks[1]=%i,"
+                      " shmem_sz=%i, nb_threads=%i\n",
+                      threads_per_block[0], threads_per_block[1], n_blocks[0], n_blocks[1],
+                      shmem_sz, threads_per_block[0] * threads_per_block[1]);
             if (verbose)
               fprintf(stderr, "INFO: impl 'conv_full_patch_stack' failed (%s), trying next implementation\n",
-                      cudaGetErrorString(sts));
+                      GpuKernel_error(k, err));
         }                         
     }
     if (1 && !work_complete) //conv_reference_full
     {
         if(verbose>1) fprintf(stderr, "INFO: will start conv_reference_full\n");
 
-        int outsize = PyGpuArray_SIZE(out);
-        int n_blocks = std::min(outsize, 4096);
-        int n_threads = std::min(ceil_intdiv(outsize, n_blocks),
-                                 256);
+        size_t outsize = PyGpuArray_SIZE(out);
+        size_t n_blocks[3] = {std::min(outsize, (size_t)4096),
+                              (size_t)1, (size_t)1};
+        size_t threads_per_block[3] = {std::min(ceil_intdiv(outsize, n_blocks[0]),
+                                        (size_t)256),
+                               (size_t)1, (size_t)1};
+
         if (0)
         {
             if (verbose)
@@ -1318,70 +1305,67 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
             if (verbose)
               fprintf(stderr, "      img : %llu %llu %llu %llu %p  "
                       "%lld %lld %lld %lld\n",
-                      (unsigned long long)PyGpuArray_DIMS(img)[0],
-                      (unsigned long long)PyGpuArray_DIMS(img)[1],
-                      (unsigned long long)PyGpuArray_DIMS(img)[2],
-                      (unsigned long long)PyGpuArray_DIMS(img)[3],
-                      cuda_get_ptr(img),
-                      (long long)PyGpuArray_STRIDES(img)[0]/4,
-                      (long long)PyGpuArray_STRIDES(img)[1]/4,
-                      (long long)PyGpuArray_STRIDES(img)[2]/4,
-                      (long long)PyGpuArray_STRIDES(img)[3]/4);
+                      (unsigned long long)nbatch,
+                      (unsigned long long)stack_len,
+                      (unsigned long long)img_len,
+                      (unsigned long long)img_wid,
+                      (void *)(cuda_get_ptr(img->ga.data) + img->ga.offset),
+                      (long long)img_stride_batch,
+                      (long long)img_stride_stack,
+                      (long long)img_stride_row,
+                      (long long)img_stride_col);
             if (verbose)
               fprintf(stderr, "      kern: %llu %llu %llu %llu %p  "
                       "%lld %lld %lld %lld\n",
-                      (unsigned long long)PyGpuArray_DIMS(kern)[0],
-                      (unsigned long long)PyGpuArray_DIMS(kern)[1],
-                      (unsigned long long)PyGpuArray_DIMS(kern)[2],
-                      (unsigned long long)PyGpuArray_DIMS(kern)[3],
-                      cuda_get_ptr(kern),
-                      (long long)PyGpuArray_STRIDES(kern)[0]/4,
-                      (long long)PyGpuArray_STRIDES(kern)[1]/4,
-                      (long long)PyGpuArray_STRIDES(kern)[2]/4,
-                      (long long)PyGpuArray_STRIDES(kern)[3]/4
-                        );
+                      (unsigned long long)nkern,
+                      (unsigned long long)nstack,
+                      (unsigned long long)kern_len,
+                      (unsigned long long)kern_wid,
+                      (void *)(cuda_get_ptr(kern->ga.data) + kern->ga.offset),
+                      (long long)kern_stride_nkern,
+                      (long long)kern_stride_stack,
+                      (long long)kern_stride_row,
+                      (long long)kern_stride_col);
             if (verbose)
                 fprintf(stderr, "      out : %llu %llu %llu %llu %p  "
                         "%lld %lld %lld %lld\n",
                       (unsigned long long)PyGpuArray_DIMS(out)[0],
                       (unsigned long long)PyGpuArray_DIMS(out)[1],
-                      (unsigned long long)PyGpuArray_DIMS(out)[2],
-                      (unsigned long long)PyGpuArray_DIMS(out)[3],
-                      cuda_get_ptr(out),
-                      (long long)PyGpuArray_STRIDES(out)[0]/4,
-                      (long long)PyGpuArray_STRIDES(out)[1]/4,
-                      (long long)PyGpuArray_STRIDES(out)[2]/4,
-                      (long long)PyGpuArray_STRIDES(out)[3]/4);
+                      (unsigned long long)out_len,
+                      (unsigned long long)out_wid,
+                      (void *)(cuda_get_ptr(out->ga.data) + out->ga.offset),
+                      (long long)out_stride_batch,
+                      (long long)out_stride_nkern,
+                      (long long)out_stride_row,
+                      (long long)out_stride_col);
             if (verbose)
               fprintf(stderr, "   launch params: %i %i %i\n",
-                      outsize, n_blocks, n_threads);
+                      outsize, n_blocks[0], threads_per_block[0]);
             if (verbose)
                 fprintf(stderr, "   subsample params: %llu %llu\n",
                         (unsigned long long)subsample_rows,
                         (unsigned long long)subsample_cols);
         }
-        conv_reference_full<<<n_blocks, n_threads>>>(
-                PyGpuArray_DIMS(img)[0], PyGpuArray_DIMS(kern)[0],
-                PyGpuArray_DIMS(img)[1],
-                PyGpuArray_DIMS(img)[2], PyGpuArray_DIMS(img)[3],
-                PyGpuArray_DIMS(kern)[2], PyGpuArray_DIMS(kern)[3],
-                PyGpuArray_DIMS(out)[2], PyGpuArray_DIMS(out)[3],
-                cuda_get_ptr(img), PyGpuArray_STRIDES(img)[0]/4,
-                PyGpuArray_STRIDES(img)[1]/4,
-                PyGpuArray_STRIDES(img)[2]/4,
-                PyGpuArray_STRIDES(img)[3]/4,
-                cuda_get_ptr(kern), PyGpuArray_STRIDES(kern)[0]/4,
-                PyGpuArray_STRIDES(kern)[1]/4,
-                PyGpuArray_STRIDES(kern)[2]/4,
-                PyGpuArray_STRIDES(kern)[3]/4,
-                cuda_get_ptr(out), PyGpuArray_STRIDES(out)[0]/4,
-                PyGpuArray_STRIDES(out)[1]/4,
-                PyGpuArray_STRIDES(out)[2]/4,
-                PyGpuArray_STRIDES(out)[3]/4,
-                subsample_rows, subsample_cols);
 
-        cudaError_t sts = cudaGetLastError();
-        if (cudaSuccess == sts) 
+        void *kernel_params[] = {
+            (void *)&nbatch, (void *)&nkern, (void *)&stack_len,
+            (void *)&img_len, (void *)&img_wid,
+            (void *)&kern_len, (void *)&kern_wid,
+            (void *)&out_len, (void *)&out_wid,
+            (void *)img->ga.data, (void *)&img->ga.offset,
+            (void *)&img_stride_batch, (void *)&img_stride_stack,
+            (void *)&img_stride_row, (void *)&img_stride_col,
+            (void *)kern->ga.data, (void *)&kern->ga.offset,
+            (void *)&kern_stride_nkern, (void *)&kern_stride_stack,
+            (void *)&kern_stride_row, (void *)&kern_stride_col,
+            (void *)out->ga.data, (void *)&out->ga.offset,
+            (void *)&out_stride_batch, (void *)&out_stride_nkern,
+            (void *)&out_stride_row, (void *)&out_stride_col,
+            (void *)&subsample_rows, (void *)&subsample_cols};
+        int err = GpuKernel_call(&conv_reference_full_node_<<<<HASH_PLACEHOLDER>>>>_0,
+                                 3, threads_per_block, n_blocks, 0, kernel_params);
+
+        if (err == GA_NO_ERROR)
         {
             if (verbose)
               fprintf(stderr, "INFO: used 'conv_reference_full' version"
@@ -1394,17 +1378,18 @@ PyGpuArray_conv_full(const PyGpuArrayObject *img, const PyGpuArrayObject * kern,
         else
         {
           if (verbose)
-            fprintf(stderr, "threads.x=%i, threads.y=%i, grid.x=%i, grid.y=%i,"
-                    " shared_size=%i, nb_threads=%i\n",
-                    n_threads, 1, n_blocks, 1, 0, n_threads);
+            fprintf(stderr, "threads_per_block[0]=%i, threads_per_block[1]=%i,"
+                    " n_blocks[0]=%i, n_blocks[1]=%i,"
+                    " shmem_sz=%i, nb_threads=%i\n",
+                    threads_per_block[0], 1, n_blocks[0], 1, 0, threads_per_block[0]);
           if (verbose)
             fprintf(stderr, "INFO: impl 'conv_reference_full' failed (%s),"
                     " trying next implementation\n",
-                    cudaGetErrorString(sts));
+                    GpuKernel_error(&conv_reference_full_node_<<<<HASH_PLACEHOLDER>>>>_0, err));
           PyErr_Format(PyExc_RuntimeError,
                        "ERROR: all implementations failed for"
                        " CudaNdarray_conv_full! (%s)",
-                       cudaGetErrorString(sts));
+                       GpuKernel_error(&conv_reference_full_node_<<<<HASH_PLACEHOLDER>>>>_0, err));
           return -1;
         }
     }

--- a/theano/sandbox/gpuarray/conv.py
+++ b/theano/sandbox/gpuarray/conv.py
@@ -13,10 +13,10 @@ except ImportError:
 from six.moves import reduce
 from .comp import NVCC_compiler
 from .type import GpuArrayType
-from .basic_ops import (as_gpuarray_variable, GpuKernelBase, HideC, Kernel)
+from .basic_ops import (as_gpuarray_variable, GpuKernelBase, Kernel)
 from theano.gof import utils
 
-class GpuConv(GpuKernelBase, HideC, gof.Op):
+class GpuConv(GpuKernelBase, gof.Op):
     """
     Implement the batched and stacked 2d convolution on the gpu.
 

--- a/theano/sandbox/gpuarray/conv.py
+++ b/theano/sandbox/gpuarray/conv.py
@@ -330,11 +330,6 @@ class GpuConv(GpuKernelBase, gof.Op):
         code = code.replace('"', '\\"')
         code = code.replace('\n', '\\n')
         mod = """
-        template <typename T>
-        static T ceil_intdiv(T a, T b)
-        {
-            return (a/b) + ((a %% b) ? 1: 0);
-        }
         static const char conv_bcode[] = {%(bcode)s};
         static const char *conv_code = "%(code)s";
         """ % locals()

--- a/theano/sandbox/gpuarray/conv.py
+++ b/theano/sandbox/gpuarray/conv.py
@@ -241,7 +241,6 @@ class GpuConv(GpuKernelBase, HideC, gof.Op):
             raise MethodNotDefined('cuda only')
         cuda_root = config.cuda.root
         if cuda_root:
-            import os
             return [os.path.join(cuda_root, 'include')]
         else:
             return []

--- a/theano/sandbox/gpuarray/conv_full_kernel.cu
+++ b/theano/sandbox/gpuarray/conv_full_kernel.cu
@@ -122,7 +122,7 @@ conv_full_patch( const float* img, const float* kern, float* out,
 //template c_contiguous: if true, the img and kern have are column and row contiguous else we use the stride value from the param. The image need to be c_contiguous in the nbatch and nstack dimensions.
 
 template<bool img_c_contiguous_2d, bool kern_c_contiguous_2d>
-__global__ void
+__device__ inline void
 conv_full_patch_stack( const float* img, const float* kern, float* out,
                        int img_len, int img_wid,
                        int kern_len, int kern_wid, int nkern, int nstack,
@@ -182,6 +182,31 @@ conv_full_patch_stack( const float* img, const float* kern, float* out,
         out_row*out_wid+out_col] = sum;
 }
 
+extern "C" {
+#define __INSTANTIATE_CONV_FULL_PATCH_STACK(suffix, ...) \
+__global__ void \
+conv_full_patch_stack_##suffix( \
+    const float *img, const float *kern, float *out, \
+    int img_len, int img_wid, \
+    int kern_len, int kern_wid, int nkern, int nstack, \
+    int img_stride_col, int img_stride_row, \
+    int kern_stride_col, int kern_stride_row,  \
+    int kern_stride_stack, int kern_stride_nkern) \
+{ \
+    conv_full_patch_stack<__VA_ARGS__>( \
+        img, kern, out, img_len, img_wid, kern_len, kern_wid, nkern, nstack, \
+        img_stride_col, img_stride_row, kern_stride_col, kern_stride_row,  \
+        kern_stride_stack, kern_stride_nkern); \
+}
+
+__INSTANTIATE_CONV_FULL_PATCH_STACK(0, false, false)
+__INSTANTIATE_CONV_FULL_PATCH_STACK(1, false, true)
+__INSTANTIATE_CONV_FULL_PATCH_STACK(2, true, false)
+__INSTANTIATE_CONV_FULL_PATCH_STACK(3, true, true)
+
+#undef __INSTANTIATE_CONV_FULL_PATCH_STACK
+}
+
 /**
  * As conv_patch_stack, but used for the full convolution by padding the image in shared memory.
  * I keep it separated from conv_patch as we take 19-20 register which is more than the 10/16 max for each thread and thus this could lower the occupency.
@@ -200,8 +225,8 @@ conv_full_patch_stack( const float* img, const float* kern, float* out,
  * template low_mem: if true, as split but with use less dynamic shared memory but use more registers.
  *          if you set split and low_mem to true, we will use the low_mem version!
  */
-template<bool flipped_kern, int KERN_WIDTH, bool c_contiguous, bool split, bool low_mem >
-__global__ void
+template<bool flipped_kern, bool c_contiguous, bool split, bool low_mem >
+__device__ inline void
 conv_full_patch_stack_padded( const float* img, const float* kern, float* out,
                   const int img_len, const int img_wid,
                   const int kern_len, const int kern_wid,
@@ -257,7 +282,7 @@ conv_full_patch_stack_padded( const float* img, const float* kern, float* out,
           const float* idx_kern=&d_kern[row*kern_wid];
           const float* idx_in=&d_img[(row+out_row)*img_wid_valid+out_col];
           
-          convolutionRowNoFlip<KERN_WIDTH>(sum, idx_kern, idx_in, kern_wid);
+          convolutionRowNoFlip(sum, idx_kern, idx_in, kern_wid);
         }
       }
       out[batch_id*out_wid*out_len*nkern+//the good batch
@@ -292,7 +317,7 @@ conv_full_patch_stack_padded( const float* img, const float* kern, float* out,
               const float* idx_kern=&d_kern[row*kern_wid];
               const float* idx_in=&d_img[(row+out_row)*img_wid_valid+out_col];
               
-              convolutionRowNoFlip<KERN_WIDTH>(sum, idx_kern, idx_in, kern_wid);
+              convolutionRowNoFlip(sum, idx_kern, idx_in, kern_wid);
             }
           if(out_row<out_len)
             out[batch_id*out_wid*out_len*nkern+//the good batch
@@ -340,7 +365,7 @@ conv_full_patch_stack_padded( const float* img, const float* kern, float* out,
             const float* idx_kern=&d_kern[row*kern_wid];
             const float* idx_in=&d_img[(row+out_row-out_row_iter*nb_rows)*img_wid_valid+out_col];
             
-            convolutionRowNoFlip<KERN_WIDTH>(sum, idx_kern, idx_in, kern_wid);
+            convolutionRowNoFlip(sum, idx_kern, idx_in, kern_wid);
           }
         }
         if(out_row<out_len)
@@ -349,6 +374,42 @@ conv_full_patch_stack_padded( const float* img, const float* kern, float* out,
               out_row*out_wid+out_col] = sum;
       }
     }
+}
+
+extern "C" {
+#define __INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(suffix, ...) \
+__global__ void \
+conv_full_patch_stack_padded_##suffix( \
+    const float *img, const float *kern, float *out, \
+    const int img_len, const int img_wid, \
+    const int kern_len, const int kern_wid, \
+    const int nkern, const int nstack, \
+    const int img_stride_col, const int img_stride_row, \
+    const int img_stride_stack, const int img_stride_batch, \
+    const int kern_stride_col, const int kern_stride_row, \
+    const int kern_stride_stack, const int kern_stride_nkern) \
+{ \
+    conv_full_patch_stack_padded<__VA_ARGS__>( \
+        img, kern, out, img_len, img_wid, kern_len, kern_wid, nkern, nstack, \
+        img_stride_col, img_stride_row, img_stride_stack, img_stride_batch, \
+        kern_stride_col, kern_stride_row, \
+        kern_stride_stack, kern_stride_nkern); \
+}
+
+__INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(0, false, false, false, false)
+__INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(1, false, false, false, true)
+__INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(2, false, false, true, false)
+__INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(4, false, true, false, false)
+__INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(5, false, true, false, true)
+__INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(6, false, true, true, false)
+__INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(8, true, false, false, false)
+__INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(9, true, false, false, true)
+__INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(10, true, false, true, false)
+__INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(12, true, true, false, false)
+__INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(13, true, true, false, true)
+__INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED(14, true, true, true, false)
+
+#undef __INSTANTIATE_CONV_FULL_PATCH_STACK_PADDED
 }
 
 template <int i> __device__ float everything_dot(const float * x, const int sx, const float * y, const int sy) 
@@ -364,7 +425,6 @@ template <> __device__ float everything_dot<1>(const float * x, const int sx, co
 { 
     return x[0] * y[0];
 }
-template<int NSTACK>
 __global__ void
 conv_full_load_everything( const float* img, const float* kern, float* out,
                  int img_len, int img_wid,
@@ -423,9 +483,9 @@ conv_full_load_everything( const float* img, const float* kern, float* out,
             {
                 int icol = out_col - kern_wid+1+col;
                 if (icol < 0 || icol > img_wid) continue;
-                if (NSTACK > 0)
+                if (THEANO_KERN_WID > 0)
                 {
-                    sum += everything_dot<NSTACK>(d_img + irow*img_wid + icol, img_len*img_wid,
+                    sum += everything_dot<THEANO_KERN_WID>(d_img + irow*img_wid + icol, img_len*img_wid,
                             d_kern + row*kern_wid+col, kern_len*kern_wid);
                 }
                 else

--- a/theano/sandbox/gpuarray/elemwise.py
+++ b/theano/sandbox/gpuarray/elemwise.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import copy
+import os
 from theano.compat import izip
 import numpy
 
@@ -177,7 +178,6 @@ class GpuElemwise(GpuKernelBase, HideC, Elemwise):
             raise MethodNotDefined('cuda only')
         cuda_root = config.cuda.root
         if cuda_root:
-            import os
             return [os.path.join(cuda_root, 'include')]
         else:
             return []
@@ -735,7 +735,6 @@ class GpuCAReduceCuda(GpuKernelBase, HideC, CAReduceDtype):
     def c_header_dirs(self):
         cuda_root = config.cuda.root
         if cuda_root:
-            import os
             return [os.path.join(cuda_root, 'include')]
 
     def c_headers(self):

--- a/theano/sandbox/gpuarray/neighbours.py
+++ b/theano/sandbox/gpuarray/neighbours.py
@@ -1,3 +1,4 @@
+import os
 import numpy
 
 from theano import Op, Apply, config
@@ -12,13 +13,14 @@ except ImportError:
     pass
 
 from .basic_ops import (as_gpuarray_variable,
-                        host_from_gpu, gpu_from_host)
+                        host_from_gpu, gpu_from_host,
+                        GpuKernelBase, Kernel)
 from .opt import register_opt as register_gpu_opt, op_lifter
 from .type import GpuArrayType
 from .comp import NVCC_compiler
 
 
-class GpuImages2Neibs(Images2Neibs, Op):
+class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
     def __init__(self, mode='valid'):
         if mode not in ['valid', 'ignore_borders', 'wrap_centered']:
             raise NotImplementedError("Only the mode valid, ignore_borders"
@@ -43,25 +45,42 @@ class GpuImages2Neibs(Images2Neibs, Op):
                                    dtype=ten4.type.dtype)()])
 
     def c_code_cache_version(self):
-        return (9, 1)
+        return (10,1)
 
     def c_headers(self):
+        if pygpu.get_default_context().kind == 'opencl':
+            raise MethodNotDefined('cuda only')
         return ['cuda.h', '<gpuarray/extension.h>', '<numpy_compat.h>',
-                '<gpuarray/ext_cuda.h>']
+                '<gpuarray/ext_cuda.h>', '<gpuarray/types.h>']
 
-    def c_compiler(self):
-        return NVCC_compiler
+    def c_header_dirs(self):
+        if pygpu.get_default_context().kind == 'opencl':
+            raise MethodNotDefined('cuda only')
+        cuda_root = config.cuda.root
+        if cuda_root:
+            import os
+            return [os.path.join(cuda_root, 'include')]
+        else:
+            return []
 
     def c_init_code(self):
+        if pygpu.get_default_context().kind == 'opencl':
+            raise MethodNotDefined('cuda only')
         return ['setup_ext_cuda();']
 
-    def c_support_code_apply(self, node, nodename):
+    def gpu_kernels(self, node, nodename):
         dtype_ten4 = node.inputs[0].dtype
         dtype_z = node.outputs[0].dtype
+        flags = Kernel.get_flags(dtype_ten4, dtype_z)
+        type_ten4 = gpuarray.dtype_to_ctype(dtype_ten4)
+        type_z = gpuarray.dtype_to_ctype(dtype_z)
         mode = self.mode
-        return """
+        kernels = []
+        kname = "k_multi_warp_less"
+        k_var = "k_multi_warp_less_" + nodename
+        code = """
 //a version that use less register but don't work in all case.
-        static __global__ void k_multi_warp_less_%(nodename)s(
+        KERNEL void %(kname)s(
             const int nb_batch,
             const int nb_stack,
             const int height,
@@ -72,15 +91,17 @@ class GpuImages2Neibs(Images2Neibs, Op):
             const int step_y,
             const int grid_c,
             const int grid_d,
-            const int stride0, const int stride1,
-            const int stride2, const int stride3,
-            npy_%(dtype_ten4)s * global_ten4,
-            const int out_s0, const int out_s1,
-            npy_%(dtype_z)s * global_out
+            const size_t stride0, const size_t stride1,
+            const size_t stride2, const size_t stride3,
+            const %(type_ten4)s * global_ten4, const size_t offset_ten4,
+            const size_t out_s0, const size_t out_s1,
+            %(type_z)s * global_out, const size_t offset_out
         )
         {
             const int wrap_centered_idx_shift_x = c/2;
             const int wrap_centered_idx_shift_y = d/2;
+            global_ten4 = (const %(type_ten4)s *)(((char *)global_ten4)+offset_ten4);
+            global_out = (%(type_z)s *)(((char *)global_out)+offset_out);
 
             for(int tblock = blockIdx.x*blockDim.z+threadIdx.z;
                 tblock<nb_batch*nb_stack*grid_c*grid_d;
@@ -131,9 +152,22 @@ class GpuImages2Neibs(Images2Neibs, Op):
                                 }
                             }
             }
-        }
+        }""" % locals()
+        params = [
+            'intc', 'intc', 'intc', 'intc', 'intc', 'intc',
+            'intc', 'intc', 'intc', 'intc',
+            'uintp', 'uintp', 'uintp', 'uintp',
+            gpuarray.GpuArray, 'uintp',
+            'uintp', 'uintp',
+            gpuarray.GpuArray, 'uintp',
+            ]
+        kernels.append(Kernel(code=code, name=kname, params=params,
+                              flags=flags, objvar=k_var))
 
-        static __global__ void k_multi_warp_%(nodename)s(
+        kname = "k_multi_warp"
+        k_var = "k_multi_warp_" + nodename
+        code = """
+        KERNEL void %(kname)s(
             const int nb_batch,
             const int nb_stack,
             const int height,
@@ -144,15 +178,17 @@ class GpuImages2Neibs(Images2Neibs, Op):
             const int step_y,
             const int grid_c,
             const int grid_d,
-            const int stride0, const int stride1,
-            const int stride2, const int stride3,
-            npy_%(dtype_ten4)s * global_ten4,
-            const int out_s0, const int out_s1,
-            npy_%(dtype_z)s * global_out
+            const size_t stride0, const size_t stride1,
+            const size_t stride2, const size_t stride3,
+            const %(type_ten4)s * global_ten4, const size_t offset_ten4,
+            const size_t out_s0, const size_t out_s1,
+            %(type_z)s * global_out, const size_t offset_out
         )
         {
             const int wrap_centered_idx_shift_x = c/2;
             const int wrap_centered_idx_shift_y = d/2;
+            global_ten4 = (const %(type_ten4)s *)(((char *)global_ten4)+offset_ten4);
+            global_out = (%(type_z)s *)(((char *)global_out)+offset_out);
 
             for(int tblock = blockIdx.x*blockDim.z+threadIdx.z;
                 tblock<nb_batch*nb_stack*grid_c*grid_d;
@@ -207,6 +243,17 @@ class GpuImages2Neibs(Images2Neibs, Op):
             }
         }
         """ % locals()
+        params = [
+            'intc', 'intc', 'intc', 'intc', 'intc', 'intc',
+            'intc', 'intc', 'intc', 'intc',
+            'uintp', 'uintp', 'uintp', 'uintp',
+            gpuarray.GpuArray, 'uintp',
+            'uintp', 'uintp',
+            gpuarray.GpuArray, 'uintp',
+            ]
+        kernels.append(Kernel(code=code, name=kname, params=params,
+                              flags=flags, objvar=k_var))
+        return kernels
 
     def c_code(self, node, name, inp, out, sub):
         dtype_ten4 = node.inputs[0].dtype
@@ -220,15 +267,21 @@ class GpuImages2Neibs(Images2Neibs, Op):
         z, = out
         fail = sub['fail']
         mode = self.mode
+        err_check = """
+            if (err != GA_NO_ERROR) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "gpuarray error: *fptr: %%s.",
+                             GpuKernel_error(fptr, err));
+                %(fail)s;
+            }
+        """ % locals()
+        sync = ""
         if config.gpuarray.sync:
-            cnda_thread_sync = "GpuArray_sync(&%(z)s->ga);" % dict(z=z)
-        else:
-            cnda_thread_sync = ""
+            sync = """
+            err = GpuArray_sync(&%(z)s->ga);
+            %(err_check)s
+            """ % locals()
         return """
-#ifndef CEIL_INTDIV
-#define CEIL_INTDIV(a, b) ((a/b) + ((a %% b) ? 1: 0))
-#endif
-
         int grid_c = -1;
         int grid_d = -1;
 
@@ -281,10 +334,10 @@ class GpuImages2Neibs(Images2Neibs, Op):
                                  PyGpuArray_DIMS(%(ten4)s)[3]);
                     %(fail)s;
                 }
-                grid_c = CEIL_INTDIV(((PyGpuArray_DIMS(%(ten4)s))[2]),
-                                     step_x);
-                grid_d = CEIL_INTDIV(((PyGpuArray_DIMS(%(ten4)s))[3]),
-                                     step_y);
+                grid_c = ceil_intdiv(((PyGpuArray_DIMS(%(ten4)s))[2]),
+                                     (size_t)step_x);
+                grid_d = ceil_intdiv(((PyGpuArray_DIMS(%(ten4)s))[3]),
+                                     (size_t)step_y);
 
 
             }else if ( "%(mode)s" == "valid") {
@@ -367,75 +420,57 @@ class GpuImages2Neibs(Images2Neibs, Op):
             const npy_intp step_y = (npy_intp) *(npy_%(dtype_neib_step)s*)
                                          PyArray_GETPTR1(%(neib_step)s, 1);
 
-            dim3 n_threads(d,c,1);
+            size_t threads_per_block[3] = {d, c, 1};
             //Their is a max of 512 threads per blocks
-            while(n_threads.x*n_threads.y>512 && n_threads.y>1)n_threads.y--;
-            while(n_threads.x*n_threads.y>512 && n_threads.x>1)n_threads.x--;
+            while(threads_per_block[0]*threads_per_block[1]>512 && threads_per_block[1]>1)threads_per_block[1]--;
+            while(threads_per_block[0]*threads_per_block[1]>512 && threads_per_block[0]>1)threads_per_block[0]--;
 
             //Make bigger block to have better memory access pattern and
             //a higher core utilisation. for smaller patch size
 
-            while(c*d*(n_threads.z+1) < 128 && n_threads.z<64 &&
-                  n_threads.z<PyGpuArray_DIMS(%(z)s)[0]){
-                n_threads.z++;
+            while(c*d*(threads_per_block[2]+1) < 128 && threads_per_block[2]<64 &&
+                  threads_per_block[2]<PyGpuArray_DIMS(%(z)s)[0]){
+                threads_per_block[2]++;
             }
             int nb_block;
-            if (PyGpuArray_DIMS(%(z)s)[0] %% n_threads.z == 0)
-                nb_block = PyGpuArray_DIMS(%(z)s)[0] / n_threads.z;
+            if (PyGpuArray_DIMS(%(z)s)[0] %% threads_per_block[2] == 0)
+                nb_block = PyGpuArray_DIMS(%(z)s)[0] / threads_per_block[2];
             else
-                nb_block = (PyGpuArray_DIMS(%(z)s)[0] / n_threads.z) + 1;
-            dim3 n_blocks(std::min(32*1024,nb_block));
-            int n_shared = 0;
+                nb_block = (PyGpuArray_DIMS(%(z)s)[0] / threads_per_block[2]) + 1;
+            size_t n_blocks[3] = {std::min(32*1024,nb_block), 1, 1};
 
-            void (*f)(int, int, int ,int,
-                      int, int, int ,int,
-                      int, int,
-                      int, int, int, int,
-                      npy_%(dtype_ten4)s*,
-                      int, int,
-                      npy_%(dtype_z)s*);
-            if(n_threads.x==d && n_threads.y==c){
-                f = k_multi_warp_less_%(name)s;
+            GpuKernel *fptr;
+            if(threads_per_block[0]==d && threads_per_block[1]==c){
+                fptr = &k_multi_warp_less_%(name)s;
             }else{
-                f = k_multi_warp_%(name)s;
+                fptr = &k_multi_warp_%(name)s;
             }
 
-            f<<<n_blocks, n_threads, n_shared>>>(
-                nb_batch,
-                nb_stack,
-                height, width,
-                c, d, step_x, step_y,
-                grid_c, grid_d,
-                PyGpuArray_STRIDES(%(ten4)s)[0] / %(itemsize_ten4)s,
-                PyGpuArray_STRIDES(%(ten4)s)[1] / %(itemsize_ten4)s,
-                PyGpuArray_STRIDES(%(ten4)s)[2] / %(itemsize_ten4)s,
-                PyGpuArray_STRIDES(%(ten4)s)[3] / %(itemsize_ten4)s,
-                (npy_%(dtype_ten4)s*)(
-                                ((char *)cuda_get_ptr(%(ten4)s->ga.data)) +
-                                %(ten4)s->ga.offset),
-                PyGpuArray_STRIDES(%(z)s)[0] / %(itemsize_z)s,
-                PyGpuArray_STRIDES(%(z)s)[1] / %(itemsize_z)s,
-                (npy_%(dtype_z)s*)(((char *)cuda_get_ptr(%(z)s->ga.data)) +
-                                   %(z)s->ga.offset)
-            );
-            %(cnda_thread_sync)s
-            cudaError_t sts = cudaGetLastError();
-            if (cudaSuccess != sts)
-            {
-                PyErr_Format(PyExc_RuntimeError, "GpuImages2Neibs:"
-                             " Cuda error: %%s: %%s. (grid: %%i x %%i;"
-                             " block: %%i x %%i x %%i; shared: %%i)\\n",
-                    "k_multi_warp_%(name)s",
-                    cudaGetErrorString(sts),
-                    n_blocks.x,
-                    n_blocks.y,
-                    n_threads.x,
-                    n_threads.y,
-                    n_threads.z,
-                    n_shared);
-                %(fail)s;
-            }
-
+            size_t stride_A0 = PyGpuArray_STRIDES(%(ten4)s)[0] / %(itemsize_ten4)s;
+            size_t stride_A1 = PyGpuArray_STRIDES(%(ten4)s)[1] / %(itemsize_ten4)s;
+            size_t stride_A2 = PyGpuArray_STRIDES(%(ten4)s)[2] / %(itemsize_ten4)s;
+            size_t stride_A3 = PyGpuArray_STRIDES(%(ten4)s)[3] / %(itemsize_ten4)s;
+            size_t stride_Z0 = PyGpuArray_STRIDES(%(z)s)[0] / %(itemsize_z)s;
+            size_t stride_Z1 = PyGpuArray_STRIDES(%(z)s)[1] / %(itemsize_z)s;
+            void *kernel_params[] = {(void *)&nb_batch,
+                                     (void *)&nb_stack,
+                                     (void *)&height, (void *)&width,
+                                     (void *)&c, (void *)&d,
+                                     (void *)&step_x, (void *)&step_y,
+                                     (void *)&grid_c, (void *)&grid_d,
+                                     (void *)&stride_A0,
+                                     (void *)&stride_A1,
+                                     (void *)&stride_A2,
+                                     (void *)&stride_A3,
+                                     (void *)%(ten4)s->ga.data,
+                                     (void *)&%(ten4)s->ga.offset,
+                                     (void *)&stride_Z0,
+                                     (void *)&stride_Z1,
+                                     (void *)%(z)s->ga.data,
+                                     (void *)&%(z)s->ga.offset};
+            int err = GpuKernel_call(fptr, 3, threads_per_block, n_blocks, 0, kernel_params);
+            %(err_check)s
+            %(sync)s
         } // END NESTED SCOPE
         """ % locals()
 

--- a/theano/sandbox/gpuarray/neighbours.py
+++ b/theano/sandbox/gpuarray/neighbours.py
@@ -58,7 +58,6 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
             raise MethodNotDefined('cuda only')
         cuda_root = config.cuda.root
         if cuda_root:
-            import os
             return [os.path.join(cuda_root, 'include')]
         else:
             return []

--- a/theano/sandbox/gpuarray/nnet.py
+++ b/theano/sandbox/gpuarray/nnet.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import numpy
+import os
 
 from theano import Op, Apply, config
 from six import StringIO
@@ -45,7 +46,6 @@ class GpuCrossentropySoftmaxArgmax1HotWithBias(GpuKernelBase, Op):
             raise MethodNotDefined('cuda only')
         cuda_root = config.cuda.root
         if cuda_root:
-            import os
             return [os.path.join(cuda_root, 'include')]
 
     def c_headers(self):
@@ -335,7 +335,6 @@ class GpuCrossentropySoftmax1HotWithBiasDx(GpuKernelBase, Op):
             raise MethodNotDefined('cuda only')
         cuda_root = config.cuda.root
         if cuda_root:
-            import os
             return [os.path.join(cuda_root, 'include')]
 
     def c_headers(self):
@@ -549,7 +548,6 @@ class GpuSoftmax (GpuKernelBase, Op):
             raise MethodNotDefined('cuda only')
         cuda_root = config.cuda.root
         if cuda_root:
-            import os
             return [os.path.join(cuda_root, 'include')]
 
     def c_headers(self):
@@ -754,7 +752,6 @@ class GpuSoftmaxWithBias (GpuKernelBase, Op):
             raise MethodNotDefined('cuda only')
         cuda_root = config.cuda.root
         if cuda_root:
-            import os
             return [os.path.join(cuda_root, 'include')]
         else:
             return []

--- a/theano/sandbox/gpuarray/subtensor.py
+++ b/theano/sandbox/gpuarray/subtensor.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import copy
 import numpy
+import os
 
 import theano
 from theano import tensor, gof, Op, config
@@ -180,7 +181,6 @@ class GpuIncSubtensor(GpuKernelBase, IncSubtensor):
     def c_header_dirs(self):
         cuda_root = config.cuda.root
         if cuda_root:
-            import os
             return [os.path.join(cuda_root, 'include')]
         else:
             return []
@@ -550,7 +550,6 @@ class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, GpuAdvancedIncSubtensor1):
             raise MethodNotDefined('cuda only')
         cuda_root = config.cuda.root
         if cuda_root:
-            import os
             return [os.path.join(cuda_root, 'include')]
 
     def c_init_code(self):


### PR DESCRIPTION
Currently, the gpuarray back end of Theano uses a mixture of libgpuarray and nvcc, which is slow for online compilation.  We can speed up the GPU code compilation using libgpuarray API alone without nvcc, especially when libgpuarray is built with the nvrtc support (see https://github.com/Theano/libgpuarray/pull/72).

This hopefully helps managing GPU related code in Theano and libgpuarray by having vendor specific implementation only in libgpuarray.