### PR TITLE
Add a 'name' argument to '.copy' method of Theano variables

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2815,8 +2815,11 @@ alloc = Alloc()
 pprint.assign(alloc, printing.FunctionPrinter('alloc'))
 
 
-"""Create a duplicate of `a` (with duplicated storage)"""
-tensor_copy = elemwise.Elemwise(scal.identity)
+@constructor
+def tensor_copy(input):
+    """Create a duplicate of a tensor `input` with duplicated storage."""
+    return elemwise.Elemwise(scal.identity)(input)
+
 pprint.assign(tensor_copy, printing.IgnorePrinter())
 
 

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2815,7 +2815,6 @@ alloc = Alloc()
 pprint.assign(alloc, printing.FunctionPrinter('alloc'))
 
 
-@constructor
 def tensor_copy(input):
     """Create a duplicate of a tensor `input` with duplicated storage."""
     return elemwise.Elemwise(scal.identity)(input)

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2819,7 +2819,7 @@ def tensor_copy(input):
     """Create a duplicate of a tensor `input` with duplicated storage."""
     return elemwise.Elemwise(scal.identity)(input)
 
-pprint.assign(tensor_copy, printing.IgnorePrinter())
+pprint.assign(elemwise.Elemwise(scal.identity), printing.IgnorePrinter())
 
 
 @constructor

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2815,11 +2815,9 @@ alloc = Alloc()
 pprint.assign(alloc, printing.FunctionPrinter('alloc'))
 
 
-def tensor_copy(input):
-    """Create a duplicate of a tensor `input` with duplicated storage."""
-    return elemwise.Elemwise(scal.identity)(input)
-
-pprint.assign(elemwise.Elemwise(scal.identity), printing.IgnorePrinter())
+"""Create a duplicate of `a` (with duplicated storage)"""
+tensor_copy = elemwise.Elemwise(scal.identity)
+pprint.assign(tensor_copy, printing.IgnorePrinter())
 
 
 @constructor

--- a/theano/tensor/tests/test_var.py
+++ b/theano/tensor/tests/test_var.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal, assert_string_equal
 
 import theano
 import theano.tensor as tt
@@ -19,3 +20,14 @@ def test_numpy_method():
         f = theano.function([x], y)
         utt.assert_allclose(np.nan_to_num(f(data)),
                             np.nan_to_num(fct(data)))
+
+
+def test_copy():
+    x = tt.matrix('x')
+    data = np.random.rand(5, 5)
+    y = x.copy(name='y')
+    f = theano.function([x], y)
+    assert_equal(f(data), data)
+    assert_string_equal(y.name, 'y')
+
+

--- a/theano/tensor/tests/test_var.py
+++ b/theano/tensor/tests/test_var.py
@@ -29,5 +29,3 @@ def test_copy():
     f = theano.function([x], y)
     assert_equal(f(data), data)
     assert_string_equal(y.name, 'y')
-
-

--- a/theano/tensor/tests/test_var.py
+++ b/theano/tensor/tests/test_var.py
@@ -23,7 +23,7 @@ def test_numpy_method():
 
 
 def test_copy():
-    x = tt.matrix('x')
+    x = tt.dmatrix('x')
     data = np.random.rand(5, 5)
     y = x.copy(name='y')
     f = theano.function([x], y)

--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -521,7 +521,7 @@ class _tensor_py_operators:
 
     # COPYING
     def copy(self, name=None):
-        """Copy a variable and set a name to the copy."""
+        """Copy a variable and optionally assign a name."""
         copied_variable = theano.tensor.basic.tensor_copy(self)
         copied_variable.name = name
         return copied_variable

--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -520,8 +520,11 @@ class _tensor_py_operators:
         return theano.tensor.subtensor.take(self, indices, axis, mode)
 
     # COPYING
-    def copy(self):
-        return theano.tensor.basic.tensor_copy(self)
+    def copy(self, name=None):
+        """Copy a variable and set a name to the copy."""
+        copied_variable = theano.tensor.basic.tensor_copy(self)
+        copied_variable.name = name
+        return copied_variable
 
     def __iter__(self):
         try:


### PR DESCRIPTION
Fixes #3273.