### PR TITLE
Scan inplace opt

### DIFF
--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -1030,7 +1030,7 @@ class ScanInplaceOptimizer(Optimizer):
         op = node.op
 
         info = copy.deepcopy(op.info)
-        if not 'destroy_map' in info:
+        if 'destroy_map' not in info:
             info['destroy_map'] = OrderedDict()
 
         for out_idx in output_indices:
@@ -1064,10 +1064,9 @@ class ScanInplaceOptimizer(Optimizer):
                 remove=[node],
                 reason='scanOp_make_inplace')
             return new_outs[0].owner
-        except InconsistencyError as e:
+        except InconsistencyError:
             # Failed moving output to be computed inplace
             return node
-
 
     def apply(self, fgraph):
 


### PR DESCRIPTION
This is work in progress to attempt to speed up the ScanInplaceOptimizer() since some users have been reporting a lot of time being spent in this optimization.

Instead of trying to make the scan compute every output inplace one by one, this starts by attempting to make scan compute all its outputs inplace. It is doesn't work then it goes back to trying every output one by one.

