### PR TITLE
Fix a non-ascii character in a comment in test_flake8.py.

### DIFF
--- a/theano/tests/test_flake8.py
+++ b/theano/tests/test_flake8.py
@@ -20,7 +20,7 @@ __contact__ = "Saizheng Zhang <saizhenglisa..at..gmail.com>"
 # We ignore:
 # - "line too long"
 #    too complex to do with the C code
-# - "closing bracket does not match indentation of opening bracket’s line"
+# - "closing bracket does not match indentation of opening bracket's line"
 #    ignored by default by pep8
 ignore = ('E501', 'E123', 'E133')
 


### PR DESCRIPTION
Apparently the python on travis doesn't care, but my version of python complains about this.