### PR TITLE
automatic gpu selection no longer works in CUDA-TK 7.0

### DIFF
--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -399,9 +399,9 @@ def use(device,
 
         # Has PyCUDA already initialized the GPU context
         pycuda_init_dev = False
-        if config.pycuda.init:
-            import theano.misc.pycuda_init
-            pycuda_init_dev = theano.misc.pycuda_init.pycuda_available
+#        if config.pycuda.init:
+#            import theano.misc.pycuda_init
+#            pycuda_init_dev = theano.misc.pycuda_init.pycuda_available
 
         try:
             if (device != 'gpu') and not pycuda_init_dev:

--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -399,9 +399,9 @@ def use(device,
 
         # Has PyCUDA already initialized the GPU context
         pycuda_init_dev = False
-#        if config.pycuda.init:
-#            import theano.misc.pycuda_init
-#            pycuda_init_dev = theano.misc.pycuda_init.pycuda_available
+        if config.pycuda.init:
+            import theano.misc.pycuda_init
+            pycuda_init_dev = theano.misc.pycuda_init.pycuda_available
 
         try:
             if (device != 'gpu') and not pycuda_init_dev:

--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -404,7 +404,11 @@ def use(device,
             pycuda_init_dev = theano.misc.pycuda_init.pycuda_available
 
         try:
-            if (device != 'gpu') and not pycuda_init_dev:
+            if pycuda_init_dev:
+                use.device_number = active_device_number()
+                # This is needed to initialize the cublas handle.
+                gpu_init(use.device_number, config.lib.cnmem)
+            elif(device != 'gpu'):
                 assert isinstance(device, int)
                 gpu_init(device, config.lib.cnmem)
                 use.device_number = device


### PR DESCRIPTION
- fixing an issue introduced with CUDA-TK 7.0, when automatic selection
  of free gpu by os / library no longer works. Library always selects '0',
  which leads to crash in case of 'exclusive mode' when '0' is taken and 
  other gpus are free.
- this fix is inspired by Dan Povey's fix for Kaldi:
  kaldi-asr/kaldi@6548565
- it does a loop over gpus until a free gpu is taken.
- pycuda initialization was also affected by the bug from CUDA 7.0, so it is better to disable it.