### PR TITLE
Fix Sphinx markup in docs

### DIFF
--- a/doc/install.txt
+++ b/doc/install.txt
@@ -123,8 +123,8 @@ A contributor made rpm package for Mandriva_ 2010.2 of Theano 0.3.1.
 Docker images
 ~~~~~~~~~~~~~
 
-Builds of Theano are available as `Docker <https://www.docker.com/whatisdocker>`_ images: `Theano Docker (CPU)
-<https://hub.docker.com/r/kaixhin/theano/>`_ or `Theano Docker (CUDA)<https://hub.docker.com/r/kaixhin/cuda-theano/>`_.
+Builds of Theano are available as `Docker <https://www.docker.com/whatisdocker>`_ images:
+`Theano Docker (CPU) <https://hub.docker.com/r/kaixhin/theano/>`_ or `Theano Docker (CUDA) <https://hub.docker.com/r/kaixhin/cuda-theano/>`_.
 These are updated on a weekly basis with bleeding-edge builds of Theano. Examples of running bash in a Docker container
 are as follows:
 
@@ -133,8 +133,8 @@ are as follows:
     sudo docker run -it kaixhin/theano
     sudo docker run -it --device /dev/nvidiactl --device /dev/nvidia-uvm --device /dev/nvidia0 kaixhin/cuda-theano:7.0
 
-For a guide to Docker, see the `official docs<https://docs.docker.com/userguide/>`_. For more details on how to use the
-Theano Docker images, including requirements for CUDA support, consult the `source project<https://github.com/Kaixhin/dockerfiles>`_.
+For a guide to Docker, see the `official docs <https://docs.docker.com/userguide/>`_. For more details on how to use the
+Theano Docker images, including requirements for CUDA support, consult the `source project <https://github.com/Kaixhin/dockerfiles>`_.
 
 Basic user install instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes an error in the markup (spacing for links in reStructuredText) introduced in pull https://github.com/Theano/Theano/pull/3399.