### PR TITLE
Implement DownsampleFactorMax.R_op 

### DIFF
--- a/theano/sandbox/cuda/blas.py
+++ b/theano/sandbox/cuda/blas.py
@@ -2214,6 +2214,204 @@ class GpuDownsampleFactorMax(GpuOp):
         }
         """ % locals()
 
+class GpuDownsampleFactorMaxRop(GpuOp):
+    """
+    Implement rop for downsample with max on the gpu.
+    """
+    def __init__(self, ds, ignore_border=False):
+        self.ds = tuple(ds)
+        self.ignore_border = ignore_border
+
+    def __eq__(self, other):
+        return (type(self) == type(other) and
+                self.ds == other.ds and
+                self.ignore_border == other.ignore_border)
+
+    def __hash__(self):
+        return hash(type(self)) ^ hash(self.ds) ^ hash(self.ignore_border)
+
+    def __str__(self):
+        return '%s{%s,%s}' % (self.__class__.__name__,
+                              self.ds,
+                              self.ignore_border)
+
+    def make_node(self, x, ex):
+        if not isinstance(x.type, CudaNdarrayType):
+            raise TypeError()
+        if not isinstance(ex.type, CudaNdarrayType):
+            raise TypeError()
+        if not x.type.ndim == 4:
+            raise TypeError()
+        return Apply(self, [x, ex], [x.type()])
+
+    #def perform(self, node, input_storage, output_storage):
+        #raise NotImplementedError('only C is implemented')
+    def c_code_cache_version(self):
+        return (1)
+
+    def c_code(self, node, nodename, inps, out, sub):
+        x, ex = inps
+        z, = out
+        fail = sub['fail']
+        ds0, ds1 = self.ds
+        ignore_border = int(self.ignore_border)
+        return """
+        int dims[4], xdim2, xdim3;
+        if (%(x)s->nd != 4)
+        {
+            PyErr_SetString(PyExc_ValueError, "rank error");
+            %(fail)s;
+        }
+        xdim2 = CudaNdarray_HOST_DIMS(%(x)s)[2];
+        xdim3 = CudaNdarray_HOST_DIMS(%(x)s)[3];
+        dims[0] = CudaNdarray_HOST_DIMS(%(x)s)[0];
+        dims[1] = CudaNdarray_HOST_DIMS(%(x)s)[1];
+        dims[2] = xdim2 / %(ds0)s;
+        dims[3] = xdim3 / %(ds1)s;
+        if (! %(ignore_border)s)
+        {
+            dims[2] += (xdim2%%(%(ds0)s)?1:0);
+            dims[3] += (xdim3%%(%(ds1)s)?1:0);
+        }
+        if(dims[3]>512){
+            PyErr_Format(PyExc_ValueError,
+                         "GpuDownsampleFactorMaxRop: last dimension size of %%d"
+                         " is bigger then 512. This case is not implemented.",
+                         dims[3]);
+            %(fail)s;
+        }
+
+        if ((NULL == %(z)s)
+            || (CudaNdarray_HOST_DIMS(%(z)s)[0] != dims[0])
+            || (CudaNdarray_HOST_DIMS(%(z)s)[1] != dims[1])
+            || (CudaNdarray_HOST_DIMS(%(z)s)[2] != dims[2])
+            || (CudaNdarray_HOST_DIMS(%(z)s)[3] != dims[3]))
+        {
+            Py_XDECREF(%(z)s);
+            %(z)s = (CudaNdarray*)CudaNdarray_New();
+            if ((NULL == %(z)s)
+                || CudaNdarray_alloc_contiguous(%(z)s, 4, dims))
+            {
+                Py_XDECREF(%(z)s);
+                %(z)s = NULL;
+                PyErr_SetString(PyExc_ValueError,
+                                "Was not able to allocate output!");
+                %(fail)s;
+            }
+        }
+        {
+
+            dim3 grid(dims[0] * dims[1], dims[2]);
+            //dim3 block(std::min(dims[3], 512));
+            //TODO: implement this by supporting more outputs than threads
+            dim3 block(dims[3]);
+            if ((grid.x*grid.y) && dims[3])
+            kMaxPoolRop_%(nodename)s<%(ds0)s, %(ds1)s> <<<grid, block,
+                                                       2*xdim3*sizeof(float)>>>(
+                dims[0], dims[1], dims[2], dims[3], xdim2, xdim3,
+                CudaNdarray_DEV_DATA(%(x)s),
+                CudaNdarray_DEV_DATA(%(ex)s),
+                CudaNdarray_HOST_STRIDES(%(x)s)[0],
+                CudaNdarray_HOST_STRIDES(%(x)s)[1],
+                CudaNdarray_HOST_STRIDES(%(x)s)[2],
+                CudaNdarray_HOST_STRIDES(%(x)s)[3],
+                CudaNdarray_DEV_DATA(%(z)s),
+                CudaNdarray_HOST_STRIDES(%(z)s)[0],
+                CudaNdarray_HOST_STRIDES(%(z)s)[1],
+                CudaNdarray_HOST_STRIDES(%(z)s)[2],
+                CudaNdarray_HOST_STRIDES(%(z)s)[3]);
+            CNDA_THREAD_SYNC;
+            cudaError_t err = cudaGetLastError();
+            if( cudaSuccess != err)
+            {
+                PyErr_Format(PyExc_RuntimeError,
+                    "Cuda error: %%s: %%s. (grid: %%i x %%i;"
+                    " block: %%i x %%i x %%i)\\n",
+                    "kMaxPoolRop_%(nodename)s",
+                    cudaGetErrorString(err),
+                    grid.x,
+                    grid.y,
+                    block.x,
+                    block.y,
+                    block.z);
+                %(fail)s;
+            }
+        }
+        """ % locals()
+
+    def c_support_code_apply(self, node, nodename):
+        ignore_border = int(self.ignore_border)
+        return """
+        template<int pf2, int pf3>
+        __global__ void kMaxPoolRop_%(nodename)s(
+           int D0, int D1, int D2, int D3, int xD2, int xD3,
+           const float * x,
+           const float * ev,
+           int xS0, int xS1, int xS2, int xS3,
+           float *z, int zS0, int zS1, int zS2, int zS3)
+        {
+            float cur_max, cur_x, cur_ev, cur_max_ev;
+            int i0 = blockIdx.x %% D0;
+            int i1 = blockIdx.x / D0;
+            int i2 = blockIdx.y;
+
+            extern __shared__ float xbuf[]; //size [xD3]
+
+            for (int r2 = 0;
+                 (r2 < pf2) && (%(ignore_border)s || (r2 + i2*pf2 < xD2));
+                 ++r2)
+            {
+                __syncthreads();
+                // load the current row of the image into shared memory
+                for (int j = threadIdx.x; j < xD3; j += blockDim.x)
+                {
+                    xbuf[j]       =  x[i0*xS0 + i1*xS1 + (i2*pf2+r2)*xS2 + j*xS3];
+                    xbuf[j + xD3] = ev[i0*xS0 + i1*xS1 + (i2*pf2+r2)*xS2 + j*xS3];
+                }
+                __syncthreads();
+
+                // initialize our max if this is the first row we're loading
+                cur_max = (r2 == 0) ? xbuf[threadIdx.x*pf3] : cur_max;
+                cur_max_ev = (r2 == 0) ? xbuf[xD3 + threadIdx.x*pf3] :cur_max_ev;
+
+                // do a mini-reduction over the pf3 relevant elements
+                // in the current row
+                if (%(ignore_border)s)
+                {
+                    for (int k = 0; k < pf3; ++k)
+                    {
+                        cur_x  = xbuf[threadIdx.x*pf3+k];
+                        cur_ev = xbuf[xD3 + threadIdx.x*pf3+k];
+                        if (cur_x > cur_max)
+                        {
+                            cur_max = cur_x;
+                            cur_max_ev = cur_ev;
+                        }
+
+                    }
+                }
+                else
+                {
+                    for (int k = 0; k < pf3; ++k)
+                    {
+                        if (threadIdx.x*pf3 + k < xD3)
+                        {
+                            cur_x  = xbuf[threadIdx.x*pf3+k];
+                            cur_ev = xbuf[xD3+threadIdx.x*pf3+k];
+                            if (cur_x > cur_max)
+                            {
+                            cur_max = cur_x;
+                            cur_max_ev = cur_ev;
+                            }
+                        }
+                    }
+                }
+            }
+
+            //store the result to global memory
+            z[i0*zS0 + i1*zS1 + i2*zS2 + threadIdx.x*zS3] = cur_max_ev;
+        }
+        """ % locals()
 
 class GpuDownsampleFactorMaxGrad(GpuOp):
     """

--- a/theano/sandbox/cuda/opt.py
+++ b/theano/sandbox/cuda/opt.py
@@ -44,7 +44,7 @@ from theano.sandbox.cuda.blas import gpu_ger_inplace
 from theano.sandbox.cuda.blas import gpu_ger_no_inplace
 from theano.sandbox.cuda.blas import (
     GpuDownsampleFactorMax, GpuDownsampleFactorMaxGrad,
-    GpuDownsampleFactorMaxGradGrad)
+    GpuDownsampleFactorMaxRop, GpuDownsampleFactorMaxGradGrad)
 
 from theano.sandbox.blocksparse import SparseBlockGemv, SparseBlockOuter
 from theano.sandbox.cuda.blocksparse import (
@@ -1866,6 +1866,27 @@ def local_gpu_downsample_factor_max_grad(node):
             return [host_from_gpu(gpu_ds_grad(x.owner.inputs[0],
                                               as_cuda_ndarray_variable(z),
                                               as_cuda_ndarray_variable(gz)))]
+
+@register_opt()
+@local_optimizer([downsample.DownsampleFactorMaxRop])
+def local_gpu_downsample_factor_max_rop(node):
+    if (isinstance(node.op, downsample.DownsampleFactorMaxRop) and
+        node.op.ds == node.op.st):
+
+        assert node.op.__props__ == ('ds', 'ignore_border', 'st', 'padding',
+                                     'mode')
+        if (node.op.padding != (0, 0) or
+            node.op.mode != 'max' or
+            node.op.st != node.op.ds):
+
+            return
+
+        x, ex = node.inputs
+        if (x.owner and isinstance(x.owner.op, HostFromGpu)):
+            gpu_ds_grad = GpuDownsampleFactorMaxRop(node.op.ds,
+                                                     node.op.ignore_border)
+            return [host_from_gpu(gpu_ds_grad(x,
+                                              as_cuda_ndarray_variable(ex)))]
 
 
 @register_opt()

--- a/theano/tensor/signal/downsample.py
+++ b/theano/tensor/signal/downsample.py
@@ -1257,22 +1257,23 @@ class DownsampleFactorMaxRop(Op):
         fake_zz -= numpy.inf
         ds0, ds1 = self.ds
         if self.ignore_border:
-            x_usable2 = (x.shape[2] / ds0 * ds0)
+            x_usable2 = (x.shape[2] // ds0 * ds0)
         else: x_usable2 = x.shape[2]
         if self.ignore_border:
-            x_usable3 = (x.shape[3] / ds1 * ds1)
+            x_usable3 = (x.shape[3] // ds1 * ds1)
         else: x_usable3 = x.shape[3]
         for n in xrange(x.shape[0]):
             for k in xrange(x.shape[1]):
                 for i in xrange(x_usable2):
-                    zi = i / ds0
+                    zi = i // ds0
                     for j in xrange(x_usable3):
-                        zj = j / ds1
+                        zj = j // ds1
                         if fake_zz[n, k, zi, zj] < x[n, k, i, j]:
                             fake_zz[n, k, zi, zj] = x[n, k, i, j]
                             zz[n, k, zi, zj] = ex[n, k, i, j]
 
     def c_code(self, node, name, inp, out, sub):
+        raise NotImplementedError("c_code exists but needs debugging")
         x, ex = inp
         z, = out
         fail = sub['fail']

--- a/theano/tensor/signal/downsample.py
+++ b/theano/tensor/signal/downsample.py
@@ -333,6 +333,19 @@ class DownsampleFactorMax(Op):
                                     st=self.st, padding=self.padding,
                                     mode=self.mode)(
                                         x, gz)]
+
+    def R_op(self, inputs, eval_points):
+        # R_op can receive None as eval_points.
+        # That mean there is no diferientiable path through that input
+        # If this imply that you cannot compute some outputs,
+        # return None for those.
+        if eval_points[0] is None:
+            return [None]
+        rop = DownsampleFactorMaxRop(self.ds,
+                                     ignore_border=self.ignore_border,								
+                                     st=self.st, padding=self.padding)
+        return [rop(inputs[0], eval_points[0])]
+
     def c_headers(self):
         return ['<algorithm>']
 
@@ -1146,3 +1159,196 @@ def local_average_pool_grad(node):
                             padding=node.op.padding,
                             mode=node.op.mode)(node.inputs[0],
                                                node.inputs[2])]
+
+
+class DownsampleFactorMaxRop(Op):
+    """
+    Implements the R-operator for the downsample operation.
+    """
+
+    @staticmethod
+    def out_shape(imgshape, ds, ignore_border=False):
+        """Return the shape of the output from this op, for input of given shape and flags.
+
+        :param imgshape: the shape of a tensor of images. The last two elements are interpreted
+        as the number of rows, and the number of cols.
+        :type imgshape: tuple, list, or similar.
+
+        :param ds: downsample factor over rows and columns
+        :type ds: list or tuple of two ints
+
+        :param ignore_border: if ds doesn't divide imgshape, do we include an extra row/col of
+        partial downsampling (False) or ignore it (True).
+        :type ignore_border: bool
+
+        :rtype: list
+        :returns: the shape of the output from this op, for input of given shape.  This will
+        have the same length as imgshape, but with last two elements reduced as per the
+        downsampling & ignore_border flags.
+        """
+        if len(imgshape) < 2:
+            raise TypeError('imgshape must have at least two elements (rows, cols)')
+        r, c = imgshape[-2:]
+        rval = list(imgshape[:-2]) + [ r / ds[0], c / ds[1]]
+        if not ignore_border:
+            if r % ds[0]:
+                rval[-2] += 1
+            if c % ds[1]:
+                rval[-1] += 1
+        return rval
+
+    def __init__(self, ds, ignore_border=False):
+        """
+        :param ds: downsample factor over rows and columns
+        :type ds: list or tuple of two ints
+
+        :param ignore_border: if ds doesn't divide imgshape, do we include an extra row/col of
+        partial downsampling (False) or ignore it (True).
+        :type ignore_border: bool
+
+        TODO: why is poolsize an op parameter here?
+        """
+        self.ds = tuple(ds)
+        self.ignore_border = ignore_border
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.ds == other.ds and self.ignore_border == other.ignore_border
+
+    def __hash__(self):
+        return hash(type(self)) ^ hash(self.ds) ^ hash(self.ignore_border)
+
+    def __str__(self):
+        return '%s{%s,%s}' % (self.__class__.__name__, self.ds, self.ignore_border)
+
+    def make_node(self, x, eval_point):
+        if x.type.ndim != 4:
+            raise TypeError('Expected tensor4')
+        if x.type.ndim != 4:
+            return TypeError('Expected tensor4')
+        # TODO: consider restrucing the dtype?
+        x = as_tensor_variable(x)
+        eval_point = as_tensor_variable(eval_point)
+        return gof.Apply(self, [x, eval_point], [x.type()])
+
+    def perform(self, node, inp, out):
+        x, ex = inp
+        z, = out
+        if len(x.shape) != 4:
+            raise NotImplementedError('DownsampleFactorMax requires 4D input for now')
+        z_shape = self.out_shape(x.shape, self.ds, self.ignore_border)
+        if (z[0] is None) or (z[0].shape != z_shape):
+            z[0] = numpy.zeros(self.out_shape(x.shape, self.ds, self.ignore_border))
+            z[0] = theano._asarray(z[0], dtype=x.dtype)
+        zz = z[0]
+        fake_zz = numpy.zeros(self.out_shape(x.shape, self.ds,
+                                             self.ignore_border))
+
+        ## zz needs to be initialized with -inf for the following to work
+        zz -= numpy.inf
+        fake_zz -= numpy.inf
+        ds0, ds1 = self.ds
+        if self.ignore_border:
+            x_usable2 = (x.shape[2] / ds0 * ds0)
+        else: x_usable2 = x.shape[2]
+        if self.ignore_border:
+            x_usable3 = (x.shape[3] / ds1 * ds1)
+        else: x_usable3 = x.shape[3]
+        for n in xrange(x.shape[0]):
+            for k in xrange(x.shape[1]):
+                for i in xrange(x_usable2):
+                    zi = i / ds0
+                    for j in xrange(x_usable3):
+                        zj = j / ds1
+                        if fake_zz[n, k, zi, zj] < x[n, k, i, j]:
+                            fake_zz[n, k, zi, zj] = x[n, k, i, j]
+                            zz[n, k, zi, zj] = ex[n, k, i, j]
+
+    def c_code(self, node, name, inp, out, sub):
+        x, ex = inp
+        z, = out
+        fail = sub['fail']
+        ignore_border = int(self.ignore_border)
+        ds0, ds1 = self.ds
+        return """
+        int typenum = PyArray_ObjectType((PyObject*)%(x)s, 0);
+        int x_shp0_usable;
+        int x_shp1_usable;
+        int z_shp0, z_shp1;
+        if(%(x)s->nd!=4)
+        {
+            PyErr_SetString(PyExc_ValueError, "x must be a 4d ndarray");
+            %(fail)s;
+        }
+        z_shp0 = %(x)s->dimensions[2] / %(ds0)s;
+        z_shp1 = %(x)s->dimensions[3] / %(ds1)s;
+        if (%(ignore_border)s)
+        {
+            x_shp0_usable = z_shp0 * %(ds0)s;
+            x_shp1_usable = z_shp1 * %(ds1)s;
+        }
+        else
+        {
+            z_shp0 += (%(x)s->dimensions[2] %% %(ds0)s) ? 1 : 0;
+            z_shp1 += (%(x)s->dimensions[3] %% %(ds1)s) ? 1 : 0;
+            x_shp0_usable = %(x)s->dimensions[2];
+            x_shp1_usable = %(x)s->dimensions[3];
+        }
+        if ((!%(z)s)
+          || *PyArray_DIMS(%(z)s)!=4
+          ||(%(z)s->dimensions[0] != %(x)s->dimensions[0])
+          ||(%(z)s->dimensions[1] != %(x)s->dimensions[1])
+          ||(%(z)s->dimensions[2] != z_shp0)
+          ||(%(z)s->dimensions[3] != z_shp1)
+          )
+        {
+          if (%(z)s) Py_XDECREF(%(z)s);
+
+          npy_intp dims[4] = {0,0,0,0};
+          dims[0]=%(x)s->dimensions[0];
+          dims[1]=%(x)s->dimensions[1];
+          dims[2]=z_shp0;
+          dims[3]=z_shp1;
+          %(z)s = (PyArrayObject*) PyArray_ZEROS(4, dims, typenum,0); //TODO: zeros not necessary
+        }
+
+
+        if (z_shp0 && z_shp1)
+        {
+            npy_intp fake_dims[4] = {0,0,0,0};
+            fake_dims[0]=%(x)s->dimensions[0];
+            fake_dims[1]=%(x)s->dimensions[1];
+            fake_dims[2]=z_shp0;
+            fake_dims[3]=z_shp1;
+            PyArrayObject * fake_z = (PyArrayObject*) PyArray_ZEROS(4, fake_dims, typenum, 0);
+            for(int b=0;b<%(x)s->dimensions[0];b++){
+              for(int k=0;k<%(x)s->dimensions[1];k++){
+                int mini_i = 0;
+                int zi = 0;
+                for(int i=0;i< x_shp0_usable; i++){
+                  int mini_j = 0;
+                  int zj = 0;
+                  for(int j=0; j<x_shp1_usable; j++){
+                    dtype_%(x)s  a = ((dtype_%(x)s  *)(PyArray_GETPTR4(%(x)s ,b,k,i,j)))[0];
+                    dtype_%(ex)s fa = ((dtype_%(ex)s *)(PyArray_GETPTR4(%(ex)s,b,k,i,j)))[0];
+                    dtype_%(z)s * __restrict__ z = ((dtype_%(z)s*)(PyArray_GETPTR4(%(z)s,b,k,zi,zj)));
+                    dtype_%(z)s * __restrict__ fz = ((dtype_%(z)s*)(PyArray_GETPTR4(fake_z,b,k,zi,zj)));
+                    if (((mini_j| mini_i) == 0) || fz[0] < a)
+                    {
+                      fz[0] = a;
+                      z[0] = fa;
+                    }
+                    mini_j = ((mini_j + 1) == %(ds1)s) ? 0 : mini_j+1;
+                    zj += (mini_j == 0);
+                  }
+                  mini_i = ((mini_i + 1) == %(ds0)s) ? 0 : mini_i+1;
+                  zi += (mini_i == 0);
+                }
+              }
+            }
+            Py_XDECREF(fake_z);
+            //free(fake_z)
+        }
+        """ % locals()
+
+    def c_code_cache_version(self):
+        return (0, 1)

--- a/theano/tensor/signal/downsample.py
+++ b/theano/tensor/signal/downsample.py
@@ -1166,6 +1166,8 @@ class DownsampleFactorMaxRop(Op):
     Implements the R-operator for the downsample operation.
     """
 
+    __props__ = ('ds', 'ignore_border', 'st', 'padding', 'mode')
+
     @staticmethod
     def out_shape(imgshape, ds, ignore_border=False):
         """Return the shape of the output from this op, for input of given shape and flags.
@@ -1197,7 +1199,7 @@ class DownsampleFactorMaxRop(Op):
                 rval[-1] += 1
         return rval
 
-    def __init__(self, ds, ignore_border=False):
+    def __init__(self, ds, ignore_border, st=None, padding=(0, 0), mode='max'):
         """
         :param ds: downsample factor over rows and columns
         :type ds: list or tuple of two ints
@@ -1210,6 +1212,13 @@ class DownsampleFactorMaxRop(Op):
         """
         self.ds = tuple(ds)
         self.ignore_border = ignore_border
+        if st is None:
+            st = ds
+        self.st = tuple(st)
+        self.padding = tuple(padding)
+        self.mode = mode
+        assert self.mode == 'max'
+
 
     def __eq__(self, other):
         return type(self) == type(other) and self.ds == other.ds and self.ignore_border == other.ignore_border
@@ -1226,8 +1235,8 @@ class DownsampleFactorMaxRop(Op):
         if x.type.ndim != 4:
             return TypeError('Expected tensor4')
         # TODO: consider restrucing the dtype?
-        x = as_tensor_variable(x)
-        eval_point = as_tensor_variable(eval_point)
+        x = tensor.as_tensor_variable(x)
+        eval_point = tensor.as_tensor_variable(eval_point)
         return gof.Apply(self, [x, eval_point], [x.type()])
 
     def perform(self, node, inp, out):

--- a/theano/tests/test_rop.py
+++ b/theano/tests/test_rop.py
@@ -259,6 +259,33 @@ class test_RopLop(RopLop_checker):
             self.x[:4].dimshuffle('x', 0), 0).sum(axis=1),
             (1,))
 
+    def test_downsample(self):
+        rng = numpy.random.RandomState(utt.fetch_seed())
+        maxpoolshps = ((1,1),(3,2),(2,3))
+        vx = (rng.rand(2,3,3,4) * 2.0).astype(theano.config.floatX)
+        vv = (rng.rand(2,3,3,4) * 2.0).astype(theano.config.floatX)
+        input = theano.shared(vx)
+        eval_p = theano.shared(vv)
+        for maxpoolshp in maxpoolshps:
+            for ignore_border in [False, True]:
+                nwOp = DownsampleFactorMax(maxpoolshp,
+                                           ignore_border=ignore_border)
+                out = nwOp(input).flatten()
+                yv = tensor.Rop(out, input, eval_p)
+                rop_f = function([], yv,
+                                 on_unused_input='ignore')
+                sy, _ = theano.scan(lambda i, y, x, v:
+                                    (tensor.grad(y[i], x) * v).sum(),
+                                    sequences=tensor.arange(out.shape[0]),
+                                    non_sequences=[out, input, eval_p])
+                scan_f = function([], sy,
+                                  on_unused_input='ignore')
+                v1 = rop_f()
+                v2 = scan_f()
+                assert numpy.allclose(v1, v2), ("Rop mismatch: %s %s" %
+                                                (v1,v2))
+
+
     def test_conv(self):
         for border_mode in ['valid', 'full']:
             image_shape = (2, 2, 4, 5)


### PR DESCRIPTION
This is a PR to attack issue #305.
Imported what seemed relevant from pascanur:downsampling_rop branch (PR #622).
When comparing the two code bases, the pascanur branch seems quite archaic.

I am not familiar with the Theano code base, so I did my best pythonic guesses. I most certainly introduced bugs. This code will need heavy testing and/or upgrades.

`test_rop.py` includes a test for the new feature, and it currently fails.

```
....SES..................
======================================================================
ERROR: test_downsample (theano.tests.test_rop.test_RopLop)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/benenson/code/references/Theano/theano/tests/test_rop.py", line 274, in test_downsample
    yv = tensor.Rop(out, input, eval_p)
  File "/home/benenson/code/references/Theano/theano/gradient.py", line 293, in Rop
    _traverse(out.owner)
  File "/home/benenson/code/references/Theano/theano/gradient.py", line 256, in _traverse
    _traverse(inp.owner)
  File "/home/benenson/code/references/Theano/theano/gradient.py", line 288, in _traverse
    seen_nodes[node] = op.R_op(node.inputs, same_type_eval_points)
  File "/home/benenson/code/references/Theano/theano/tensor/signal/downsample.py", line 346, in R_op
    st=self.st, padding=self.padding)
TypeError: __init__() got an unexpected keyword argument 'padding'

----------------------------------------------------------------------
```

I had added `st=self.st, padding=self.padding` because this are new arguments present on the other downsampling operators. Not sure how/if should be present in Rop.

Anyone interested on helping for this PR is most welcome. Theano internals look quite gloomy.