### PR TITLE
Fix stack interface use

### DIFF
--- a/theano/sparse/sandbox/sp.py
+++ b/theano/sparse/sandbox/sp.py
@@ -411,8 +411,8 @@ def convolve(kerns, kshp, nkern, images, imgshp, step=(1, 1), bias=None,
     patches = (sparse.structured_dot(csc, images.T)).T
 
     # compute output of linear classifier
-    pshape = tensor.stack(images.shape[0] * tensor.as_tensor(N.prod(outshp)),\
-                          tensor.as_tensor(imgshp[0] * kern_size))
+    pshape = tensor.stack([images.shape[0] * tensor.as_tensor(N.prod(outshp)),\
+                           tensor.as_tensor(imgshp[0] * kern_size)])
     patch_stack = tensor.reshape(patches, pshape, ndim=2)
 
     # kern is of shape: nkern x ksize*number_of_input_features
@@ -425,9 +425,9 @@ def convolve(kerns, kshp, nkern, images, imgshp, step=(1, 1), bias=None,
 
     # now to have feature maps in raster order ...
     # go from bsize*outshp x nkern to bsize x nkern*outshp
-    newshp = tensor.stack(images.shape[0],\
-                          tensor.as_tensor(N.prod(outshp)),\
-                          tensor.as_tensor(nkern))
+    newshp = tensor.stack([images.shape[0],\
+                           tensor.as_tensor(N.prod(outshp)),\
+                           tensor.as_tensor(nkern)])
     tensout = tensor.reshape(output, newshp, ndim=3)
     output = tensor.DimShuffle((False,) * tensout.ndim, (0, 2, 1))(tensout)
     if flatten:
@@ -477,17 +477,17 @@ def max_pool(images, imgshp, maxpoolshp):
                                     indptr, spmat_shape)
     patches = sparse.structured_dot(csc, images.T).T
 
-    pshape = tensor.stack(images.shape[0] *\
-                              tensor.as_tensor(N.prod(outshp)),
-                          tensor.as_tensor(imgshp[0]),
-                          tensor.as_tensor(poolsize))
+    pshape = tensor.stack([images.shape[0] *\
+                               tensor.as_tensor(N.prod(outshp)),
+                           tensor.as_tensor(imgshp[0]),
+                           tensor.as_tensor(poolsize)])
     patch_stack = tensor.reshape(patches, pshape, ndim=3)
 
     out1 = tensor.max(patch_stack, axis=2)
 
-    pshape = tensor.stack(images.shape[0],
-                          tensor.as_tensor(N.prod(outshp)),
-                          tensor.as_tensor(imgshp[0]))
+    pshape = tensor.stack([images.shape[0],
+                           tensor.as_tensor(N.prod(outshp)),
+                           tensor.as_tensor(imgshp[0])])
     out2 = tensor.reshape(out1, pshape, ndim=3)
 
     out3 = tensor.DimShuffle(out2.broadcastable, (0, 2, 1))(out2)

--- a/theano/tensor/nnet/neighbours.py
+++ b/theano/tensor/nnet/neighbours.py
@@ -569,8 +569,8 @@ def neibs2images(neibs, neib_shape, original_shape, mode='valid'):
     neib_shape = T.as_tensor_variable(neib_shape)
     original_shape = T.as_tensor_variable(original_shape)
 
-    new_neib_shape = T.stack(original_shape[-1] // neib_shape[1],
-                             neib_shape[1])
+    new_neib_shape = T.stack([original_shape[-1] // neib_shape[1],
+                              neib_shape[1]])
     output_2d = images2neibs(neibs.dimshuffle('x', 'x', 0, 1),
                              new_neib_shape, mode=mode)
 

--- a/theano/tensor/signal/conv.py
+++ b/theano/tensor/signal/conv.py
@@ -80,10 +80,10 @@ def conv2d(input, filters, image_shape=None, filter_shape=None,
     else:
         sym_nkern = 1
 
-    new_input_shape = tensor.join(0, tensor.stack(sym_bsize, 1), input.shape[-2:])
+    new_input_shape = tensor.join(0, tensor.stack([sym_bsize, 1]), input.shape[-2:])
     input4D = tensor.reshape(input, new_input_shape, ndim=4)
 
-    new_filter_shape = tensor.join(0, tensor.stack(sym_nkern, 1), filters.shape[-2:])
+    new_filter_shape = tensor.join(0, tensor.stack([sym_nkern, 1]), filters.shape[-2:])
     filters4D = tensor.reshape(filters, new_filter_shape, ndim=4)
 
     ### perform actual convolution ###

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -5118,7 +5118,7 @@ class T_local_reduce(unittest.TestCase):
         # on 32 bit systems
         A = theano.shared(numpy.array([1, 2, 3, 4, 5], dtype='int64'))
 
-        f = theano.function([], T.sum(T.stack(A, A), axis=0), mode=self.mode)
+        f = theano.function([], T.sum(T.stack([A, A]), axis=0), mode=self.mode)
         assert numpy.allclose(f(), [2, 4, 6, 8, 10])
         topo = f.maker.fgraph.toposort()
         assert isinstance(topo[-1].op, T.Elemwise)
@@ -5127,7 +5127,7 @@ class T_local_reduce(unittest.TestCase):
         try:
             old = theano.config.warn.reduce_join
             theano.config.warn.reduce_join = False
-            f = theano.function([], T.sum(T.stack(A, A), axis=1),
+            f = theano.function([], T.sum(T.stack([A, A]), axis=1),
                                 mode=self.mode)
         finally:
             theano.config.warn.reduce_join = old
@@ -5454,7 +5454,7 @@ class TestMakeVector(utt.InferShapeTester):
 def test_local_join_1():
     # test for vector
     a = tensor.vector('a')
-    s = tensor.stack(a)
+    s = tensor.stack([a])
     f = function([a], s, mode=mode_opt)
     val = f([1])
     assert numpy.all(val == [1])
@@ -5520,7 +5520,7 @@ def test_local_join_empty():
 
     # test for vector, vector, empty to matrix
     # We can't optimize this case.
-    s = tensor.stack(a, a, empty_vec)
+    s = tensor.stack([a, a, empty_vec])
     f = function([a], s, mode=mode_opt)
     val = f([])
     assert numpy.all(val == [1])


### PR DESCRIPTION
Tests with theano-nose are filled with DeprecationWarning messages because or PR #3318 

```/home/dpln/deep-learning-suite/theano/theano/tensor/nnet/neighbours.py:109: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  return [neibs2images(gz, neib_shape, x.shape, mode=self.mode),/home/dpln/deep-learning-suite/theano/theano/tensor/nnet/neighbours.py:109: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  return [neibs2images(gz, neib_shape, x.shape, mode=self.mode),/home/dpln/deep-learning-suite/theano/theano/tensor/nnet/neighbours.py:109: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  return [neibs2images(gz, neib_shape, x.shape, mode=self.mode),....................................................................................................................................................................................................................................................................................................................E..........................................S..................../home/dpln/deep-learning-suite/theano/theano/tensor/nnet/neighbours.py:109: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  return [neibs2images(gz, neib_shape, x.shape, mode=self.mode),./home/dpln/deep-learning-suite/theano/theano/tensor/nnet/neighbours.py:109: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  return [neibs2images(gz, neib_shape, x.shape, mode=self.mode),.../home/dpln/deep-learning-suite/theano/theano/tensor/nnet/tests/test_neighbours.py:41: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  neibs2images(neibs, neib_shape, images.shape),/home/dpln/deep-learning-suite/theano/theano/tensor/nnet/tests/test_neighbours.py:41: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  neibs2images(neibs, neib_shape, images.shape),/home/dpln/deep-learning-suite/theano/theano/tensor/nnet/tests/test_neighbours.py:41: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  neibs2images(neibs, neib_shape, images.shape),/home/dpln/deep-learning-suite/theano/theano/tensor/nnet/tests/test_neighbours.py:41: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  neibs2images(neibs, neib_shape, images.shape),/home/dpln/deep-learning-suite/theano/theano/tensor/nnet/tests/test_neighbours.py:41: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  neibs2images(neibs, neib_shape, images.shape),/home/dpln/deep-learning-suite/theano/theano/tensor/nnet/tests/test_neighbours.py:41: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  neibs2images(neibs, neib_shape, images.shape),/home/dpln/deep-learning-suite/theano/theano/tensor/nnet/tests/test_neighbours.py:41: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  neibs2images(neibs, neib_shape, images.shape),/home/dpln/deep-learning-suite/theano/theano/tensor/nnet/tests/test_neighbours.py:41: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  neibs2images(neibs, neib_shape, images.shape),./home/dpln/deep-learning-suite/theano/theano/tensor/nnet/tests/test_neighbours.py:324: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  return neibs2images(neibs, (2, 2), (2, 3, 10, 10))/home/dpln/deep-learning-suite/theano/theano/tensor/nnet/neighbours.py:109: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.  return [neibs2images(gz, neib_shape, x.shape, mode=self.mode),.../home/dpln/deep-learning-suite/theano/theano/tensor/nnet/tests/test_neighbours.py:91: DeprecationWarning: stack(*tensors) interface is deprecated, use stack(tensors, axis=0) instead.```