### PR TITLE
Scan grad speedup

### DIFF
--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -359,7 +359,8 @@ def Lop(f, wrt, eval_points, consider_constant=None,
 
 def grad(cost, wrt, consider_constant=None,
          disconnected_inputs='raise', add_names=True,
-         known_grads=None, return_disconnected='zero'):
+         known_grads=None, return_disconnected='zero',
+         null_gradients='raise'):
     """
     Return symbolic gradients for one or more variables with respect to some
     cost.
@@ -405,6 +406,12 @@ def grad(cost, wrt, consider_constant=None,
         - 'None' : If wrt[i] is disconnected, return value i will be
                    None
         - 'Disconnected' : returns variables of type DisconnectedType
+
+    :type null_gradients: string
+    :param null_gradients: Defines the behaviour if some of the variables in
+            ``wrt`` have a null gradient. The possibles values are :
+        - 'raise' : raise a NullTypeGradError exception
+        - 'return' : return the null gradients
 
     :rtype: variable or list/tuple of Variables (matching `wrt`)
 
@@ -547,6 +554,12 @@ def grad(cost, wrt, consider_constant=None,
                                grad_dict, wrt, cost_name)
 
     for i in xrange(len(rval)):
+        if isinstance(rval[i].type, NullType):
+            if null_gradients == 'raise':
+                raise NullTypeGradError("tensor.grad encountered a NaN. " +
+                                        rval[i].type.why_null)
+            else:
+                assert null_gradients == 'return'
         if isinstance(rval[i].type, DisconnectedType):
             handle_disconnected(rval[i])
             if return_disconnected == 'zero':
@@ -1115,6 +1128,19 @@ def _populate_grad_dict(var_to_app_to_idx,
             # we won't be able to post-process out the Nones if it does that
             input_grads = list(input_grads)
 
+            # Need to propagate the NullType gradients; if an input grad is
+            # not disconnected and the corresponding input is connected
+            # to at least one output whose gradient is NullType then the input
+            # grad should be NullType.
+            op_conn_pattern = _node_to_pattern(node)
+            for inp_idx in range(len(input_grads)):
+                for out_idx in range(len(ograd_is_nan)):
+                    if (ograd_is_nan[out_idx] and
+                            op_conn_pattern[inp_idx][out_idx] and
+                            not isinstance(input_grads[inp_idx].type,
+                                           DisconnectedType)):
+                        input_grads[inp_idx] = output_grads[out_idx]
+
             # Do type checking on the result
 
             # List of bools indicating if each input only has integer outputs
@@ -1238,6 +1264,7 @@ def _populate_grad_dict(var_to_app_to_idx,
         if var not in grad_dict:
             # If var is not in grad_dict already, we must compute it
             if var in var_to_app_to_idx:
+                null_terms = []
                 terms = []
                 node_to_idx = var_to_app_to_idx[var]
                 for node in node_to_idx:
@@ -1252,9 +1279,8 @@ def _populate_grad_dict(var_to_app_to_idx,
                                                          type(term)))
 
                         if isinstance(term.type, NullType):
-                            raise NullTypeGradError("tensor.grad "
-                                                    "encountered a NaN. " +
-                                                    term.type.why_null)
+                            null_terms.append(term)
+                            continue
 
                         # Don't try to sum up DisconnectedType placeholders
                         if isinstance(term.type, DisconnectedType):
@@ -1269,7 +1295,11 @@ def _populate_grad_dict(var_to_app_to_idx,
                         terms.append(term)
 
                 # Add up the terms to get the total gradient on this variable
-                if len(terms) > 0:
+                if len(null_terms) > 0:
+                    # At least one term is a NullType : the total gradient
+                    # will also be a NullType
+                    grad_dict[var] = null_terms[0]
+                elif len(terms) > 0:
                     # the next line is like sum(terms) but doesn't add an
                     # extraneous TensorConstant(0)
                     grad_dict[var] = reduce(lambda x, y: x + y, terms)

--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -1802,7 +1802,14 @@ class Scan(PureOp):
                    get_inp_idx(self_inputs.index(x)) in connected_inputs]
             gmp = OrderedDict()
 
-            known_grads = dict([(k*1,v) for (k,v) in known_grads.items()])
+            # Required in case there is a pair of variables X and Y, with X
+            # used to compute Y, for both of which there is an external
+            # gradient signal. Without this, the total gradient signal on X
+            # will be the external gradient  signalknown_grads[X]. With this,
+            # it will be the sum of the external gradient signal and the
+            # gradient obtained by propagating Y's external gradient signal
+            # to X.
+            known_grads = dict([(k.copy(),v) for (k,v) in known_grads.items()])
 
             grads = gradient.grad(
                         cost=None,

--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -1936,7 +1936,7 @@ class Scan(PureOp):
                 dc_dxts_idx += 1
             else:
                 if isinstance(dC_douts[i].type, DisconnectedType):
-                    c_dxts_idx += 1
+                    dc_dxts_idx += 1
                     continue
                 else:
                     if diff_outputs[i] in known_grads:

--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -1809,7 +1809,7 @@ class Scan(PureOp):
             # it will be the sum of the external gradient signal and the
             # gradient obtained by propagating Y's external gradient signal
             # to X.
-            known_grads = dict([(k.copy(),v) for (k,v) in known_grads.items()])
+            known_grads = dict([(k.copy(), v) for (k, v) in known_grads.items()])
 
             grads = gradient.grad(
                         cost=None,


### PR DESCRIPTION
NOTE : I'm still in the process of testing this change but it might still be good to start getting feedback. Since this changes the graphs that result from taking gradients of Scan nodes, it may mean that new optimizations that were previously not needed would now be more useful/important.

This PR modifies the way Scan takes the gradient of it's inner function. Instead of doing nb_inputs * nb_outputs calls to grad to get the gradient of its inner function, it now does only one such call. This makes grad() generally faster but even more so in the case of taking the gradient of nested scans in which the number of calls to grad() would increase exponentially with the number of levels of nested scans. Because of the reduced number of calls to grad() the resulting scan grads have simple graphs and less duplicate nodes so optimization is faster and (because we don't have optimizations for every single case) execution is sometimes faster. Also, execution with no/few optimizations (i.e. FAST_COMPILE), execution is much much faster.

On the LSTM tutorial, on my machine, the time to take the gradients goes from 0.30 to 0.15 seconds, the compilation time goes from 16s to 13s and the time to run the scan_grad drops by ~40% resulting in a global ~20% drop in execution time.

On the following (not-rigorous) graph using nested scans, the time to take the gradients goes from 6.9s to 0.7s seconds, the compilation time goes from 18s to 7s but the execution time stayed the same because the resulting Theano function was the same as without this change.
```
def test_grad_speed():
    a = tensor.fmatrix()
    b = tensor.fmatrix()
    c = tensor.fmatrix()
    d = tensor.fmatrix()
    e = tensor.fmatrix()

    def outer_step(a_1, b_1, c_1, d_1, e_1):
        def inner_step(a_2, b_2, c_2, d_2, e_2):
            total = a_2 + b_2 + c_2 + d_2 + e_2
            total = total + 1 + 1 + 1 + 1
            return total, total, total, total, total

        result_inner, _ = theano.scan(fn=inner_step,
                                      sequences=[a_1, b_1, c_1, d_1, e_1],
                                      name="inner_scan")

        total = (result_inner[0][-1] + result_inner[1][-1] +
                 result_inner[2][-1] + result_inner[3][-1] +
                 result_inner[4][-1])
        return total, total, total, total, total

    result_outer, _ = theano.scan(
        fn=outer_step,
        sequences=[a, b, c, d, e],
        name="outer_scan"
    )
```




