### PR TITLE
Fix GpuFromHost compilation error using libgpuarray

### DIFF
--- a/theano/sandbox/gpuarray/basic_ops.py
+++ b/theano/sandbox/gpuarray/basic_ops.py
@@ -309,7 +309,7 @@ class GpuFromHost(Op):
 
     def c_code(self, node, name, inputs, outputs, sub):
         return """
-        PyGpuArrayObject *%(name)s_tmp;
+        PyArrayObject *%(name)s_tmp;
         %(name)s_tmp = PyArray_GETCONTIGUOUS(%(inp)s);
         if (%(name)s_tmp == NULL)
           %(fail)s


### PR DESCRIPTION
When trying to run a simple Theano example with latest theano / libgpuarray using OpenCL, I ran into the following errors

```python
import theano
import theano.tensor as T
x = T.dmatrix('x')
s = 1 / (1 + T.exp(-x))
logistic = theano.function([x], s)
logistic([[0, 1], [-1, -2]])
```

```
/home/julien.rebetez/.theano/compiledir_Linux-2.6-el6.x86_64-x86_64-with-centos-6.7-Final-x86_64-2.7.10-64/tmpAYEbvH/mod.cpp: In member function ‘int<unnamed>::__struct_compiled_op_1e445e5da5a62eeb42cc430a1d702612::run()’:
/home/julien.rebetez/.theano/compiledir_Linux-2.6-el6.x86_64-x86_64-with-centos-6.7-Final-x86_64-2.7.10-64/tmpAYEbvH/mod.cpp:200: error: cannot convert ‘PyArrayObject*’ to ‘PyGpuArrayObject*’ in assignment
/home/julien.rebetez/.theano/compiledir_Linux-2.6-el6.x86_64-x86_64-with-centos-6.7-Final-x86_64-2.7.10-64/tmpAYEbvH/mod.cpp:211: error: cannot convert ‘PyGpuArrayObject*’ to ‘PyArrayObject*’ for argument ‘1’ to ‘void* PyArray_DATA(PyArrayObject*)’
```

This is due to PyGpuArrayObject being assigned a PyArrayObject (I think this was introduced by 55f671d30cc). This pull request fixes this.