### PR TITLE
Add warning if profile_optimizer=True but profile=False

### DIFF
--- a/doc/extending/optimization.txt
+++ b/doc/extending/optimization.txt
@@ -657,7 +657,8 @@ Detailed profiling of Theano optimizer
 
 You can get more detailed profiling information about the Theano
 optimizer phase by setting to `True` the Theano flags
-:attr:`config.profile_optimizer`.
+:attr:`config.profile_optimizer` (this require `config.profile` to be `True`
+as well).
 
 This will output something like this:
 

--- a/theano/compile/function_module.py
+++ b/theano/compile/function_module.py
@@ -1459,6 +1459,10 @@ class FunctionMaker(object):
                     if theano.config.profile_optimizer:
                         profile.optimizer_profile = (optimizer,
                                                      optimizer_profile)
+                elif theano.config.profile_optimizer:
+                    warnings.warn((
+                        "config.profile_optimizer requires config.profile to "
+                        " be set to True as well"), stacklevel=3)
                 _logger.debug('Optimizing took %f seconds', opt_time)
 
                 # Add deep copy to respect the memory interface


### PR DESCRIPTION
It took me some time to figure out why `config.profile_optimizer` wasn't working (config.profile was False). This adds a small note about this in the optimization doc page and shows a warning if the user forgets to set config.profile to True as well.