### PR TITLE
changing `assert` to `AssertionError`

### DIFF
--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -431,7 +431,8 @@ def grad(cost, wrt, consider_constant=None,
         from theano import tensor
 
     if cost is None:
-        assert known_grads is not None
+        if known_grads is None:
+            raise AssertionError("cost and known_grads can't both be None.")
 
     if cost is not None and isinstance(cost.type, NullType):
         raise ValueError("Can't differentiate a NaN cost."


### PR DESCRIPTION
This `assert` statement does not provide any error message making debugging this case hard. Moreover, `assert` is eliminated when using optimized python code (https://docs.python.org/2.7/reference/simple_stmts.html#the-assert-statement), introducing a potential bug into the system. Explicitly checking and raising an AssertionError addresses both issues.