### PR TITLE
Fix index errors

### DIFF
--- a/theano/sandbox/cuda/dnn_fwd.c
+++ b/theano/sandbox/cuda/dnn_fwd.c
@@ -188,12 +188,12 @@ APPLY_SPECIFIC(conv_fwd)(CudaNdarray *input, CudaNdarray *kerns,
       }
 
       // Extract the spatial size of the filters
-      int filter_h = CudaNdarray_HOST_DIMS(kerns)[3];
-      int filter_w = CudaNdarray_HOST_DIMS(kerns)[4];
+      int filter_h = CudaNdarray_HOST_DIMS(kerns)[2];
+      int filter_w = CudaNdarray_HOST_DIMS(kerns)[3];
 
       // Extract the spatial size of the input
-      int input_h = CudaNdarray_HOST_DIMS(input)[3];
-      int input_w = CudaNdarray_HOST_DIMS(input)[4];
+      int input_h = CudaNdarray_HOST_DIMS(input)[2];
+      int input_w = CudaNdarray_HOST_DIMS(input)[3];
 
       // Ensure that the selected implementation supports the requested
       // convolution. Fall back to a safe implementation otherwise.

--- a/theano/sandbox/cuda/dnn_gi.c
+++ b/theano/sandbox/cuda/dnn_gi.c
@@ -183,12 +183,12 @@ APPLY_SPECIFIC(conv_gi)(CudaNdarray *kerns, CudaNdarray *output,
       }
 
       // Extract the spatial size of the filters
-      int filter_h = CudaNdarray_HOST_DIMS(kerns)[3];
-      int filter_w = CudaNdarray_HOST_DIMS(kerns)[4];
+      int filter_h = CudaNdarray_HOST_DIMS(kerns)[2];
+      int filter_w = CudaNdarray_HOST_DIMS(kerns)[3];
 
       // Extract the spatial size of the input
-      int input_h = CudaNdarray_HOST_DIMS(*input)[3];
-      int input_w = CudaNdarray_HOST_DIMS(*input)[4];
+      int input_h = CudaNdarray_HOST_DIMS(*input)[2];
+      int input_w = CudaNdarray_HOST_DIMS(*input)[3];
 
       // Ensure that the selected implementation supports the requested
       // convolution. Fall back to a safe implementation otherwise.

--- a/theano/sandbox/cuda/dnn_gw.c
+++ b/theano/sandbox/cuda/dnn_gw.c
@@ -183,12 +183,12 @@ APPLY_SPECIFIC(conv_gw)(CudaNdarray *input, CudaNdarray *output,
       }
 
       // Extract the spatial size of the filters
-      int filter_h = CudaNdarray_HOST_DIMS(*kerns)[3];
-      int filter_w = CudaNdarray_HOST_DIMS(*kerns)[4];
+      int filter_h = CudaNdarray_HOST_DIMS(*kerns)[2];
+      int filter_w = CudaNdarray_HOST_DIMS(*kerns)[3];
 
       // Extract the spatial size of the input
-      int input_h = CudaNdarray_HOST_DIMS(input)[3];
-      int input_w = CudaNdarray_HOST_DIMS(input)[4];
+      int input_h = CudaNdarray_HOST_DIMS(input)[2];
+      int input_w = CudaNdarray_HOST_DIMS(input)[3];
 
       // Ensure that the selected implementation supports the requested
       // convolution. Fall back to a safe implementation otherwise.

--- a/theano/sandbox/gpuarray/dnn_fwd.c
+++ b/theano/sandbox/gpuarray/dnn_fwd.c
@@ -154,8 +154,8 @@ APPLY_SPECIFIC(conv_fwd)(PyGpuArrayObject *input, PyGpuArrayObject *kerns,
     }
 
     if (stride[0] != 1 || stride[1] != 1 ||
-        PyGpuArray_DIM(input, 0) > 1024 || PyGpuArray_DIM(input, 1) > 1024 ||
-        (PyGpuArray_DIM(kerns, 0) == 1 && PyGpuArray_DIM(kerns, 1) == 1)) {
+        PyGpuArray_DIM(input, 2) > 1024 || PyGpuArray_DIM(input, 3) > 1024 ||
+        (PyGpuArray_DIM(kerns, 2) == 1 && PyGpuArray_DIM(kerns, 3) == 1)) {
       algo = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM;
     }
   }

--- a/theano/sandbox/gpuarray/dnn_gi.c
+++ b/theano/sandbox/gpuarray/dnn_gi.c
@@ -146,8 +146,8 @@ APPLY_SPECIFIC(conv_gi)(PyGpuArrayObject *kerns, PyGpuArrayObject *output,
     }
 
     if (stride[0] != 1 || stride[1] != 1 ||
-        PyGpuArray_DIM(*input, 0) > 1024 || PyGpuArray_DIM(*input, 1) > 1024 ||
-        (PyGpuArray_DIM(kerns, 0) == 1 && PyGpuArray_DIM(kerns, 1) == 1)) {
+        PyGpuArray_DIM(*input, 2) > 1024 || PyGpuArray_DIM(*input, 3) > 1024 ||
+        (PyGpuArray_DIM(kerns, 2) == 1 && PyGpuArray_DIM(kerns, 3) == 1)) {
       algo = CUDNN_CONVOLUTION_BWD_DATA_ALGO_0;
     }
   }

--- a/theano/sandbox/gpuarray/dnn_gw.c
+++ b/theano/sandbox/gpuarray/dnn_gw.c
@@ -148,8 +148,8 @@ APPLY_SPECIFIC(conv_gw)(PyGpuArrayObject *input, PyGpuArrayObject *output,
     }
 
     if (stride[0] != 1 || stride[1] != 1 ||
-        PyGpuArray_DIM(input, 0) > 1024 || PyGpuArray_DIM(input, 1) > 1024 ||
-        (PyGpuArray_DIM(*kerns, 0) == 1 && PyGpuArray_DIM(*kerns, 1) == 1)) {
+        PyGpuArray_DIM(input, 2) > 1024 || PyGpuArray_DIM(input, 3) > 1024 ||
+        (PyGpuArray_DIM(*kerns, 2) == 1 && PyGpuArray_DIM(*kerns, 3) == 1)) {
       algo = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0;
     }
   }


### PR DESCRIPTION
In all 6 modified files, the code was supposed to look at the spatial dimensions of the inputs and the filters in the case of 2d convolution.

These should be dimensions with 2 and 3 since the input dimensions are (batch, channel, 0, 1) and the filter dimensions are (filter, channel, 0, 1). However, in both backends, the indices were wrong. This meant that the FFT implementation was not used in many cases where it could have been used.