### PR TITLE
Cast Py_None to PyTypeObject * to satisfy g++ 4.9.

### DIFF
--- a/theano/sandbox/gpuarray/basic_ops.py
+++ b/theano/sandbox/gpuarray/basic_ops.py
@@ -423,7 +423,7 @@ class GpuFromHost(Op):
                                        (size_t *)PyArray_DIMS(%(name)s_tmp),
                                        (ssize_t *)PyArray_STRIDES(%(name)s_tmp),
                                        %(ctx)s,
-                                       Py_None);
+                                       (PyTypeObject *)Py_None);
           Py_DECREF(%(name)s_tmp);
           if (%(out)s == NULL) {
               %(fail)s
@@ -573,7 +573,7 @@ class GpuAlloc(HideC, Alloc):
             Py_XDECREF(%(zz)s);
             %(zz)s = pygpu_zeros(%(ndim)s, %(name)s_shape,
                                  %(vv)s->ga.typecode, GA_C_ORDER,
-                                 %(ctx)s, Py_None);
+                                 %(ctx)s, (PyTypeObject *)Py_None);
             if (!%(zz)s) {
                 %(fail)s
             }
@@ -582,7 +582,7 @@ class GpuAlloc(HideC, Alloc):
                 Py_XDECREF(%(zz)s);
                 %(zz)s = pygpu_empty(%(ndim)s, %(name)s_shape,
                                      %(vv)s->ga.typecode, GA_C_ORDER,
-                                     %(ctx)s, Py_None);
+                                     %(ctx)s, (PyTypeObject *)Py_None);
                 if (!%(zz)s) {
                     %(fail)s
                 }
@@ -1060,7 +1060,7 @@ KERNEL void k(GLOBAL_MEM %(ctype)s *a, ga_size n, ga_size m) {
         %(z)s = pygpu_zeros(2, dims,
                             %(typecode)s,
                             GA_C_ORDER,
-                            %(ctx)s, Py_None);
+                            %(ctx)s, (PyTypeObject *)Py_None);
         if (%(z)s == NULL) {
             %(fail)s
         }

--- a/theano/sandbox/gpuarray/conv.cu
+++ b/theano/sandbox/gpuarray/conv.cu
@@ -1243,7 +1243,7 @@ PyGpuArray_Conv(PyGpuArrayObject *img, PyGpuArrayObject * kern,
 
       rval = pygpu_zeros(4, out_dim,
                          img->ga.typecode, GA_C_ORDER,
-                         img->context, Py_None);
+                         img->context, (PyTypeObject *)Py_None);
       //rval might be null
     }
     if ((rval==NULL)

--- a/theano/sandbox/gpuarray/elemwise.py
+++ b/theano/sandbox/gpuarray/elemwise.py
@@ -315,7 +315,7 @@ class GpuElemwise(GpuKernelBase, HideC, Elemwise):
         {
             %(oname)s = pygpu_empty(%(nd)d, dims,
                             %(typecode)s, GA_C_ORDER,
-                            %(ctx)s, Py_None);
+                            %(ctx)s, (PyTypeObject *)Py_None);
             if (!%(oname)s) {
                 %(fail)s
             }
@@ -776,7 +776,7 @@ class GpuCAReduceCuda(GpuKernelBase, HideC, CAReduceDtype):
             Py_XDECREF(%(z)s);
             %(z)s = pygpu_empty(%(nd_out)s, new_dims,
                                 %(out_typecode)s, GA_C_ORDER,
-                                %(ctx)s, Py_None);
+                                %(ctx)s, (PyTypeObject *)Py_None);
             if (NULL == %(z)s)
             {
                 PyErr_Format(PyExc_RuntimeError, "Failed to allocate output");
@@ -2770,7 +2770,7 @@ class GpuCAReduceCPY(GpuKernelBase, HideC, CAReduceDtype):
                     j += 1
             code += """
          if (need_out) {
-             %(output)s = pygpu_empty(%(nd_out)s, out_dims, %(out_type)s, GA_C_ORDER, %(ctx)s, Py_None);
+             %(output)s = pygpu_empty(%(nd_out)s, out_dims, %(out_type)s, GA_C_ORDER, %(ctx)s, (PyTypeObject *)Py_None);
              if (!%(output)s) {
                  %(fail)s
              }
@@ -2783,7 +2783,7 @@ class GpuCAReduceCPY(GpuKernelBase, HideC, CAReduceDtype):
         if (%(output)s == NULL || %(output)s->ga.nd != 0) {
             Py_XDECREF(%(output)s);
             %(output)s = pygpu_empty(0, NULL, %(out_type)s, GA_C_ORDER,
-                                     %(ctx)s, Py_None);
+                                     %(ctx)s, (PyTypeObject *)Py_None);
             if (!%(output)s) {
                 %(fail)s
             }
@@ -2794,7 +2794,7 @@ class GpuCAReduceCPY(GpuKernelBase, HideC, CAReduceDtype):
         if acc_dtype != node.outputs[0].type.dtype:
             code += """
         tmp = pygpu_empty(%(output)s->ga.nd, %(output)s->ga.dimensions,
-                          %(acc_type)s, GA_C_ORDER, %(ctx)s, Py_None);
+                          %(acc_type)s, GA_C_ORDER, %(ctx)s, (PyTypeObject *)Py_None);
         if (!tmp) %(fail)s
         """ % dict(output=output, fail=sub['fail'], ctx=sub['context'],
                    acc_type=dtype_to_typecode(acc_dtype))

--- a/theano/sandbox/gpuarray/gemm16.c
+++ b/theano/sandbox/gpuarray/gemm16.c
@@ -3,7 +3,7 @@
 /* Why do we need this? */
 size_t dim = 2048 * 32;
 rand_buf = pygpu_empty(1, &dim, GA_UINT, GA_C_ORDER, CONTEXT,
-                       Py_None);
+                       (PyTypeObject *)Py_None);
 if (rand_buf == NULL) {
   FAIL;
 }

--- a/theano/sandbox/gpuarray/gpuarray_helper.h
+++ b/theano/sandbox/gpuarray/gpuarray_helper.h
@@ -22,7 +22,7 @@ static int theano_prep_output(PyGpuArrayObject **out, unsigned int nd,
   }
 
   Py_XDECREF(*out);
-  *out = pygpu_empty(nd, dims, typecode, ord, c, Py_None);
+  *out = pygpu_empty(nd, dims, typecode, ord, c, (PyTypeObject *)Py_None);
   return (*out == NULL) ? 1 : 0;
 }
 

--- a/theano/sandbox/gpuarray/neighbours.py
+++ b/theano/sandbox/gpuarray/neighbours.py
@@ -377,7 +377,7 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                 dims[0] = z_dim0;
                 dims[1] = z_dim1;
                 %(z)s = pygpu_empty(2, dims, %(typecode_z)s,
-                                    GA_C_ORDER, %(ctx)s, Py_None);
+                                    GA_C_ORDER, %(ctx)s, (PyTypeObject *)Py_None);
                 if (!%(z)s)
                 {
                     PyErr_SetString(PyExc_MemoryError, "GpuImages2Neibs:"

--- a/theano/sandbox/gpuarray/nnet.py
+++ b/theano/sandbox/gpuarray/nnet.py
@@ -222,7 +222,7 @@ class GpuCrossentropySoftmaxArgmax1HotWithBias(GpuKernelBase, Op):
             Py_XDECREF(%(nll)s);
             %(nll)s = pygpu_empty(1, PyGpuArray_DIMS(%(y_idx)s),
                                 %(typecode_x)s, GA_C_ORDER, %(ctx)s,
-                                Py_None);
+                                (PyTypeObject *)Py_None);
             if (!%(nll)s) {
                 %(fail)s
             }
@@ -236,7 +236,7 @@ class GpuCrossentropySoftmaxArgmax1HotWithBias(GpuKernelBase, Op):
             Py_XDECREF(%(sm)s);
             %(sm)s = pygpu_empty(2, PyGpuArray_DIMS(%(x)s),
                                 %(typecode_b)s, GA_C_ORDER,
-                                %(ctx)s, Py_None);
+                                %(ctx)s, (PyTypeObject *)Py_None);
             if(!%(sm)s)
             {
                 PyErr_SetString(PyExc_MemoryError,
@@ -252,7 +252,7 @@ class GpuCrossentropySoftmaxArgmax1HotWithBias(GpuKernelBase, Op):
             Py_XDECREF(%(am)s);
             %(am)s = pygpu_empty(1, PyGpuArray_DIMS(%(y_idx)s),
                                 %(typecode_y_idx)s, GA_C_ORDER,
-                                %(ctx)s, Py_None);
+                                %(ctx)s, (PyTypeObject *)Py_None);
             if(!%(am)s)
             {
                 PyErr_SetString(PyExc_MemoryError,
@@ -414,7 +414,7 @@ class GpuCrossentropySoftmax1HotWithBiasDx(GpuKernelBase, Op):
             Py_XDECREF(%(dx)s);
             %(dx)s = pygpu_empty(2, PyGpuArray_DIMS(%(sm)s),
                                  %(typecode_dx)s, GA_C_ORDER,
-                                 %(ctx)s, Py_None);
+                                 %(ctx)s, (PyTypeObject *)Py_None);
             if (!%(dx)s) {
                 %(fail)s
             }
@@ -583,7 +583,7 @@ class GpuSoftmax(GpuKernelBase, Op):
             Py_XDECREF(%(z)s);
             %(z)s = pygpu_empty(2, PyGpuArray_DIMS(%(x)s),
                                 %(typecode)s, GA_C_ORDER,
-                                %(ctx)s, Py_None);
+                                %(ctx)s, (PyTypeObject *)Py_None);
             if (!%(z)s) {
                 %(fail)s
             }
@@ -797,7 +797,7 @@ class GpuSoftmaxWithBias(GpuKernelBase, Op):
             Py_XDECREF(%(z)s);
             %(z)s = pygpu_empty(2, PyGpuArray_DIMS(%(x)s),
                                 %(typecode)s, GA_C_ORDER,
-                                %(ctx)s, Py_None);
+                                %(ctx)s, (PyTypeObject *)Py_None);
             if (!%(z)s) {
                 %(fail)s
             }

--- a/theano/sandbox/gpuarray/subtensor.py
+++ b/theano/sandbox/gpuarray/subtensor.py
@@ -457,7 +457,7 @@ if (%(out)s == NULL || !GpuArray_IS_C_CONTIGUOUS(&%(out)s->ga) ||
   tmp = %(v)s->ga.dimensions[0];
   %(v)s->ga.dimensions[0] = %(idx)s->ga.dimensions[0];
   %(out)s = pygpu_empty(%(v)s->ga.nd, %(v)s->ga.dimensions, %(v)s->ga.typecode,
-                        GA_C_ORDER, %(v)s->context, Py_None);
+                        GA_C_ORDER, %(v)s->context, (PyTypeObject *)Py_None);
   %(v)s->ga.dimensions[0] = tmp; // Don't remove this line
 }
 


### PR DESCRIPTION
Otherwise there are a bunch of compile errors in the new backend.