### PR TITLE
Add print_test_value_by_default option

### DIFF
--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -861,6 +861,13 @@ import theano and print the config variable, as in:
    optimization phase. Theano user's do not need to use this. This is
    to help debug shape error in Theano optimization.
 
+.. attribute:: print_test_value
+
+    Bool value, default: False 
+
+    If ``'True'``, Theano will override the '__str__' method of its variables 
+    to also print the tag.test_value when this is available.
+
 .. attribute:: reoptimize_unpickled_function
 
     Bool value, default: False (changed in master after Theano 0.7 release)

--- a/theano/compile/debugmode.py
+++ b/theano/compile/debugmode.py
@@ -764,7 +764,7 @@ def debugprint(r, prefix='', depth=-1, done=None, print_type=False,
                 outer_id_str = get_id_str(outer_r.owner)
             else:
                 outer_id_str = get_id_str(outer_r)
-            print('%s%s %s%s -> %s' % (prefix, r, id_str, type_str,
+            print('%s%s %s%s -> %s' % (prefix, r.__str_name__(), id_str, type_str,
                                        outer_id_str), file=file)
         else:
             # this is an input variable
@@ -772,7 +772,7 @@ def debugprint(r, prefix='', depth=-1, done=None, print_type=False,
             if smap:
                 data = " " + str(smap.get(r, ''))
             id_str = get_id_str(r)
-            print('%s%s %s%s%s' % (prefix, r, id_str,
+            print('%s%s %s%s%s' % (prefix, r.__str_name__(), id_str,
                                    type_str, data),
                   file=file)
 

--- a/theano/compile/debugmode.py
+++ b/theano/compile/debugmode.py
@@ -764,7 +764,7 @@ def debugprint(r, prefix='', depth=-1, done=None, print_type=False,
                 outer_id_str = get_id_str(outer_r.owner)
             else:
                 outer_id_str = get_id_str(outer_r)
-            print('%s%s %s%s -> %s' % (prefix, r.__str_name__(), id_str, type_str,
+            print('%s%s %s%s -> %s' % (prefix, r, id_str, type_str,
                                        outer_id_str), file=file)
         else:
             # this is an input variable
@@ -772,7 +772,7 @@ def debugprint(r, prefix='', depth=-1, done=None, print_type=False,
             if smap:
                 data = " " + str(smap.get(r, ''))
             id_str = get_id_str(r)
-            print('%s%s %s%s%s' % (prefix, r.__str_name__(), id_str,
+            print('%s%s %s%s%s' % (prefix, r, id_str,
                                    type_str, data),
                   file=file)
 

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -645,7 +645,7 @@ AddConfigVar(
 
 
 AddConfigVar(
-    'print_test_value_by_default',
+    'print_test_value',
     ("If 'True', Theano will override the '__str__' method of its "
      "variables to also print the tag.test_value when this is available."),
     BoolParam(False),

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -646,8 +646,10 @@ AddConfigVar(
 
 AddConfigVar(
     'print_test_value',
-    ("If 'True', Theano will override the '__str__' method of its "
-     "variables to also print the tag.test_value when this is available."),
+    ("If 'True', the __eval__ of a Theano variable will return its test_value "
+     "when this is available. This has the practical conseguence that, e.g., "
+     "in debugging `my_var` will print the same as `my_var.tag.test_value` "
+     "when a test value is defined."),
     BoolParam(False),
     in_c_key=False)
 

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -644,6 +644,14 @@ AddConfigVar(
     in_c_key=False)
 
 
+AddConfigVar(
+    'print_test_value_by_default',
+    ("If 'True', Theano will override the '__str__' method of its "
+     "variables to also print the tag.test_value when this is available."),
+    BoolParam(False),
+    in_c_key=False)
+
+
 AddConfigVar('compute_test_value_opt',
              ("For debugging Theano optimization only."
               " Same as compute_test_value, but is used"

--- a/theano/gof/graph.py
+++ b/theano/gof/graph.py
@@ -391,38 +391,44 @@ class Variable(Node):
         self.name = name
         self.auto_name = 'auto_' + str(next(self.__count__))
 
-    def __str__(self):
-        """
-        WRITEME
+    def __str__(self, firstPass=True):
+        """Return a str representation of the Variable
 
+        Return a printable name or description of the Variable. If
+        config.print_test_value is True it will also print the test_value if
+        any.
         """
-        if config.print_test_value_by_default:
-            if self.__get_test_value__() is not None:
-                return '\n'.join([self.__str_name__(),
-                                 self.__get_test_value__()])
-        return self.__str_name__()
+        to_print = []
+        if config.print_test_value and firstPass:
+            try:
+                to_print.append(self.__str_test_value__())
+            except AttributeError:
+                return self.__str__(False)
 
-    def __str_name__(self):
-        """
-        WRITEME
-
-        """
         if self.name is not None:
-            return self.name
+            return '\n'.join([self.name] + to_print)
         if self.owner is not None:
             op = self.owner.op
             if self.index == op.default_output:
-                return str(self.owner.op) + ".out"
+                return '\n'.join(
+                    [str(self.owner.op) + ".out"] + to_print)
             else:
-                return str(self.owner.op) + "." + str(self.index)
+                return '\n'.join(
+                    [str(self.owner.op) + "." + str(self.index)] + to_print)
         else:
-            return "<%s>" % str(self.type)
+            return '\n'.join(["<%s>" % str(self.type)] + to_print)
 
-    def __get_test_value__(self):
+    def __str_test_value__(self):
+        """Return a repr of the test value
+
+        Return a printable representation of the test value. It can be
+        overridden by classes with non printable test_value to provide a
+        suitable representation of the test_value.
+        """
         try:
-            return repr(self.tag.test_value)
-        except AttributeError:
-            return None
+            return repr(theano.gof.op.get_test_value(self))
+        except:
+            raise
 
     def __repr__(self):
         return str(self)

--- a/theano/gof/graph.py
+++ b/theano/gof/graph.py
@@ -12,6 +12,7 @@ from copy import copy
 from itertools import count
 
 import theano
+from theano import config
 from theano.gof import utils
 from six import string_types, integer_types, iteritems
 from theano.misc.ordered_set import OrderedSet
@@ -395,6 +396,17 @@ class Variable(Node):
         WRITEME
 
         """
+        if config.print_test_value_by_default:
+            if self.__get_test_value__() is not None:
+                return '\n'.join([self.__str_name__(),
+                                 self.__get_test_value__()])
+        return self.__str_name__()
+
+    def __str_name__(self):
+        """
+        WRITEME
+
+        """
         if self.name is not None:
             return self.name
         if self.owner is not None:
@@ -405,6 +417,12 @@ class Variable(Node):
                 return str(self.owner.op) + "." + str(self.index)
         else:
             return "<%s>" % str(self.type)
+
+    def __get_test_value__(self):
+        try:
+            return repr(self.tag.test_value)
+        except AttributeError:
+            return None
 
     def __repr__(self):
         return str(self)

--- a/theano/gof/graph.py
+++ b/theano/gof/graph.py
@@ -391,47 +391,44 @@ class Variable(Node):
         self.name = name
         self.auto_name = 'auto_' + str(next(self.__count__))
 
-    def __str__(self, firstPass=True):
-        """Return a str representation of the Variable
+    def __str__(self):
+        """Return a str representation of the Variable.
 
-        Return a printable name or description of the Variable. If
-        config.print_test_value is True it will also print the test_value if
-        any.
         """
-        to_print = []
-        if config.print_test_value and firstPass:
-            try:
-                to_print.append(self.__str_test_value__())
-            except AttributeError:
-                return self.__str__(False)
-
         if self.name is not None:
-            return '\n'.join([self.name] + to_print)
+            return self.name
         if self.owner is not None:
             op = self.owner.op
             if self.index == op.default_output:
-                return '\n'.join(
-                    [str(self.owner.op) + ".out"] + to_print)
+                return str(self.owner.op) + ".out"
             else:
-                return '\n'.join(
-                    [str(self.owner.op) + "." + str(self.index)] + to_print)
+                return str(self.owner.op) + "." + str(self.index)
         else:
-            return '\n'.join(["<%s>" % str(self.type)] + to_print)
+            return "<%s>" % str(self.type)
 
-    def __str_test_value__(self):
-        """Return a repr of the test value
+    def __repr_test_value__(self):
+        """Return a repr of the test value.
 
         Return a printable representation of the test value. It can be
         overridden by classes with non printable test_value to provide a
         suitable representation of the test_value.
         """
-        try:
-            return repr(theano.gof.op.get_test_value(self))
-        except:
-            raise
+        return repr(theano.gof.op.get_test_value(self))
 
-    def __repr__(self):
-        return str(self)
+    def __repr__(self, firstPass=True):
+        """Return a repr of the Variable.
+
+        Return a printable name or description of the Variable. If
+        config.print_test_value is True it will also print the test_value if
+        any.
+        """
+        to_print = [str(self)]
+        if config.print_test_value and firstPass:
+            try:
+                to_print.append(self.__repr_test_value__())
+            except AttributeError:
+                pass
+        return '\n'.join(to_print)
 
     def clone(self):
         """

--- a/theano/sandbox/cuda/var.py
+++ b/theano/sandbox/cuda/var.py
@@ -45,11 +45,8 @@ class CudaNdarrayVariable(_operators, Variable):
     pass
 
     # override default
-    def __str_test_value__(self):
-        try:
-            return repr(numpy.array(theano.gof.op.get_test_value(self)))
-        except:
-            raise
+    def __repr_test_value__(self):
+        return repr(numpy.array(theano.gof.op.get_test_value(self)))
 CudaNdarrayType.Variable = CudaNdarrayVariable
 
 

--- a/theano/sandbox/cuda/var.py
+++ b/theano/sandbox/cuda/var.py
@@ -43,6 +43,13 @@ class _operators(tensor.basic._tensor_py_operators):
 
 class CudaNdarrayVariable(_operators, Variable):
     pass
+
+    # override default
+    def __str_test_value__(self):
+        try:
+            return repr(numpy.array(theano.gof.op.get_test_value(self)))
+        except:
+            raise
 CudaNdarrayType.Variable = CudaNdarrayVariable
 
 

--- a/theano/sandbox/gpuarray/type.py
+++ b/theano/sandbox/gpuarray/type.py
@@ -420,6 +420,9 @@ class _operators(_tensor_py_operators):
 
 
 class GpuArrayVariable(_operators, Variable):
+    # override the default
+    def __repr_test_value__(self):
+        return repr(numpy.array(theano.gof.op.get_test_value(self)))
     pass
 
 


### PR DESCRIPTION
Add a configuration option to override `Variable.__str__` and print the `tag.test_value` after the variable name by default. By default the option is disabled.

@lamblin Thank you very much for the assistance!