### PR TITLE
Fix pydotprint issue for Python 3

### DIFF
--- a/theano/printing.py
+++ b/theano/printing.py
@@ -865,8 +865,8 @@ def pydotprint(fct, outfile=None,
     # it, we must copy it.
     outputs = list(outputs)
     if isinstance(fct, Function):
-        for i, fg_ii in reversed(zip(fct.maker.expanded_inputs,
-                                     fct.maker.fgraph.inputs)):
+        function_inputs = zip(fct.maker.expanded_inputs, fct.maker.fgraph.inputs)
+        for i, fg_ii in reversed(list(function_inputs)):
             if i.update is not None:
                 k = outputs.pop()
                 # Use the fgaph.inputs as it isn't the same as maker.inputs


### PR DESCRIPTION
The main problem is that `zip` function in Python 3 is an iterator and `reversed` function doesn't work with an iterators. 

Previously I got `TypeError` exception: 

```
  File "theano/printing.py", line 847, in pydotprint
    fct.maker.fgraph.inputs)):
TypeError: argument to reversed() must be a sequence
```

That fix works fine for me in Python 3.4