### PR TITLE
Add OpenMP support to CorrMM.

### DIFF
--- a/theano/tensor/nnet/corr.py
+++ b/theano/tensor/nnet/corr.py
@@ -7,13 +7,13 @@ from theano import gof
 from theano.tensor import as_tensor_variable, TensorType
 from theano.tensor.nnet.abstract_conv2d import get_conv_output_shape
 from theano.tensor.blas_headers import blas_header_text
-from theano.tensor.blas import ldflags
+from theano.tensor.blas import ldflags, blas_header_version
 
 
 _logger = logging.getLogger(__name__)
 
 
-class BaseCorrMM(gof.Op):
+class BaseCorrMM(gof.OpenMPOp):
     """
     Base class for `CorrMM`, `CorrMM_gradWeights` and
     `CorrMM_gradInputs`. Cannot be used directly.
@@ -29,7 +29,8 @@ class BaseCorrMM(gof.Op):
     check_broadcast = False
     __props__ = ('border_mode', 'subsample')
 
-    def __init__(self, border_mode="valid", subsample=(1, 1)):
+    def __init__(self, border_mode="valid", subsample=(1, 1), openmp=None):
+        super(BaseCorrMM, self).__init__(openmp=openmp)
         if isinstance(border_mode, int):
             if border_mode < 0:
                 raise ValueError(
@@ -73,7 +74,11 @@ class BaseCorrMM(gof.Op):
         return ldflags()
 
     def c_compile_args(self):
-        return ldflags(libs=False, flags=True)
+        ret = ldflags(libs=False, flags=True)
+        # Add the -fopenmp flags
+        ret += super(BaseCorrMM, self).c_compile_args()
+
+        return ret
 
     def c_lib_dirs(self):
         return ldflags(libs=False, libs_dir=True)
@@ -86,7 +91,7 @@ class BaseCorrMM(gof.Op):
 
     def c_code_cache_version(self):
         # raise this whenever modifying any of the support_code_files
-        return (1, 0)
+        return (2, self.openmp, blas_header_version())
 
     def c_support_code_apply(self, node, nodename):
         # REMEMBER TO RAISE c_code_cache_version when changing any of
@@ -354,8 +359,8 @@ class CorrMM(BaseCorrMM):
         Set to `(1, 1)` to disable subsampling.
 
     """
-    def __init__(self, border_mode="valid", subsample=(1, 1)):
-        super(CorrMM, self).__init__(border_mode, subsample)
+    def __init__(self, border_mode="valid", subsample=(1, 1), openmp=None):
+        super(CorrMM, self).__init__(border_mode, subsample, openmp=openmp)
 
     def make_node(self, img, kern):
         img = as_tensor_variable(img)
@@ -410,8 +415,8 @@ class CorrMM_gradWeights(BaseCorrMM):
 
     """
 
-    def __init__(self, border_mode="valid", subsample=(1, 1)):
-        super(CorrMM_gradWeights, self).__init__(border_mode, subsample)
+    def __init__(self, border_mode="valid", subsample=(1, 1), openmp=None):
+        super(CorrMM_gradWeights, self).__init__(border_mode, subsample, openmp=openmp)
 
     def make_node(self, img, topgrad, shape=None):
         img = as_tensor_variable(img)
@@ -507,8 +512,8 @@ class CorrMM_gradInputs(BaseCorrMM):
 
     """
 
-    def __init__(self, border_mode="valid", subsample=(1, 1)):
-        super(CorrMM_gradInputs, self).__init__(border_mode, subsample)
+    def __init__(self, border_mode="valid", subsample=(1, 1), openmp=None):
+        super(CorrMM_gradInputs, self).__init__(border_mode, subsample, openmp=openmp)
 
     def make_node(self, kern, topgrad, shape=None):
         kern = as_tensor_variable(kern)

--- a/theano/tensor/nnet/corr_gemm.c
+++ b/theano/tensor/nnet/corr_gemm.c
@@ -203,6 +203,7 @@ PyArrayObject* corrMM(PyArrayObject* bottom,
         output = top;
         // valid correlation: im2col, then gemm
         // Iterate over batch
+        #pragma omp parallel for schedule(static)
         for (int n = 0; n < batchSize; n++) {
             // First, im2col
             im2col((%(float_type)s*)PyArray_DATA(bottom) + n * bottom_stride, nChannels, bottomHeight,
@@ -303,6 +304,7 @@ PyArrayObject* corrMM(PyArrayObject* bottom,
         PyArray_FILLWBYTE(bottom, 0);
         // full convolution: gemm, then col2im
         // Iterate over batch
+        #pragma omp parallel for schedule(static)
         for (int n = 0; n < batchSize; n++) {
             // gemm into columns
             %(gemm)s(&NTrans, &Trans,

--- a/theano/tensor/nnet/corr_gemm.c
+++ b/theano/tensor/nnet/corr_gemm.c
@@ -262,6 +262,7 @@ PyArrayObject* corrMM(PyArrayObject* bottom,
         output = weight;
         // valid convolution: im2col, then gemm
         // Iterate over batch
+        #pragma omp parallel for schedule(static)
         for (int n = 0; n < batchSize; n++) {
             // First, im2col
             im2col((%(float_type)s*)PyArray_DATA(bottom) + n * bottom_stride, nChannels, bottomHeight,


### PR DESCRIPTION
This patch results in a ~5x performance gain when combined with #3618 for my MNIST-like CNN when run on an 80-core machine. This improvement is seen both during training and during forward operation.