### PR TITLE
Fixes cl.exe not being seen on Windows

### DIFF
--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -69,6 +69,8 @@ if ((err = cudnnCreate(&_handle)) != CUDNN_STATUS_SUCCESS) {
                 params.append("-I" + config.dnn.include_path)
             if config.dnn.library_path:
                 params.append("-L" + config.dnn.library_path)
+            if config.nvcc.compiler_bindir:
+                params.extend(['--compiler-bindir', config.nvcc.compiler_bindir])
             # Do not run here the test program. It would run on the
             # default gpu, not the one selected by the user. If mixed
             # GPU are installed or if the GPUs are configured in


### PR DESCRIPTION
On Windows, in `theano.sandbox.cuda.dnn.dnn_available()`, `comp`, `out` and `err` evaluate to:

```python
False
b"nvcc fatal   : Cannot find compiler 'cl.exe' in PATH\r\n"
b''
```
So I found it necessary to add the `--compiler-bindir` flag to the source, in order to actually use CuDNN.