### PR TITLE
Fix get_conv_output_shape for symbolic input

### DIFF
--- a/theano/tensor/nnet/abstract_conv2d.py
+++ b/theano/tensor/nnet/abstract_conv2d.py
@@ -43,8 +43,8 @@ def get_conv_output_shape(image_shape, kernel_shape,
         output channels, height and width of the image. None where undefined.
 
     """
-    bsize, imshp = image_shape[0], list(image_shape[2:])
-    nkern, kshp = kernel_shape[0], list(kernel_shape[2:])
+    bsize, imshp = image_shape[0], image_shape[2:]
+    nkern, kshp = kernel_shape[0], kernel_shape[2:]
     if isinstance(border_mode, tuple):
         out_shp = tuple(get_conv_shape_1axis(
             imshp[i], kshp[i], border_mode[i], subsample[i])


### PR DESCRIPTION
Fixes #3699 for me. This removes a call to `list` on a symbolic shape vector, which was breaking dnn_conv.

@laurent-dinh was there was a reason for this call to list in cases of non-symbolic input? I may leave it to your travis build to find out :)