### PR TITLE
Release the GIL in the new back-end to allow multi-threads computation.

### DIFF
--- a/theano/misc/check_multi_gpu.py
+++ b/theano/misc/check_multi_gpu.py
@@ -76,21 +76,14 @@ def main(dev1, dev2):
     t2 = time.time()
     r = None
 
-    print("two ctx, 2 fct async, 1 thread %f" % (t2 - t,))
+    print("two ctx, 2 fct async %f" % (t2 - t,))
 
     t = time.time()
     r = f5.fn()
     r2 = f6.fn()
     t2 = time.time()
     r = None
-    print("two ctx, 2 fct with transfer, 1 thread %f" % (t2 - t,))
-
-    t = time.time()
-    r = f5()
-    t2 = time.time()
-    r = None
-
-    print("one ctx, 1 fct with transfer, 1 thread %f" % (t2 - t,))
+    print("two ctx, 2 fct with transfer %f" % (t2 - t,))
 
     # Multi-thread version
     class myThread (threading.Thread):
@@ -104,13 +97,14 @@ def main(dev1, dev2):
             # print "Starting " + self.name
             # r = self.f.fn(n_calls=10)
             r = self.f()
+            # print "End " + self.name
             if self.sync:
                 r[0].sync()
             self.r = r
             # print "Exiting " + self.name
 
-    thread1 = myThread("Thread-1", f3, True)
-    thread2 = myThread("Thread-2", f4, True)
+    thread1 = myThread("Thread-3", f3, True)
+    thread2 = myThread("Thread-4", f4, True)
     t = time.time()
     thread1.start()
     thread2.start()
@@ -120,32 +114,8 @@ def main(dev1, dev2):
 
     print("two ctx, 2 fct async, 2 threads %f" % (t2 - t,))
 
-    thread1 = myThread("Thread-1", f3, True)
-    thread2 = myThread("Thread-2", f4, True)
-    t = time.time()
-    thread1.start()
-    thread2.start()
-    thread2.join()
-    thread1.join()
-    t2 = time.time()
-
-    print("two ctx, 2 fct async, 2 threads %f reverse join" % (t2 - t,))
-
-    thread1 = myThread("Thread-1", f3, False)
-    thread2 = myThread("Thread-2", f4, False)
-    t = time.time()
-    thread1.start()
-    thread2.start()
-    thread1.join()
-    thread2.join()
-    thread1.r[0].sync()
-    thread2.r[0].sync()
-    t2 = time.time()
-
-    print("two ctx, 2 fct async + late sync, 2 threads %f" % (t2 - t,))
-
-    thread1 = myThread("Thread-3", f5, False)
-    thread2 = myThread("Thread-4", f6, False)
+    thread1 = myThread("Thread-5", f5, False)
+    thread2 = myThread("Thread-6", f6, False)
     t = time.time()
     thread1.start()
     thread2.start()
@@ -155,16 +125,6 @@ def main(dev1, dev2):
 
     print("two ctx, 2 fct with transfer, 2 threads %f" % (t2 - t,))
 
-    thread1 = myThread("Thread-3", f5, False)
-    thread2 = myThread("Thread-4", f6, False)
-    t = time.time()
-    thread1.start()
-    thread2.start()
-    thread2.join()
-    thread1.join()
-    t2 = time.time()
-
-    print("two ctx, 2 fct with transfer, 2 threads %f reverse join" % (t2 - t,))
 
 if __name__ == '__main__':
     import sys

--- a/theano/misc/check_multi_gpu.py
+++ b/theano/misc/check_multi_gpu.py
@@ -106,6 +106,7 @@ def main(dev1, dev2):
             r = self.f()
             if self.sync:
                 r[0].sync()
+            self.r = r
             # print "Exiting " + self.name
 
     thread1 = myThread("Thread-1", f3, True)
@@ -119,6 +120,30 @@ def main(dev1, dev2):
 
     print("two ctx, 2 fct async, 2 threads %f" % (t2 - t,))
 
+    thread1 = myThread("Thread-1", f3, True)
+    thread2 = myThread("Thread-2", f4, True)
+    t = time.time()
+    thread1.start()
+    thread2.start()
+    thread2.join()
+    thread1.join()
+    t2 = time.time()
+
+    print("two ctx, 2 fct async, 2 threads %f reverse join" % (t2 - t,))
+
+    thread1 = myThread("Thread-1", f3, False)
+    thread2 = myThread("Thread-2", f4, False)
+    t = time.time()
+    thread1.start()
+    thread2.start()
+    thread1.join()
+    thread2.join()
+    thread1.r[0].sync()
+    thread2.r[0].sync()
+    t2 = time.time()
+
+    print("two ctx, 2 fct async + late sync, 2 threads %f" % (t2 - t,))
+
     thread1 = myThread("Thread-3", f5, False)
     thread2 = myThread("Thread-4", f6, False)
     t = time.time()
@@ -129,6 +154,17 @@ def main(dev1, dev2):
     t2 = time.time()
 
     print("two ctx, 2 fct with transfer, 2 threads %f" % (t2 - t,))
+
+    thread1 = myThread("Thread-3", f5, False)
+    thread2 = myThread("Thread-4", f6, False)
+    t = time.time()
+    thread1.start()
+    thread2.start()
+    thread2.join()
+    thread1.join()
+    t2 = time.time()
+
+    print("two ctx, 2 fct with transfer, 2 threads %f reverse join" % (t2 - t,))
 
 if __name__ == '__main__':
     import sys

--- a/theano/misc/check_multi_gpu.py
+++ b/theano/misc/check_multi_gpu.py
@@ -21,19 +21,14 @@ def main(dev1, dev2):
     init_dev(dev2, 'ctx2')
 
     size = 1024 * 16
-    val1a = shared(numpy.random.randn(size, size).astype('float32'),
-                   target='ctx1')
-    val1b = shared(numpy.random.randn(size, size).astype('float32'),
-                   target='ctx1')
-    val1c = shared(numpy.random.randn(size, size).astype('float32'),
-                   target='ctx1')
-    val1d = shared(numpy.random.randn(size, size).astype('float32'),
-                   target='ctx1')
+    data = numpy.random.randn(size, size).astype('float32')
+    val1a = shared(data, target='ctx1')
+    val1b = shared(data, target='ctx1')
+    val1c = shared(data, target='ctx1')
+    val1d = shared(data, target='ctx1')
 
-    val2a = shared(numpy.random.randn(size, size).astype('float32'),
-                   target='ctx2')
-    val2b = shared(numpy.random.randn(size, size).astype('float32'),
-                   target='ctx2')
+    val2a = shared(data, target='ctx2')
+    val2b = shared(data, target='ctx2')
 
     f1 = theano.function([], [gpu_dot22(val1a, val1b),
                               gpu_dot22(val1c, val1d)])

--- a/theano/misc/check_multi_gpu.py
+++ b/theano/misc/check_multi_gpu.py
@@ -36,12 +36,22 @@ def main(dev1, dev2):
                               gpu_dot22(val2a, val2b)])
     f3 = theano.function([], [gpu_dot22(val1a, val1b)])
     f4 = theano.function([], [gpu_dot22(val2a, val2b)])
-    f5 = theano.function([], [gpu_dot22(val1a, val1b).transfer('cpu')])
-    f6 = theano.function([], [gpu_dot22(val2a, val2b).transfer('cpu')])
+    f5 = theano.function([], [gpu_dot22(val1a, val1b)[0, 0].transfer('cpu')])
+    f6 = theano.function([], [gpu_dot22(val2a, val2b)[0, 0].transfer('cpu')])
 
+    # pre-execute to load code to GPU.
     r = f1.fn()
     r[0].sync(), r[1].sync()
+    r = f2.fn()
+    r[0].sync(), r[1].sync()
+    r = f3.fn()
+    r[0].sync()
+    r = f4.fn()
+    r[0].sync()
+    r = f5.fn()
+    r = f6.fn()
     r = None
+
     t = time.time()
     r = f1.fn()
     r[0].sync(), r[1].sync()
@@ -50,9 +60,6 @@ def main(dev1, dev2):
 
     print("one ctx async %f" % (t2 - t,))
 
-    r = f2.fn()
-    r[0].sync(), r[1].sync()
-    r = None
     t = time.time()
     r = f2.fn()
     r[0].sync(), r[1].sync()
@@ -61,11 +68,6 @@ def main(dev1, dev2):
 
     print("two ctx async %f" % (t2 - t,))
 
-    r = f3.fn()
-    r[0].sync()
-    r = f4.fn()
-    r[0].sync()
-    r = None
     t = time.time()
     r = f3.fn()
     r2 = f4.fn()
@@ -76,9 +78,6 @@ def main(dev1, dev2):
 
     print("two ctx, 2 fct async, 1 thread %f" % (t2 - t,))
 
-    r = f5.fn()
-    r = f6.fn()
-    r = None
     t = time.time()
     r = f5.fn()
     r2 = f6.fn()
@@ -86,8 +85,6 @@ def main(dev1, dev2):
     r = None
     print("two ctx, 2 fct with transfer, 1 thread %f" % (t2 - t,))
 
-    r = f5()
-    r = None
     t = time.time()
     r = f5()
     t2 = time.time()
@@ -130,7 +127,6 @@ def main(dev1, dev2):
     thread1.join()
     thread2.join()
     t2 = time.time()
-    r = None
 
     print("two ctx, 2 fct with transfer, 2 threads %f" % (t2 - t,))
 

--- a/theano/sandbox/gpuarray/basic_ops.py
+++ b/theano/sandbox/gpuarray/basic_ops.py
@@ -325,9 +325,11 @@ class HostFromGpu(Op):
             if (%(name)s_ga == &%(name)s_ga_s) GpuArray_clear(%(name)s_ga);
             %(fail)s
         }
+        Py_BEGIN_ALLOW_THREADS
         %(name)serr = GpuArray_read(PyArray_DATA(%(out)s),
                                     PyArray_NBYTES(%(out)s),
                                     %(name)s_ga);
+        Py_END_ALLOW_THREADS
         if (%(name)s_ga == &%(name)s_ga_s) GpuArray_clear(%(name)s_ga);
         if (%(name)serr != GA_NO_ERROR) {
             PyErr_SetString(PyExc_RuntimeError, "Could not read device data.");
@@ -337,7 +339,7 @@ class HostFromGpu(Op):
                'out': outputs[0]}
 
     def c_code_cache_version(self):
-        return (1,)
+        return (2,)
 
     def grad(self, inputs, grads):
         gz, = grads
@@ -408,8 +410,10 @@ class GpuFromHost(Op):
             theano_size_check(%(out)s, PyArray_NDIM(%(name)s_tmp),
                               (size_t *)PyArray_DIMS(%(name)s_tmp),
                               get_typecode((PyObject *)PyArray_DESCR(%(name)s_tmp)))) {
+          Py_BEGIN_ALLOW_THREADS
           int err = GpuArray_write(&%(out)s->ga, PyArray_DATA(%(name)s_tmp),
                                    PyArray_NBYTES(%(name)s_tmp));
+          Py_END_ALLOW_THREADS
           Py_DECREF(%(name)s_tmp);
           if (err != GA_NO_ERROR) {
             PyErr_Format(PyExc_RuntimeError, "Could not write data to gpu");
@@ -433,7 +437,7 @@ class GpuFromHost(Op):
                'out': outputs[0], 'fail': sub['fail']}
 
     def c_code_cache_version(self):
-        return (8,)
+        return (9,)
 
 
 class GpuToGpu(Op):


### PR DESCRIPTION
Also update the timing to show more cases. Example of result when using this libgpuarray PR:

https://github.com/Theano/libgpuarray/pull/117

one ctx async 3.349727
two ctx async 1.713157
two ctx, 2 fct async 1.717468
two ctx, 2 fct with transfer 3.635517
two ctx, 2 fct async, 2 threads 1.731599
two ctx, 2 fct with transfer, 2 threads 2.071597

This mean that one function with 2 gemm, if we put them on 2 GPUs, we have a 1.95x speed up.
If we split the 2 gemm each in a function, we kepp the 1.95x speed up.

If we add one gpu to cpu transfer after the gemm and keep 2 function each with 1 gemm and 1 transer, we loose the speed up. We get a speed up (slowdown) of 0.92x again the version without tranfers and ONE GPU.

If we use 2 threads, each with its function without transfer, go drop to 1.93x speed up.
But if we do the same with the gemm + transfer, we go from a slowdown of 0.92x to a speed up of 1.61x.