### PR TITLE
Fix DnnConv and its gradients to work with zero batch size. Fixes #3715

### DIFF
--- a/theano/sandbox/cuda/dnn_fwd.c
+++ b/theano/sandbox/cuda/dnn_fwd.c
@@ -12,8 +12,6 @@ APPLY_SPECIFIC(conv_fwd)(CudaNdarray *input, CudaNdarray *kerns,
     return 1;
   }
 
-  if (c_set_tensorNd(input, APPLY_SPECIFIC(input)) == -1)
-    return 1;
   if (c_set_filterNd(kerns, APPLY_SPECIFIC(kerns)) == -1)
     return 1;
 
@@ -30,7 +28,17 @@ APPLY_SPECIFIC(conv_fwd)(CudaNdarray *input, CudaNdarray *kerns,
     return 1;
 #endif
 
-   if (c_set_tensorNd(*output, APPLY_SPECIFIC(output)) == -1)
+  if (CudaNdarray_HOST_DIMS(input)[0] == 0) {
+    // if input batch is empty, we return the empty output without calling cuDNN
+    // (which will fail on zero batch size)
+    return 0;
+  }
+
+  if (c_set_tensorNd(input, APPLY_SPECIFIC(input)) == -1)
+    return 1;
+
+
+  if (c_set_tensorNd(*output, APPLY_SPECIFIC(output)) == -1)
      return 1;
 
   {

--- a/theano/sandbox/cuda/dnn_gi.c
+++ b/theano/sandbox/cuda/dnn_gi.c
@@ -12,8 +12,6 @@ APPLY_SPECIFIC(conv_gi)(CudaNdarray *kerns, CudaNdarray *output,
     return 1;
   }
 
-  if (c_set_tensorNd(output, APPLY_SPECIFIC(output)) == -1)
-    return 1;
   if (c_set_filterNd(kerns, APPLY_SPECIFIC(kerns)) == -1)
     return 1;
 
@@ -29,6 +27,14 @@ APPLY_SPECIFIC(conv_gi)(CudaNdarray *kerns, CudaNdarray *output,
   if (beta != 0.0 && CudaNdarray_CopyFromCudaNdarray(*input, im))
     return 1;
 #endif
+
+  if (CudaNdarray_HOST_DIMS(output)[0] == 0) {
+    // Zero batch size for output image, return zero batch size gradient
+    return 0;
+  }
+
+  if (c_set_tensorNd(output, APPLY_SPECIFIC(output)) == -1)
+    return 1;
 
   if (c_set_tensorNd(*input, APPLY_SPECIFIC(input)) == -1)
     return 1;

--- a/theano/sandbox/cuda/dnn_gw.c
+++ b/theano/sandbox/cuda/dnn_gw.c
@@ -12,11 +12,6 @@ APPLY_SPECIFIC(conv_gw)(CudaNdarray *input, CudaNdarray *output,
     return 1;
   }
 
-  if (c_set_tensorNd(input, APPLY_SPECIFIC(input)) == -1)
-    return 1;
-  if (c_set_tensorNd(output, APPLY_SPECIFIC(output)) == -1)
-    return 1;
-
   int nb_dim = CudaNdarray_NDIM(output);
 
 #ifdef CONV_INPLACE
@@ -30,6 +25,20 @@ APPLY_SPECIFIC(conv_gw)(CudaNdarray *input, CudaNdarray *output,
     return 1;
 #endif
 
+
+  if (CudaNdarray_HOST_DIMS(input)[0] == 0) {
+    // zero batch size. Return a zero gradient without calling cuDNN (which will fail on zero batch size)
+    Py_XDECREF(*kerns);
+    *kerns = (CudaNdarray *) CudaNdarray_ZEROS(CudaNdarray_NDIM((*kerns)), (int *) CudaNdarray_HOST_DIMS((*kerns)));
+    if (*kerns == NULL) return 1;
+    return 0;
+  }
+
+
+  if (c_set_tensorNd(input, APPLY_SPECIFIC(input)) == -1)
+    return 1;
+  if (c_set_tensorNd(output, APPLY_SPECIFIC(output)) == -1)
+    return 1;
   if (c_set_filterNd(*kerns, APPLY_SPECIFIC(kerns)) == -1)
     return 1;
 

--- a/theano/sandbox/cuda/tests/test_dnn.py
+++ b/theano/sandbox/cuda/tests/test_dnn.py
@@ -31,6 +31,35 @@ else:
     mode_without_gpu = theano.compile.mode.get_default_mode().excluding('gpu')
 
 
+def test_dnn_empty_batch():
+    img_shp = (0, 5, 6, 8)
+    kern_shp = (3, 5, 5, 6)
+    img = T.ftensor4('img')
+    kern = T.ftensor4('kern')
+    out = T.ftensor4('out')
+    desc = dnn.GpuDnnConvDesc(
+        border_mode='valid')(img.shape, kern.shape)
+
+    o = dnn.dnn_conv(img, kern)
+    f = theano.function([img, kern], o, mode=mode_with_gpu)
+    d = f(numpy.random.rand(*img_shp).astype('float32'),
+          numpy.random.rand(*kern_shp).astype('float32'))
+    assert d.shape == (0, 3, 2, 3)
+
+    out = gpu_alloc_empty(*kern_shp)
+    o = dnn.GpuDnnConvGradW()(img, kern, out, desc)
+    f = theano.function([img, kern], o, mode=mode_with_gpu)
+    d = f(numpy.random.rand(*img_shp).astype('float32'),
+          numpy.random.rand(*kern_shp).astype('float32'))
+
+    out = gpu_alloc_empty(*img_shp)
+    o = dnn.GpuDnnConvGradI()(kern, img, out, desc)
+    f = theano.function([img, kern], o, mode=mode_with_gpu)
+    d = f(numpy.random.rand(*img_shp).astype('float32'),
+          numpy.random.rand(*kern_shp).astype('float32'))
+    assert numpy.all(d == numpy.zeros(img_shp))
+
+
 def test_dnn_conv_desc_merge():
     if not cuda.dnn.dnn_available():
         raise SkipTest(cuda.dnn.dnn_available.msg)


### PR DESCRIPTION
This checks for zero batch size and returns the appropriate result (zero-size and/or filled with zeros) in this case without calling cuDNN.

It seems cuDNN doesn't like zero dimensions in general, the call to `cudnnSetTensorNdDescriptor` via  `c_set_tensorNd` triggers the error, this is why some of the `c_set_tensorNd` calls needed to be moved further down.

fix gh-3715
