### PR TITLE
Added config variable to disable initial testing of nvidia drivers

### DIFF
--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -174,6 +174,14 @@ import theano and print the config variable, as in:
 
     Print active device at when the GPU device is initialized.
 
+.. attribute:: enable_initial_driver_test
+
+    Bool value: either ``True`` or ``False``
+
+    Default: ``True``
+
+    Tests the nvidia driver when a GPU device is initialized.
+
 .. attribute:: floatX
 
     String value: either 'float64' or 'float32'

--- a/theano/__init__.py
+++ b/theano/__init__.py
@@ -107,7 +107,8 @@ if config.device.startswith('gpu') or config.init_gpu_device.startswith('gpu'):
     if theano.sandbox.cuda.cuda_available:
         import theano.sandbox.cuda.tests.test_driver
 
-        theano.sandbox.cuda.tests.test_driver.test_nvidia_driver1()
+        if config.enable_initial_driver_test:
+            theano.sandbox.cuda.tests.test_driver.test_nvidia_driver1()
 
 if (config.device.startswith('cuda') or
         config.device.startswith('opencl') or

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -146,6 +146,13 @@ AddConfigVar(
     in_c_key=False)
 
 
+AddConfigVar(
+    'enable_initial_driver_test',
+    "Tests the nvidia driver when a GPU device is initialized.",
+    BoolParam(True, allow_override=False),
+    in_c_key=False)
+
+
 def default_cuda_root():
     v = os.getenv('CUDA_ROOT', "")
     if v:


### PR DESCRIPTION
Performing module tests on import causes a small overhead. It seems that running these tests is not required for Theano to properly initialize on systems where the tests would have passed. I added a configuration option to disable these tests which cuts import time by 20-30% for small test cases.