### PR TITLE
Update test for recent scipy.

### DIFF
--- a/theano/tensor/tests/test_slinalg.py
+++ b/theano/tensor/tests/test_slinalg.py
@@ -306,7 +306,14 @@ class TestKron(utt.InferShapeTester):
                 f = function([x, y], kron(x, y))
                 b = self.rng.rand(*shp1).astype(config.floatX)
                 out = f(a, b)
-                assert numpy.allclose(out, scipy.linalg.kron(a, b))
+                # Newer versions of scipy want 4 dimensions at least,
+                # so we have to add a dimension to a and flatten the result.
+                if len(shp0) + len(shp1) == 3:
+                    scipy_val = scipy.linalg.kron(
+                        a[numpy.newaxis, :], b).flatten()
+                else:
+                    scipy_val = scipy.linalg.kron(a, b)
+                utt.assert_allclose(out, scipy_val)
 
     def test_numpy_2d(self):
         for shp0 in [(2, 3)]:


### PR DESCRIPTION
This fixes a test when run with a recent version of scipy.
We still support the old cases, even if scipy dropped them.