### PR TITLE
Add __matmul__ method to tensor_py_operators 

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -5536,9 +5536,48 @@ def matmul(a, b):
     """
     Computes the matrix multiplication two tensor variables.
 
+    If any operands are scalar an error is raised.
+    If number of dimensions do not match and one operand is a vector, the vector
+    is promoted to a matrix before applying operation.
+        Note: As the exact shape of the operands cannot be determined at
+        compilation time, it is not possible to infer whether the vector should
+        be treated as a row- or column vector. Therefore _column_ vectors will
+        be assumed, if any inference must be made. such promoted vector will
+        have shape = [1, m] as is the default transform from 1D array to
+        np.matrix in the numpy library. *note that this is not strictly
+        compliant with PEP 465*. Therefore the user must take care to correctly
+        transpose the vector if a row vector was intended.
+
     For two matrices, this is equivalent to matrix multiplication.
     For two vectors, this is the inner product.
-    For N > 2 dimensions, this is a batched dot product
+
+    If any operand has more than 2 dimensions, this is a batched matrix
+    multiplication:
+        The matrix multiplication is performed with the assumption, that the
+        operands are stacks of matrices with the matrix residing in the last 2
+        dimensions. (remember that a vector is promoted to matrix before this
+        step is reached)
+
+        The stacks do not have to have same number of dimensions, the stack with
+        the least number dimensions will be broadcast onto the other. This
+        corresponds to repeating the stack such that the resulting promoted
+        stack matches the other:
+            A.ndim = 3, B.ndim=4
+            B.shape[0] = 3
+            A -> Ap: [A, A, A]
+            Ap.ndim = 4
+            result: matmult(Ap, B)
+
+        The batching will the be performed over the first n-2 dimensions which
+        therefore must match:
+            Ap.shape[:-2] == B.shape[:-2]
+
+        To perform the matrix multiplication the last dimension of the first
+        operand must match the second to last operand of the second operand:
+            Ap.shape[-1] == B.shape[-2]
+
+        The result then has the shape:
+            B.shape[:-2] + B[-2] + A[-1]
     """
     nd1, nd2 = a.ndim, b.ndim
 
@@ -5547,24 +5586,52 @@ def matmul(a, b):
         raise ValueError("Scalar operands are not allowed, use '*' instead")
 
     # If both operands have ndim < 2 this a simple dot operation
+    # promotion of 1d vectors to 2d matrix should be handled by dot()
     if nd1 <= 2 and nd2 <= 2:
         return dot(a, b)
 
-    # if one of the operands have ndim > 2 this is a batched dot (einsum).
-    # operands of inequal size would be ambigous
+    # if any operand have ndim > 2 this is a batched matrix multiplication.
+
+    # do vector promotion
+    if a.ndim == 1:
+        a = a.reshape([a.shape[0], 1], 2)
+
+    if b.ndim == 1:
+        b = b.reshape([b.shape[0], 1], 2)
+
+    # if the stacks are not aligned, use scan to iterate over first dimension
+    # of largest operand and call recursively until a and b has same ndim
     if nd1 != nd2:
-        raise ValueError('a.ndim != b.ndim. matmult takes only operands of same',
-                         'dimensionality when one operand has ndim > 2')
+        if a.ndim > b.ndim:
+            result, updates = theano.scan(
+                fn=lambda a_sub_tensor, _b:
+                matmul(a_sub_tensor, _b),
+                outputs_info=None,
+                sequences=[a],
+                non_sequences=[b])
+            return result
+
+        if a.ndim < b.ndim:
+            result, updates = theano.scan(
+                fn=lambda b_sub_tensor, _a:
+                matmul(_a, b_sub_tensor),
+                outputs_info=None,
+                sequences=[b],
+                non_sequences=[a])
+            return result
+
+    # If this code is reached operands have same number of dimensions
+    # shape of a and b must be the same except for the last 2 axes which must
+    # be compatible with a matrix multiplication:
+    #   a: ND (..., dim1, dim2)
+    #   b: ND (..., dim2, dim3)
 
     # for ndim 3 there exists a method we can use without modification
     if nd1 == 3:
         return batched_dot(a, b)
 
-    # ndim > 3
-    # shape of a and b must be the same except for the last 2 axes which must
-    # compatible with the dot operation:
-    #   a: ND (..., dim1, dim2)
-    #   b: ND (..., dim2, dim3)
+    # for ndim > 3 we flatten all but last 2 dimensions such that the new
+    # operands have ndim == 3
 
     _a = a.reshape([-1, a.shape[-2], a.shape[-1]], 3)
     _b = b.reshape([-1, b.shape[-2], b.shape[-1]], 3)

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -5532,6 +5532,46 @@ pprint.assign(_dot, printing.OperatorPrinter(printing.special['middle_dot'],
                                              -1, 'left'))
 
 
+def matmul(a, b):
+    """
+    Computes the matrix multiplication two tensor variables.
+
+    For two matrices, this is equivalent to matrix multiplication.
+    For two vectors, this is the inner product.
+    For N > 2 dimensions, this is a batched dot product
+    """
+    nd1, nd2 = a.ndim, b.ndim
+
+    # According to PEP 465 matmul should *not* work with scalars
+    if nd1 == 0 or nd2 == 0:
+        raise ValueError("Scalar operands are not allowed, use '*' instead")
+
+    # If both operands have ndim < 2 this a simple dot operation
+    if nd1 <= 2 and nd2 <= 2:
+        return dot(a, b)
+
+    # if one of the operands have ndim > 2 this is a batched dot (einsum).
+    # operands of inequal size would be ambigous
+    if nd1 != nd2:
+        raise ValueError('a.ndim != b.ndim. matmult takes only operands of same',
+                         'dimensionality when one operand has ndim > 2')
+
+    # for ndim 3 there exists a method we can use without modification
+    if nd1 == 3:
+        return batched_dot(a, b)
+
+    # ndim > 3
+    # shape of a and b must be the same except for the last 2 axes which must
+    # compatible with the dot operation:
+    #   a: ND (..., dim1, dim2)
+    #   b: ND (..., dim2, dim3)
+
+    _a = a.reshape([-1, a.shape[-2], a.shape[-1]], 3)
+    _b = b.reshape([-1, b.shape[-2], b.shape[-1]], 3)
+    out = batched_dot(_a, _b)
+    return out.reshape(concatenate([a.shape[:-1], [b.shape[-1]]]), a.ndim)
+
+
 def dot(a, b):
     """
     Computes the dot product of two variables.

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -31,7 +31,7 @@ from theano.tensor import (_shared, wvector, bvector, autocast_float_as,
         horizontal_stack, vertical_stack, argmax, get_vector_length,
         fscalar, zeros_like, sum, tensor3, vector, add, addbroadcast,
         alloc, as_tensor_variable, tensor_from_scalar, ARange, autocast_float,
-        clip, constant, default, dot,
+        clip, constant, default, dot, matmul,
         dmatrix, dscalar, dvector, eq, eye, fill, flatten, inverse_permutation, Flatten,
         tensor4, permute_row_elements, fmatrix, fscalars, grad,
         inplace, iscalar, matrix, minimum, matrices, maximum, mul, neq,
@@ -1905,6 +1905,29 @@ ConjInplaceTester = makeBroadcastTester(
     expected=numpy.conj,
     good=_good_broadcast_unary_normal,
     inplace=True)
+
+
+MatmulTester = makeTester(name='MatmulTester',
+                       op=matmul,
+                       expected=lambda x, y: numpy.matmul(x, y),
+                       checks={},
+                       good=dict(correct4x4_1=(rand(2, 5, 5, 7), rand(2, 5, 7, 5)),
+                                 correct4x4_2=(rand(2, 5, 5, 7), rand(2, 5, 7, 9)),
+                                 correct3x3_1=(rand(5, 5, 7), rand(5, 7, 5)),
+                                 correct3x3_2=(rand(5, 5, 7), rand(5, 7, 9)),
+                                 correct2x2_1=(rand(5, 7), rand(7, 5)),
+                                 correct2x2_2=(rand(5, 7), rand(7, 9)),
+                                 correct2x1=(rand(5, 7), rand(7)),
+                                 correct1x2=(rand(5), rand(5, 7))
+                                 ),
+                       bad_build=dict(badscalar=(1, rand(2, 2)),
+                                      baddim3x4=(rand(2, 5, 7, 5), rand(5, 7, 5)),
+                                      ),
+                       bad_runtime=dict(bad2x2_1=(rand(5, 7), rand(5, 7)),
+                                        bad2x2_2=(rand(5, 7), rand(8, 3)),
+                                        bad3x3_1=(rand(5, 5, 7), rand(5, 8, 3)),
+                                        bad4x4_1=(rand(2, 5, 5, 7), rand(2, 5, 8, 3)),
+                                        bad4x4_2=(rand(3, 5, 5, 7), rand(2, 5, 7, 9))))
 
 
 DotTester = makeTester(name='DotTester',

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -1907,7 +1907,11 @@ ConjInplaceTester = makeBroadcastTester(
     inplace=True)
 
 
+# the reference function in numpy is new in version 1.10.0
+# skip the test if numpy version is lower
+skip_matmul = tuple(int(v) for v in numpy.version.version.split('.')) < (1, 10, 0)
 MatmulTester = makeTester(name='MatmulTester',
+                       skip=skip_matmul,
                        op=matmul,
                        expected=lambda x, y: numpy.matmul(x, y),
                        checks={},

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -1921,11 +1921,20 @@ MatmulTester = makeTester(name='MatmulTester',
                                  correct3x3_2=(rand(5, 5, 7), rand(5, 7, 9)),
                                  correct2x2_1=(rand(5, 7), rand(7, 5)),
                                  correct2x2_2=(rand(5, 7), rand(7, 9)),
+                                 # matrix matrix w. bc
+                                 correct4x5_1=(rand(2, 5, 5, 7), rand(3, 2, 5, 7, 9)),
+                                 correct5x4_2=(rand(3, 2, 5, 5, 7), rand(2, 5, 7, 9)),
+                                 correct3x4_1=(rand(5, 5, 7), rand(2, 5, 7, 9)),
+                                 correct4x3_2=(rand(2, 5, 5, 7), rand(5, 7, 9)),
+                                 # matrix vector
                                  correct2x1=(rand(5, 7), rand(7)),
-                                 correct1x2=(rand(5), rand(5, 7))
+                                 correct1x2=(rand(5), rand(5, 7)),
+                                 # vector vector
+                                 correct1x1_1=(rand(5), rand(5)),
+                                 correct1x1_2=(rand(1, 5), rand(5)),
+                                 correct1x1_3=(rand(5), rand(5, 1)),
                                  ),
-                       bad_build=dict(badscalar=(1, rand(2, 2)),
-                                      baddim3x4=(rand(2, 5, 7, 5), rand(5, 7, 5)),
+                       bad_build=dict(badscalar=(1, rand(2, 2))
                                       ),
                        bad_runtime=dict(bad2x2_1=(rand(5, 7), rand(5, 7)),
                                         bad2x2_2=(rand(5, 7), rand(8, 3)),

--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -158,7 +158,7 @@ class _tensor_py_operators(object):
         # See explanation in __add__ for the error catched
         # and the return value in that case
         try:
-            return theano.tensor.dot(self, other)
+            return theano.tensor.matmul(self, other)
         except (NotImplementedError, AsTensorError):
             return NotImplemented
 
@@ -244,7 +244,7 @@ class _tensor_py_operators(object):
         return theano.tensor.basic.sub(other, self)
 
     def __rmatmul__(self, other):
-        return theano.tensor.basic.dot(other, self)
+        return theano.tensor.basic.matmul(other, self)
 
     def __rmul__(self, other):
         return theano.tensor.basic.mul(other, self)

--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -154,6 +154,14 @@ class _tensor_py_operators(object):
         except (NotImplementedError, AsTensorError):
             return NotImplemented
 
+    def __matmul__(self, other):
+        # See explanation in __add__ for the error catched
+        # and the return value in that case
+        try:
+            return theano.tensor.dot(self, other)
+        except (NotImplementedError, AsTensorError):
+            return NotImplemented
+
     def __mul__(self, other):
         # See explanation in __add__ for the error catched
         # and the return value in that case
@@ -234,6 +242,9 @@ class _tensor_py_operators(object):
 
     def __rsub__(self, other):
         return theano.tensor.basic.sub(other, self)
+
+    def __rmatmul__(self, other):
+        return theano.tensor.basic.dot(other, self)
 
     def __rmul__(self, other):
         return theano.tensor.basic.mul(other, self)


### PR DESCRIPTION
in 3.5 the @ operator was added. This operator is specifically added to make matrix multiplications more clear. 
<http://legacy.python.org/dev/peps/pep-0465/>

This branch merely adds the `__matmul__` and `__rmatmul__` methods to the `_tensor_py_operators` class such that a two tensors can be be dotted with
```
AB = A @ B
BA = B @ A
```
instead of 
```
from tensor import dot
AB = dot(A, B)
BA = dot(B, A)
```
Hopefully improving code clarity

in accordance with the observed implementation of `__mul__`  the `__matmul__` method is supplied by  `tensor.dot` whilst `__rmatmul__` is supplied by `tensor.basic.dot`