### PR TITLE
Import pydot-ng with pydot as fallback.

### DIFF
--- a/theano/d3viz/__init__.py
+++ b/theano/d3viz/__init__.py
@@ -1,11 +1,1 @@
 from theano.d3viz.d3viz import d3viz, d3write
-
-has_requirements = False
-try:
-    # pydot-ng is a fork of pydot that is better maintained
-    import pydot_ng as pd
-except ImportError:
-    # fall back on pydot if necessary
-    import pydot as pd
-if pd.find_graphviz():
-    has_requirements = True

--- a/theano/d3viz/__init__.py
+++ b/theano/d3viz/__init__.py
@@ -2,8 +2,10 @@ from theano.d3viz.d3viz import d3viz, d3write
 
 has_requirements = False
 try:
-    import pydot as pd
-    if pd.find_graphviz():
-        has_requirements = True
+    # pydot-ng is a fork of pydot that is better maintained
+    import pydot_ng as pd
 except ImportError:
-    pass
+    # fall back on pydot if necessary
+    import pydot as pd
+if pd.find_graphviz():
+    has_requirements = True

--- a/theano/d3viz/formatting.py
+++ b/theano/d3viz/formatting.py
@@ -18,11 +18,16 @@ pydot_imported = False
 try:
     # pydot-ng is a fork of pydot that is better maintained
     import pydot_ng as pd
+    if pd.find_graphviz():
+        pydot_imported = True
 except ImportError:
-    # fall back on pydot if necessary
-    import pydot as pd
-if pd.find_graphviz():
-    pydot_imported = True
+    try:
+        # fall back on pydot if necessary
+        import pydot as pd
+        if pd.find_graphviz():
+            pydot_imported = True
+    except ImportError:
+        pass  # tests should not fail on optional dependency
 
 
 class PyDotFormatter(object):

--- a/theano/d3viz/formatting.py
+++ b/theano/d3viz/formatting.py
@@ -16,11 +16,13 @@ from theano.compile import builders
 
 pydot_imported = False
 try:
-    import pydot as pd
-    if pd.find_graphviz():
-        pydot_imported = True
+    # pydot-ng is a fork of pydot that is better maintained
+    import pydot_ng as pd
 except ImportError:
-    pass
+    # fall back on pydot if necessary
+    import pydot as pd
+if pd.find_graphviz():
+    pydot_imported = True
 
 
 class PyDotFormatter(object):

--- a/theano/d3viz/tests/test_d3viz.py
+++ b/theano/d3viz/tests/test_d3viz.py
@@ -1,7 +1,7 @@
 from nose.plugins.skip import SkipTest
 
-from theano.d3viz import has_requirements
-if not has_requirements:
+from theano.d3viz.formatting import pydot_imported
+if not pydot_imported:
     raise SkipTest('Missing requirements')
 
 import numpy as np

--- a/theano/d3viz/tests/test_formatting.py
+++ b/theano/d3viz/tests/test_formatting.py
@@ -1,7 +1,7 @@
 from nose.plugins.skip import SkipTest
 
-from theano.d3viz import has_requirements
-if not has_requirements:
+from theano.d3viz.formatting import pydot_imported
+if not pydot_imported:
     raise SkipTest('Missing requirements')
 
 import numpy as np

--- a/theano/printing.py
+++ b/theano/printing.py
@@ -22,25 +22,15 @@ from theano.gof import Op, Apply
 from theano.compile import Function, debugmode, SharedVariable
 from theano.compile.profilemode import ProfileMode
 
-# pydot-ng is a fork of pydot that is better maintained, and works
-# with more recent version of its dependencies (in particular pyparsing)
+pydot_imported = False
 try:
+    # pydot-ng is a fork of pydot that is better maintained
     import pydot_ng as pd
-    if pd.find_graphviz():
-        pydot_imported = True
-    else:
-        pydot_imported = False
-except Exception:
-    # Sometimes, a Windows-specific exception is raised
-    pydot_imported = False
-# Fall back on pydot if necessary
-if not pydot_imported:
-    try:
-        import pydot as pd
-        if pd.find_graphviz():
-            pydot_imported = True
-    except Exception:
-        pass
+except ImportError:
+    # fall back on pydot if necessary
+    import pydot as pd
+if pd.find_graphviz():
+    pydot_imported = True
 
 _logger = logging.getLogger("theano.printing")
 VALID_ASSOC = set(['left', 'right', 'either'])
@@ -733,7 +723,6 @@ def pydotprint(fct, outfile=None,
     if not pydot_imported:
         raise RuntimeError("Failed to import pydot. You must install pydot"
                            " and graphviz for `pydotprint` to work.")
-        return
 
     g = pd.Dot()
 
@@ -1065,13 +1054,10 @@ def pydotprint_variables(vars,
     if outfile is None:
         outfile = os.path.join(config.compiledir, 'theano.pydotprint.' +
                                config.device + '.' + format)
-    try:
-        import pydot as pd
-    except ImportError:
-        err = ("Failed to import pydot. You must install pydot for " +
-               "`pydotprint_variables` to work.")
-        print(err)
-        return
+    if not pydot_imported:
+        raise RuntimeError("Failed to import pydot. You must install pydot"
+                           " and graphviz for `pydotprint_variables` to work.")
+
     g = pd.Dot()
     my_list = {}
     orphanes = []

--- a/theano/printing.py
+++ b/theano/printing.py
@@ -26,11 +26,16 @@ pydot_imported = False
 try:
     # pydot-ng is a fork of pydot that is better maintained
     import pydot_ng as pd
+    if pd.find_graphviz():
+        pydot_imported = True
 except ImportError:
-    # fall back on pydot if necessary
-    import pydot as pd
-if pd.find_graphviz():
-    pydot_imported = True
+    try:
+        # fall back on pydot if necessary
+        import pydot as pd
+        if pd.find_graphviz():
+            pydot_imported = True
+    except ImportError:
+        pass  # tests should not fail on optional dependency
 
 _logger = logging.getLogger("theano.printing")
 VALID_ASSOC = set(['left', 'right', 'either'])


### PR DESCRIPTION
Added support for importing `pydot-ng` with `pydot` as fallback everywhere, shortened and standardized handling of this.