### PR TITLE
fixed cula runtime error (libcula.so not found)

### DIFF
--- a/theano/sandbox/cuda/cula.py
+++ b/theano/sandbox/cuda/cula.py
@@ -16,7 +16,7 @@ cula_available = False
 try:
     from scikits.cuda import cula
     cula_available = True
-except (ImportError, OSError, pkg_resources.DistributionNotFound):
+except (ImportError, OSError, RuntimeError, pkg_resources.DistributionNotFound):
     pass
 
 cula_initialized = False


### PR DESCRIPTION
Fixed the cula runtime error by adding "RuntimeError" in the except line.

fix gh-3785