### PR TITLE
Fix fallback in BLAS detection

### DIFF
--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -340,7 +340,7 @@ SOMEPATH/Canopy_64bit/User/lib/python2.7/site-packages/numpy/distutils/system_in
         }
         """)
     flags = ['-lblas']
-    flags.extend('-L'.join(theano.gof.cmodule.std_lib_dirs()))
+    flags.extend('-L' + d for d in theano.gof.cmodule.std_lib_dirs())
     res = GCC_compiler.try_compile_tmp(
         test_code, tmp_prefix='try_blas_',
         flags=flags, try_run=True)


### PR DESCRIPTION
Fixes broken implementation of #3654.
Before, it would try `"-lblas f i r s t / d i r e c t o r y - L s e c o n d / d i r e c t o r y"`.
With this fix, it will try `"-lblas -Lfirst/directory -Lsecond/directory"`.
Should work better as a fallback...