### PR TITLE
Check home_dir writing permission and assign temporary directory

### DIFF
--- a/theano/gof/compiledir.py
+++ b/theano/gof/compiledir.py
@@ -239,6 +239,10 @@ else:
     home_dir = get_home_dir()
     if not os.access(home_dir, os.W_OK):
         home_dir = '/tmp'
+        user = os.getenv('USER')
+        if user is not None:
+            home_dir = os.path.join(home_dir, user)
+
     default_base_compiledir = os.path.join(home_dir, '.theano')
 
 

--- a/theano/gof/compiledir.py
+++ b/theano/gof/compiledir.py
@@ -236,7 +236,10 @@ def get_home_dir():
 if sys.platform == 'win32' and os.getenv('LOCALAPPDATA') is not None:
     default_base_compiledir = os.path.join(os.getenv('LOCALAPPDATA'), 'Theano')
 else:
-    default_base_compiledir = os.path.join(get_home_dir(), '.theano')
+    home_dir = get_home_dir()
+    if not os.access(home_dir, os.W_OK):
+        home_dir = '/tmp'
+    default_base_compiledir = os.path.join(home_dir, '.theano')
 
 
 AddConfigVar(


### PR DESCRIPTION
I ran Theano on a distributed environment. On worker nodes, it might possibly we don't have writing permission for the returned dir of `get_home_dir`. In this case, the running will be failed. I think we can assign it to temporary directory in this case.