### PR TITLE
Fix Python3 regression in ``pydotprint``

### DIFF
--- a/theano/printing.py
+++ b/theano/printing.py
@@ -1028,7 +1028,7 @@ def pydotprint(fct, outfile=None,
         except pd.InvocationException:
             # based on https://github.com/Theano/Theano/issues/2988
             version = getattr(pd, '__version__', "")
-            if version and map(int, version.split(".")) < [1, 0, 28]:
+            if version and list(map(int, version.split("."))) < [1, 0, 28]:
                 raise Exception("Old version of pydot detected, which can "
                                 "cause issues with pydot printing. Try "
                                 "upgrading pydot version to a newer one")


### PR DESCRIPTION
  In Python3 ``map`` returns a map-object (and not a list). This makes the check
  introduced in #3057 fail with "TypeError: unorderable types: map() < list()"