### PR TITLE
Pull request for #3837

### DIFF
--- a/theano/sandbox/cuda/extra_ops.py
+++ b/theano/sandbox/cuda/extra_ops.py
@@ -5,11 +5,12 @@ from theano.gof import local_optimizer
 from theano.sandbox.cuda import cuda_available, GpuOp
 from theano.sandbox.cuda.basic_ops import gpu_flatten
 from theano.tensor.extra_ops import CumsumOp
+from theano.sandbox.cuda import register_opt as register_opt
 
 if cuda_available:
     from theano.sandbox.cuda import CudaNdarrayType
     from theano.sandbox.cuda.basic_ops import host_from_gpu, gpu_from_host, HostFromGpu
-from theano.sandbox.cuda import register_opt as register_gpu_opt
+
 
 
 class GpuCumsum(CumsumOp, GpuOp):
@@ -436,7 +437,7 @@ def values_eq_approx_high_tol(a, b):
     return CudaNdarrayType.values_eq_approx(a, b, rtol=rtol)
 
 
-@register_gpu_opt()
+@register_opt()
 @local_optimizer([CumsumOp])
 def use_gpu_cumsum(node):
     if type(node.op) is CumsumOp \

--- a/theano/sandbox/cuda/extra_ops.py
+++ b/theano/sandbox/cuda/extra_ops.py
@@ -9,7 +9,7 @@ from theano.tensor.extra_ops import CumsumOp
 if cuda_available:
     from theano.sandbox.cuda import CudaNdarrayType
     from theano.sandbox.cuda.basic_ops import host_from_gpu, gpu_from_host, HostFromGpu
-    from theano.sandbox.cuda import register_opt as register_gpu_opt
+from theano.sandbox.cuda import register_opt as register_gpu_opt
 
 
 class GpuCumsum(CumsumOp, GpuOp):

--- a/theano/sandbox/cuda/opt.py
+++ b/theano/sandbox/cuda/opt.py
@@ -19,7 +19,7 @@ from theano.compile import optdb
 from theano.gof import (local_optimizer, EquilibriumDB, ProxyDB,
                         Optimizer, TopoOptimizer, toolbox)
 from theano.gof.opt import LocalMetaOptimizer
-from theano.sandbox.cuda import as_cuda_ndarray_variable
+#from theano.sandbox.cuda import 
 from theano.sandbox.cuda.basic_ops import (
     gpu_eye, gpu_contiguous,
     gpu_from_host, host_from_gpu, GpuFromHost, HostFromGpu,
@@ -28,7 +28,8 @@ from theano.sandbox.cuda.basic_ops import (
     GpuFlatten, gpu_flatten,
     GpuSubtensor, GpuAdvancedSubtensor1,
     GpuAdvancedIncSubtensor1, GpuAdvancedIncSubtensor1_dev20,
-    GpuIncSubtensor, gpu_alloc, GpuAlloc, gpu_shape, GpuSplit, GpuAllocEmpty)
+    GpuIncSubtensor, gpu_alloc, GpuAlloc, gpu_shape, GpuSplit, GpuAllocEmpty,
+    as_cuda_ndarray_variable)
 
 from theano.sandbox.cuda.type import CudaNdarrayType
 from theano.sandbox.cuda.blas import (

--- a/theano/sandbox/cuda/opt.py
+++ b/theano/sandbox/cuda/opt.py
@@ -19,17 +19,16 @@ from theano.compile import optdb
 from theano.gof import (local_optimizer, EquilibriumDB, ProxyDB,
                         Optimizer, TopoOptimizer, toolbox)
 from theano.gof.opt import LocalMetaOptimizer
-#from theano.sandbox.cuda import 
 from theano.sandbox.cuda.basic_ops import (
     gpu_eye, gpu_contiguous,
+    as_cuda_ndarray_variable,
     gpu_from_host, host_from_gpu, GpuFromHost, HostFromGpu,
     GpuContiguous,
     GpuElemwise, GpuDimShuffle, GpuReshape, GpuCAReduce,
     GpuFlatten, gpu_flatten,
     GpuSubtensor, GpuAdvancedSubtensor1,
     GpuAdvancedIncSubtensor1, GpuAdvancedIncSubtensor1_dev20,
-    GpuIncSubtensor, gpu_alloc, GpuAlloc, gpu_shape, GpuSplit, GpuAllocEmpty,
-    as_cuda_ndarray_variable)
+    GpuIncSubtensor, gpu_alloc, GpuAlloc, gpu_shape, GpuSplit, GpuAllocEmpty)
 
 from theano.sandbox.cuda.type import CudaNdarrayType
 from theano.sandbox.cuda.blas import (

--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -67,6 +67,7 @@ from theano.compile.function_module import deep_copy_op
 from theano.gof import toolbox, DestroyHandler, InconsistencyError
 from theano.gof.opt import Optimizer
 from theano.gof.opt import pre_constant_merge, pre_greedy_local_optimizer
+from theano.sandbox.cuda import cuda_available
 
 from theano.scan_module import scan_op
 from theano.scan_module import scan_utils
@@ -1083,10 +1084,10 @@ class ScanInplaceOptimizer(Optimizer):
         # Depending on the values of gpu_flag and gpua_flag, get the list of
         # memory allocation ops that the optimization should be able to handle
         alloc_ops = (Alloc, AllocEmpty)
-        if self.gpu_flag:
+        if self.gpu_flag and cuda_available:
             alloc_ops += (theano.sandbox.cuda.GpuAlloc,
                           theano.sandbox.cuda.GpuAllocEmpty)
-        if self.gpua_flag:
+        if self.gpua_flag and cuda_available:
             # gpuarray might be imported but not its GpuAlloc and
             # GpuAllopEmpty ops.
             try:


### PR DESCRIPTION
Error occured when importing register_opt when running CPU code. 
Error is because:
- as_cuda_ndarray_variable was in theano.sandbox.cuda.basic_ops, and not theano.sandbox.cuda
- extra_ops has an import of register_opt only if if cuda_available, however, the optimization is registered without the same check.

fix gh-3837