### PR TITLE
Add border_mode="half" to cuDNN convolutions

### DIFF
--- a/theano/sandbox/cuda/tests/test_abstractconv.py
+++ b/theano/sandbox/cuda/tests/test_abstractconv.py
@@ -32,15 +32,18 @@ class TestConv2d(unittest.TestCase):
         self.filters_shapes = [(5, 1, 2, 2), (4, 1, 3, 3), (2, 1, 3, 3),
                                (1, 1, 2, 5), (4, 1, 2, 2), (4, 5, 2, 2)]
         self.subsamples = [(1, 1), (2, 2), (2, 4)]
-        self.border_modes = ["valid", "full", (0, 0), (1, 1), (5, 5), (5, 2)]
+        self.border_modes = ["valid", "full", "half",
+                             (0, 0), (1, 1), (5, 5), (5, 2)]
         self.filter_flip = [True, False]
 
     def get_output_shape(self, inputs_shape, filters_shape,
                          subsample, border_mode):
         if border_mode == "valid":
             border_mode = (0, 0)
-        if border_mode == "full":
+        elif border_mode == "full":
             border_mode = (filters_shape[2] - 1, filters_shape[3] - 1)
+        elif border_mode == "half":
+            border_mode = (filters_shape[2] // 2, filters_shape[3] // 2)
         batch_size = inputs_shape[0]
         num_filters = filters_shape[0]
         return (batch_size, num_filters,) \

--- a/theano/sandbox/cuda/tests/test_dnn.py
+++ b/theano/sandbox/cuda/tests/test_dnn.py
@@ -678,7 +678,7 @@ class TestDnnInferShapes(utt.InferShapeTester):
         kerns = T.ftensor4('kerns')
         out = T.ftensor4('out')
         img_val = numpy.asarray(
-            numpy.random.rand(7, 2, 6, 4),
+            numpy.random.rand(10, 2, 6, 4),
             dtype='float32'
         )
         kern_vals = numpy.asarray(
@@ -687,7 +687,7 @@ class TestDnnInferShapes(utt.InferShapeTester):
         )
 
         for params in product(
-            ['valid', 'full'],
+            ['valid', 'full', 'half'],
             [(1, 1), (2, 2)],
             ['conv', 'cross']
         ):
@@ -717,7 +717,7 @@ class TestDnnInferShapes(utt.InferShapeTester):
         kerns = ftensor5('kerns')
         out = ftensor5('out')
         img_val = numpy.asarray(
-            numpy.random.rand(7, 2, 6, 4, 11),
+            numpy.random.rand(10, 2, 6, 4, 11),
             dtype='float32'
         )
         kern_vals = numpy.asarray(
@@ -726,7 +726,7 @@ class TestDnnInferShapes(utt.InferShapeTester):
         )
 
         for params in product(
-            ['valid', 'full'],
+            ['valid', 'full', 'half'],
             [(1, 1, 1), (2, 2, 2)],
             ['conv', 'cross']
         ):
@@ -764,7 +764,7 @@ class TestDnnInferShapes(utt.InferShapeTester):
         )
 
         for params in product(
-            ['valid', 'full'],
+            ['valid', 'full', 'half'],
             [(1, 1)],  # strides besides (1, 1)
             ['conv', 'cross']
         ):
@@ -805,7 +805,7 @@ class TestDnnInferShapes(utt.InferShapeTester):
         kerns = ftensor5('kerns')
         out = ftensor5('out')
         img_val = numpy.asarray(
-            numpy.random.rand(9, 2, 4, 8, 7),
+            numpy.random.rand(9, 2, 4, 8, 13),
             dtype='float32'
         )
         kern_vals = numpy.asarray(
@@ -814,7 +814,7 @@ class TestDnnInferShapes(utt.InferShapeTester):
         )
 
         for params in product(
-            ['valid', 'full'],
+            ['valid', 'full', 'half'],
             [(1, 1, 1), (2, 2, 2)],
             ['conv', 'cross']
         ):
@@ -895,7 +895,7 @@ class TestDnnInferShapes(utt.InferShapeTester):
         kerns = ftensor5('kerns')
         out = ftensor5('out')
         img_val = numpy.asarray(
-            numpy.random.rand(8, 4, 6, 7, 5),
+            numpy.random.rand(8, 4, 6, 7, 11),
             dtype='float32'
         )
         kern_vals = numpy.asarray(
@@ -904,7 +904,7 @@ class TestDnnInferShapes(utt.InferShapeTester):
         )
 
         for params in product(
-            ['valid', 'full'],
+            ['valid', 'full', 'half'],
             [(1, 1, 1), (2, 2, 2)],
             ['conv', 'cross']
         ):
@@ -1011,6 +1011,7 @@ def test_dnn_conv_border_mode():
     dnn.dnn_conv(img, kern, border_mode=(2, 3))
     dnn.dnn_conv(img, kern, border_mode='full')
     dnn.dnn_conv(img, kern, border_mode='valid')
+    dnn.dnn_conv(img, kern, border_mode='half')
 
 
 def test_dnn_conv_alpha_output_merge():
@@ -1269,7 +1270,7 @@ def get_conv3d_test_cases():
                         [(6, 2, 2, 2, 2), (4, 2, 1, 3, 1), (1, 1, 1)],
                         [(6, 2, 2, 2, 2), (4, 2, 1, 1, 3), (1, 1, 1)],
                         [(6, 2, 2, 2, 2), (4, 2, 5, 5, 5), (1, 1, 1)]]
-    border_modes = ['valid', 'full', (1, 2, 3), (3, 2, 1), 1, 2]
+    border_modes = ['valid', 'full', 'half', (1, 2, 3), (3, 2, 1), 1, 2]
     conv_modes = ['conv', 'cross']
 
     if cuda.dnn.dnn_available() and dnn.version() >= (3000, 3000):
@@ -1325,6 +1326,8 @@ def test_conv3d_fwd():
         else:
             if border_mode == 'full':
                 pad_per_dim = [filters_shape[i] - 1 for i in range(2, 5)]
+            elif border_mode == 'half':
+                pad_per_dim = [filters_shape[i] // 2 for i in range(2, 5)]
             else:
                 if isinstance(border_mode, int):
                     pad_per_dim = [border_mode] * 3
@@ -1393,6 +1396,8 @@ def test_conv3d_bwd():
         else:
             if border_mode == 'full':
                 pad_per_dim = [filters_shape[i] - 1 for i in range(2, 5)]
+            elif border_mode == 'half':
+                pad_per_dim = [filters_shape[i] // 2 for i in range(2, 5)]
             else:
                 if isinstance(border_mode, int):
                     pad_per_dim = [border_mode] * 3

--- a/theano/tests/unittest_tools.py
+++ b/theano/tests/unittest_tools.py
@@ -219,12 +219,12 @@ class InferShapeTester(unittest.TestCase):
                     shp = inp.shape
                 if len(set(shp)) != len(shp):
                     _logger.warn(
-                        "While testing the shape inference, we received an"
-                        " input with a shape that has some repeated values: %s"
+                        "While testing shape inference for %r, we received an"
+                        " input with a shape that has some repeated values: %r"
                         ", like a square matrix. This makes it impossible to"
                         " check if the values for these dimensions have been"
                         " correctly used, or if they have been mixed up.",
-                        str(inp.shape))
+                        cls, inp.shape)
                     break
 
         outputs_function = theano.function(inputs, outputs, mode=mode)


### PR DESCRIPTION
The new `conv2d()` interface supports `border_mode="half"` for same convolutions. However, the cudnn convolution interface in Theano does not support it. `local_abstractconv_cudnn()` does not take care of this. Thus, the following fails when cuDNN is available:
```python
In [1]: import theano
Using gpu device 0: Tesla K40c (CNMeM is enabled)

In [2]: x, w = theano.tensor.tensor4s('xw')

In [3]: c = theano.tensor.nnet.conv2d(x, w, border_mode='half')

In [4]: f = theano.function([x, w], c)

ERROR (theano.gof.opt): Optimization failure due to: LocalOptGroup(local_abstractconv_cudnn,local_conv_dnn,local_abstractconv_gemm,local_abstractconv_gradinputs_gemm,local_abstractconv_gradweight_gemm,local_conv_gemm)
ERROR (theano.gof.opt): node: AbstractConv2d{border_mode='half', subsample=(1, 1), filter_flip=True, imshp=None, kshp=None}(GpuFromHost.0, GpuFromHost.0)
ERROR (theano.gof.opt): TRACEBACK:
ERROR (theano.gof.opt): Traceback (most recent call last):
  [...]
ValueError: invalid border_mode half, which must be either "valid", "full", an integer or a pair of integers
```

An easy fix would be modifying `local_abstractconv_cudnn()` to catch `border_mode="half"` and replace it with a suitable tuple of integers. It's difficult to adapt `test_abstractconv.py` accordingly, though, because it uses the cuDNN convolution as a reference. Plus it would only work for convolutions that have a filter size specified at compile time.

So I opted for changing `theano.sandbox.cuda.dnn` to include support for the "half" border mode, which wasn't very difficult either. `test_abstractconv.py` fails for me, but it also fails for the latest master.
`test_dnn.py` still needs updates for the shape inference tests (to not give repeated values).