### PR TITLE
DOC removed incorrect statement from compatibility docs

### DIFF
--- a/doc/developer/compat.txt
+++ b/doc/developer/compat.txt
@@ -92,8 +92,7 @@ come up for Theano's purposes. ``str`` represents encoded text, i.e. character
 encoding-aware; all Python 3 strings are internally stored as Unicode. When
 converting from one or the other, you must `.encode(...)` bytes and
 `.decode(...)` strings with a given character encoding (e.g. ``'ascii'``,
-``'utf8'``, ``'latin1'``). Fortunately, these methods exist as no-ops
-in Python 2.6 and 2.7.
+``'utf8'``, ``'latin1'``).
 
 C code compatibility
 --------------------


### PR DESCRIPTION
In Python 2.x encode/decode on incorrect type is not no-op - Python 2 tries to convert data implicitly first. E.g. if you call `b'hello'.encode('utf8')`, Python 2 will first convert `b'hello'` to unicode by decoding it using `sys.getdefaultencoding()`, and then encode the result to utf8. It is almost always a wrong thing to do.