### PR TITLE
optimize TensorConstant constructor

### DIFF
--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -865,12 +865,12 @@ class TensorConstant(_tensor_py_operators, Constant):
     """
     def __init__(self, type, data, name=None):
         Constant.__init__(self, type, data, name)
-        if (isinstance(data, numpy.ndarray) and
-                data.ndim > 0 and
-                len(numpy.unique(data)) == 1):
-            self.tag.unique_value = numpy.unique(data)[0]
-        else:
-            self.tag.unique_value = None
+        self.tag.unique_value = None
+        if isinstance(data, numpy.ndarray) and data.ndim > 0:
+            flat_data = data.ravel()
+            if flat_data.shape[0]:
+                if (flat_data == flat_data[0]).all():
+                    self.tag.unique_value = flat_data[0]
 
     def __str__(self):
         if self.tag.unique_value is not None:


### PR DESCRIPTION
I was using lasagne.utils.one_hot like this:

```python
from lasagne.utils import one_hot
import theano.tensor as T
from theano import function

VOCAB_SIZE = 2500
X = T.matrix('X', dtype='int32')
encode = function([X], one_hot(X, m=VOCAB_SIZE))
```

This code took about 0.47s to process, 0.34s of which were spent sorting numpy arrays:

```
         80002 function calls (79665 primitive calls) in 0.472 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.472    0.472 {built-in method builtins.exec}
        1    0.000    0.000    0.472    0.472 <string>:2(<module>)
        1    0.000    0.000    0.464    0.464 function.py:73(function)
        1    0.000    0.000    0.464    0.464 pfunc.py:329(pfunc)
        1    0.000    0.000    0.464    0.464 function_module.py:1702(orig_function)
       42    0.004    0.000    0.374    0.009 var.py:866(__init__)
       16    0.007    0.000    0.369    0.023 arraysetops.py:96(unique)
       16    0.343    0.021    0.343    0.021 {method 'sort' of 'numpy.ndarray' objects}
        1    0.000    0.000    0.241    0.241 function_module.py:1368(__init__)
        1    0.000    0.000    0.234    0.234 opt.py:94(__call__)
     67/1    0.000    0.000    0.234    0.234 opt.py:76(optimize)
      6/1    0.000    0.000    0.234    0.234 opt.py:211(apply)
       11    0.000    0.000    0.225    0.020 op.py:899(make_thunk)
       10    0.000    0.000    0.225    0.022 op.py:820(make_c_thunk)
        1    0.000    0.000    0.223    0.223 function_module.py:1561(create)
        1    0.000    0.000    0.223    0.223 link.py:687(make_thunk)
        1    0.000    0.000    0.223    0.223 vm.py:1002(make_all)
       12    0.001    0.000    0.216    0.018 opt.py:2085(apply)
       35    0.000    0.000    0.212    0.006 opt.py:1856(apply)
```

It turns out TensorConstant constructor tries to find if all items in tensor are the same using inefficient algorithm - it calls np.unique several times which does unneeded work, including sorting of all unique values. The delay is visible on constants of moderate size:

```python
a = np.random.random((2000, 2000))

%timeit len(np.unique(a)) == 1
1 loops, best of 3: 342 ms per loop

%timeit (a == a.ravel()[0]).all()
100 loops, best of 3: 2.13 ms per loop
```

After the fix (removing np.unique overhead) Theano becomes more responsive in the original example:

```
         98156 function calls (97765 primitive calls) in 0.165 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     10/1    0.000    0.000    0.165    0.165 {built-in method builtins.exec}
        1    0.000    0.000    0.165    0.165 <string>:2(<module>)
        1    0.000    0.000    0.153    0.153 function.py:73(function)
        1    0.000    0.000    0.153    0.153 pfunc.py:329(pfunc)
        1    0.000    0.000    0.153    0.153 function_module.py:1702(orig_function)
       11    0.000    0.000    0.097    0.009 op.py:899(make_thunk)
       10    0.000    0.000    0.096    0.010 op.py:820(make_c_thunk)
        1    0.000    0.000    0.094    0.094 function_module.py:1368(__init__)
       10    0.000    0.000    0.090    0.009 cc.py:1176(make_thunk)
       10    0.000    0.000    0.090    0.009 cc.py:1111(__compile__)
       10    0.000    0.000    0.090    0.009 cc.py:1580(cthunk_factory)
        1    0.000    0.000    0.087    0.087 opt.py:94(__call__)
     68/1    0.000    0.000    0.087    0.087 opt.py:76(optimize)
      6/1    0.000    0.000    0.087    0.087 opt.py:211(apply)
       12    0.001    0.000    0.070    0.006 opt.py:2085(apply)
       10    0.000    0.000    0.069    0.007 cc.py:1213(cmodule_key)
       36    0.000    0.000    0.066    0.002 opt.py:1856(apply)
      388    0.000    0.000    0.060    0.000 opt.py:1749(process_node)
        1    0.000    0.000    0.058    0.058 function_module.py:1561(create)
        1    0.000    0.000    0.058    0.058 link.py:687(make_thunk)
        1    0.000    0.000    0.058    0.058 vm.py:1002(make_all)
       67    0.000    0.000    0.051    0.001 opt.py:5773(constant_folding)
       10    0.000    0.000    0.037    0.004 cc.py:1323(cmodule_key_)
       30    0.000    0.000    0.036    0.001 cc.py:1449(<genexpr>)
       20    0.000    0.000    0.036    0.002 cc.py:1386(in_sig)
       50    0.000    0.000    0.036    0.001 utils.py:477(hash_from_code)
        8    0.000    0.000    0.036    0.004 var.py:811(theano_hash)
        8    0.000    0.000    0.036    0.004 utils.py:8(hash_from_ndarray)
       50    0.035    0.001    0.035    0.001 {built-in method _hashlib.openssl_md5}
       10    0.000    0.000    0.031    0.003 cc.py:921(compile_args)
       10    0.000    0.000    0.031    0.003 cmodule.py:1818(compile_args)
        2    0.000    0.000    0.030    0.015 cmodule.py:1859(get_lines)
        2    0.000    0.000    0.023    0.011 subprocess.py:1028(communicate)
        2    0.000    0.000    0.022    0.011 subprocess.py:1660(_communicate)
       22    0.000    0.000    0.021    0.001 selectors.py:356(select)
       22    0.021    0.001    0.021    0.001 {method 'poll' of 'select.poll' objects}
       10    0.000    0.000    0.020    0.002 cmodule.py:1114(module_from_key)
       10    0.000    0.000    0.020    0.002 cmodule.py:1009(_get_from_key)
        9    0.000    0.000    0.019    0.002 cmodule.py:699(_get_module)
        9    0.000    0.000    0.019    0.002 cmodule.py:280(dlimport)
     18/9    0.000    0.000    0.017    0.002 {built-in method builtins.__import__}
     18/9    0.000    0.000    0.017    0.002 <frozen importlib._bootstrap>:966(_find_and_load)
     18/9    0.000    0.000    0.017    0.002 <frozen importlib._bootstrap>:939(_find_and_load_unlocked)
    36/27    0.000    0.000    0.016    0.001 <frozen importlib._bootstrap>:214(_call_with_frames_removed)
       98    0.001    0.000    0.014    0.000 graph.py:954(io_toposort)
       98    0.003    0.000    0.013    0.000 graph.py:875(general_toposort)
       42    0.011    0.000    0.012    0.000 var.py:866(__init__)
    59/53    0.000    0.000    0.011    0.000 op.py:568(__call__)
```