### PR TITLE
Bump version to 0.8.0.dev0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,9 @@ AUTHOR              = "LISA laboratory, University of Montreal"
 AUTHOR_EMAIL        = "theano-dev@googlegroups.com"
 PLATFORMS           = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"]
 MAJOR               = 0
-MINOR               = 7
+MINOR               = 8
 MICRO               = 0
-SUFFIX              = ""  # Should be blank except for rc's, betas, etc.
+SUFFIX              = ".dev0"  # Should be blank except for rc's, betas, etc.
 ISRELEASED          = False
 
 VERSION             = '%d.%d.%d%s' % (MAJOR, MINOR, MICRO, SUFFIX)


### PR DESCRIPTION
this replace https://github.com/Theano/Theano/pull/3860 and close gh-3854

Use postfix .dev0 and bump to 0.8.0.dev0. This follow this new pep: https://www.python.org/dev/peps/pep-0440/#developmental-releases