### PR TITLE
fixed theano.gof.link.raise_with_op in Python 3

### DIFF
--- a/theano/gof/link.py
+++ b/theano/gof/link.py
@@ -227,7 +227,7 @@ def raise_with_op(node, thunk=None, exc_info=None, storage_map=None):
                 dtype = storage_map[k][0].dtype
                 storage_map_item.append(numpy.dtype(dtype).itemsize)
                 if shapeinfo is None:
-                    storage_map_item.append(None)
+                    storage_map_item.append(-1)
                 else:
                     sz = numpy.dtype(dtype).itemsize * numpy.prod(shapeinfo)
                     storage_map_item.append(sz)
@@ -263,7 +263,7 @@ def raise_with_op(node, thunk=None, exc_info=None, storage_map=None):
             else:
                 bytes = getsizeof(storage_map[k][0])
                 storage_map_item.append(bytes)
-                storage_map_item.append(None)
+                storage_map_item.append(-1)
 
             # Flag of shared val
             # storage_map_item[4]
@@ -278,7 +278,7 @@ def raise_with_op(node, thunk=None, exc_info=None, storage_map=None):
         from operator import itemgetter
         storage_map_list.sort(key=itemgetter(3), reverse=True)
         for item in storage_map_list:
-            if item[3] is None:
+            if item[3] == -1:
                 continue
             detailed_err_msg += " - " + item[0] + ", "
             if item[4] is True:


### PR DESCRIPTION
`raise_with_op` function stores total size in 3rd element of `storage_map_item` list and then sorts records by total size. For some records total size is not available; in this case the current code puts None to the 3rd list element. But in Python 3 comparing a number or None with None raises a ValueError, so in Python 3 `raise_with_op` fails:

```
<...snip...>
During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
<ipython-input-25-98e36ee02392> in <module>()
----> 1 cell.step(x0)

/Users/kmike/envs/dl/lib/python3.5/site-packages/theano/compile/function_module.py in __call__(self, *args, **kwargs)
    869                     node=self.fn.nodes[self.fn.position_of_error],
    870                     thunk=thunk,
--> 871                     storage_map=getattr(self.fn, 'storage_map', None))
    872             else:
    873                 # old-style linkers raise their own exceptions

/Users/kmike/envs/dl/lib/python3.5/site-packages/theano/gof/link.py in raise_with_op(node, thunk, exc_info, storage_map)
    277 
    278         from operator import itemgetter
--> 279         storage_map_list.sort(key=itemgetter(3), reverse=True)
    280         for item in storage_map_list:
    281             if item[3] is None:

TypeError: unorderable types: NoneType() < NoneType()
```

In this PR it is fixed by replacing None sentinel with `-1`.