### PR TITLE
scan: remove unconditional warning when strict=True is used

### DIFF
--- a/theano/scan_module/scan.py
+++ b/theano/scan_module/scan.py
@@ -1014,9 +1014,6 @@ def scan(fn,
     info['profile'] = profile
     info['allow_gc'] = allow_gc
     info['strict'] = strict
-    if strict:
-        warnings.warn('In the strict mode, all neccessary shared variables '
-                      'must be passed as a part of non_sequences', Warning)
 
     local_op = scan_op.Scan(inner_inputs, new_outs, info)
 


### PR DESCRIPTION
A PR for #3333. Just faced this issue today and spent some time debugging, thinking something is wrong with my code.

An objection was that error message is not clear enough without this warning. This is the error message:

```
MissingInputError: A variable that is an input to the graph was 
neither provided as an input to the function nor given a value. 
A chain of variables leading from this input to an output is 
[b_output, HostFromGpu.0, Elemwise{add,no_inplace}.0, DimShuffle{x,0}.0, Softmax.0]. 
This chain may not be unique
Backtrace when the variable is created:
  File "<ipython-input-22-04b2f3ee6772>", line 19, in __init__
    self.b_output = shared(init_ones(out_dim), 'b_output')
```

for me (a Theano novice) it looks clear enough - strict=True must be set explicitly, so I've read Theano docs about this argument before setting it, and was expecting this kind of errors; error message even pointed to the offending variable. 