### PR TITLE
Remove more warnings from the buildbot

### DIFF
--- a/theano/tensor/nnet/conv3d2d.py
+++ b/theano/tensor/nnet/conv3d2d.py
@@ -244,7 +244,7 @@ def conv3d(signals, filters,
     out_4d = tensor.nnet.conv2d(
         signals.reshape(_signals_shape_4d),
         filters.reshape(_filters_shape_4d),
-        image_shape=conv2d_signal_shape,
+        input_shape=conv2d_signal_shape,
         filter_shape=conv2d_filter_shape,
         border_mode=border_mode[1])  # ignoring border_mode[2]
 

--- a/theano/tensor/nnet/tests/test_corr.py
+++ b/theano/tensor/nnet/tests/test_corr.py
@@ -89,7 +89,7 @@ class TestCorr2D(utt.InferShapeTester):
         elif border_mode == 'valid':
             padHW = numpy.array([0, 0])
         elif border_mode == 'half':
-            padHW = numpy.floor(fil_shape2d / 2)
+            padHW = numpy.floor(fil_shape2d / 2).astype('int32')
         elif isinstance(border_mode, tuple):
             padHW = numpy.array(border_mode)
         elif isinstance(border_mode, int):


### PR DESCRIPTION
This should remove about 50% of the remaining warning messages in the tests.

The rest is a case of 80% of the effort for 20% of results.  I still might get to it at some point.