### PR TITLE
Bug fix: don't try to os.mkdirs on an empty directory

### DIFF
--- a/theano/d3viz/d3viz.py
+++ b/theano/d3viz/d3viz.py
@@ -81,7 +81,7 @@ def d3viz(fct, outfile, copy_deps=True, *args, **kwargs):
 
     # Create output directory if not existing
     outdir = os.path.dirname(outfile)
-    if not os.path.exists(outdir):
+    if not outdir == '' and not os.path.exists(outdir):
         os.makedirs(outdir)
 
     # Read template HTML file


### PR DESCRIPTION
Came across this bug when trying to output visualizations to the current directory. Previous code enforced that all visualizations be contained in a subdirectory, as the directory was never checked before calling os.mkdirs().

```
Traceback (most recent call last):
  File "main.py", line 88, in <module>
    main()
  File "main.py", line 85, in main
    output_viz(nn_step, 'step.html')
  File "main.py", line 79, in output_viz
    V.d3viz(fn, name)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/theano/d3viz/d3viz.py", line 85, in d3viz
    os.makedirs(outdir)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 2] No such file or directory: ''"
```