### PR TITLE
Fixed import of local pool submodule

### DIFF
--- a/theano/tensor/signal/downsample.py
+++ b/theano/tensor/signal/downsample.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import pool
+from . import pool
 import warnings
 
 warnings.warn("downsample module has been moved to the pool module.")


### PR DESCRIPTION
`pool` is a local submodule, so it should be imported as `from . import pool` instead of `import pool`. This fixes a bug when importing the `downsample` module (at least on Python 3).

fix gh-3894