### PR TITLE
Make sure imshp and kshp are constant

### DIFF
--- a/theano/sandbox/cuda/tests/test_abstractconv.py
+++ b/theano/sandbox/cuda/tests/test_abstractconv.py
@@ -1,3 +1,5 @@
+import numpy
+
 import theano
 from theano.tensor.nnet.tests import test_abstract_conv
 from theano.sandbox.cuda import float32_shared_constructor as gpu_shared
@@ -82,3 +84,5 @@ class TestDnnConvTypes(test_abstract_conv.TestConvTypes):
         self.input = cuda.ftensor4()
         self.filters = cuda.ftensor4()
         self.topgrad = cuda.ftensor4()
+        self.constant_tensor = cuda.CudaNdarray(
+            numpy.zeros((3, 5, 7, 11), dtype='float32'))

--- a/theano/sandbox/gpuarray/tests/test_abstractconv.py
+++ b/theano/sandbox/gpuarray/tests/test_abstractconv.py
@@ -1,10 +1,13 @@
 from nose.plugins.skip import SkipTest
 
+import numpy
+
 from theano.tensor.nnet.tests import test_abstract_conv
-from ..type import GpuArrayType, gpuarray_shared_constructor
+from ..type import GpuArrayType, gpuarray_shared_constructor, get_context
 from ..dnn import dnn_available, GpuDnnConv, GpuDnnConvGradW, GpuDnnConvGradI
 
 from .config import mode_with_gpu, test_ctx_name
+from pygpu import gpuarray
 
 gpu_ftensor4 = GpuArrayType(dtype='float32', broadcastable=(False,) * 4)
 
@@ -43,3 +46,6 @@ class TestDnnConvTypes(test_abstract_conv.TestConvTypes):
         self.input = gpu_ftensor4()
         self.filters = gpu_ftensor4()
         self.topgrad = gpu_ftensor4()
+        self.constant_tensor = gpuarray.array(
+            numpy.zeros((3, 5, 7, 11), dtype='float32'),
+            context=get_context(test_ctx_name))

--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -3,9 +3,12 @@ Abstract conv interface
 """
 
 import logging
+from six import reraise
+
 import theano
 
 from theano.tensor import as_tensor_variable, patternbroadcast
+from theano.tensor import get_scalar_constant_value, NotScalarConstantError
 from theano.gof import Apply, Op
 
 from six.moves import xrange
@@ -412,7 +415,25 @@ class BaseAbstractConv2d(Op):
                 ' integers'.format(border_mode))
 
         self.imshp = tuple(imshp) if imshp else None
+        for imshp_i in self.imshp:
+            if imshp_i is not None:
+                # Components of imshp should be constant or ints
+                try:
+                    get_scalar_constant_value(imshp_i)
+                except NotScalarConstantError:
+                    _logger.error("imshp should be None or "
+                                  "a tuple of constant int values")
+                    raise
         self.kshp = tuple(kshp) if kshp else None
+        for kshp_i in self.kshp:
+            if kshp_i is not None:
+                # Components of kshp should be constant or ints
+                try:
+                    get_scalar_constant_value(kshp_i)
+                except NotScalarConstantError:
+                    _logger.error("kshp should be None or "
+                                  "a tuple of constant int values")
+                    raise
         self.border_mode = border_mode
         self.filter_flip = filter_flip
 

--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -4,6 +4,7 @@ Abstract conv interface
 
 import logging
 from six import reraise
+import sys
 
 import theano
 
@@ -414,26 +415,30 @@ class BaseAbstractConv2d(Op):
                 '"valid", "full", "half", an integer or a pair of'
                 ' integers'.format(border_mode))
 
-        self.imshp = tuple(imshp) if imshp else None
+        self.imshp = tuple(imshp) if imshp else (None,) * 4
         for imshp_i in self.imshp:
             if imshp_i is not None:
                 # Components of imshp should be constant or ints
                 try:
-                    get_scalar_constant_value(imshp_i)
+                    get_scalar_constant_value(imshp_i,
+                                              only_process_constants=True)
                 except NotScalarConstantError:
-                    _logger.error("imshp should be None or "
-                                  "a tuple of constant int values")
-                    raise
-        self.kshp = tuple(kshp) if kshp else None
+                    reraise(ValueError,
+                            ValueError("imshp should be None or a tuple of "
+                                       "constant int values"),
+                            sys.exc_info()[2])
+        self.kshp = tuple(kshp) if kshp else (None,) * 4
         for kshp_i in self.kshp:
             if kshp_i is not None:
                 # Components of kshp should be constant or ints
                 try:
-                    get_scalar_constant_value(kshp_i)
+                    get_scalar_constant_value(kshp_i,
+                                              only_process_constants=True)
                 except NotScalarConstantError:
-                    _logger.error("kshp should be None or "
-                                  "a tuple of constant int values")
-                    raise
+                    reraise(ValueError,
+                            ValueError("kshp should be None or a tuple of "
+                                       "constant int values"),
+                            sys.exc_info()[2])
         self.border_mode = border_mode
         self.filter_flip = filter_flip
 

--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -510,7 +510,11 @@ class AbstractConv2d(BaseAbstractConv2d):
                                              filter_flip)
 
     def make_node(self, img, kern):
-        # Make sure both inputs have the same Type
+        # Make sure both inputs are Variables with the same Type
+        if not isinstance(img, theano.Variable):
+            img = as_tensor_variable(img)
+        if not isinstance(kern, theano.Variable):
+            kern = as_tensor_variable(kern)
         ktype = img.type.clone(dtype=kern.dtype,
                                broadcastable=kern.broadcastable)
         kern = ktype.filter_variable(kern)
@@ -635,7 +639,11 @@ class AbstractConv2d_gradWeights(BaseAbstractConv2d):
 
     # Update shape/height_width
     def make_node(self, img, topgrad, shape):
-        # Make sure both inputs have the same Type
+        # Make sure both inputs are Variables with the same Type
+        if not isinstance(img, theano.Variable):
+            img = as_tensor_variable(img)
+        if not isinstance(topgrad, theano.Variable):
+            topgrad = as_tensor_variable(topgrad)
         gtype = img.type.clone(dtype=topgrad.dtype,
                                broadcastable=topgrad.broadcastable)
         topgrad = gtype.filter_variable(topgrad)
@@ -766,7 +774,11 @@ class AbstractConv2d_gradInputs(BaseAbstractConv2d):
 
     # Update shape/height_width
     def make_node(self, kern, topgrad, shape):
-        # Make sure both inputs have the same Type
+        # Make sure both inputs are Variables with the same Type
+        if not isinstance(kern, theano.Variable):
+            kern = as_tensor_variable(kern)
+        if not isinstance(topgrad, theano.Variable):
+            topgrad = as_tensor_variable(topgrad)
         gtype = kern.type.clone(dtype=topgrad.dtype,
                                 broadcastable=topgrad.broadcastable)
         topgrad = gtype.filter_variable(topgrad)


### PR DESCRIPTION
Otherwise, if they are symbolic variables, they could be
used during shape inference, which could introduce dependencies
on variables outside of the graph.

I'm not sure what the best way of raising the exception again with a different error message should be.