### PR TITLE
Option for passing additional libraries for the GCC.

### DIFF
--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -191,6 +191,11 @@ def filter_nvcc_flags(s):
             " nvcc.flags value is '%s'" % s)
     return ' '.join(flags)
 
+AddConfigVar('gcc.libraries',
+             "Extra libraries to link with",
+             StrParam(""),
+             in_c_key=False)
+
 AddConfigVar('nvcc.flags',
              "Extra compiler flags for nvcc",
              ConfigParam("", filter_nvcc_flags),

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -2142,6 +2142,10 @@ class GCC_compiler(Compiler):
         libs = std_libs() + libs
         lib_dirs = std_lib_dirs() + lib_dirs
 
+        additional_libraries = theano.config.gcc.libraries.split(' ')
+        if not additional_libraries == ['']:
+             libs += additional_libraries
+
         cppfilename = os.path.join(location, 'mod.cpp')
         with open(cppfilename, 'w') as cppfile:
 


### PR DESCRIPTION
When using Theano on windows, I ran into a problem with linking - I needed to link package libpython.
So in .theanorc, I added

> [gcc]
> cxxflags = -Lc:\Anaconda3\libs -llibpython34

but that did not solve the issue.
Finally, I find out that it is because cxxflags are passed as the first arguments for the GCC - but GCC only accepts -l switch when it is passed AFTER source files.
Therefore, I modified python code that generates the GCC command, so it can accept additional libraries from the configuration. Now, my GCC section of .theanorc looks like this and the problem is solved:

> [gcc]
> cxxflags = -shared -Ic:\mingw\mingw32\include -Lc:\Anaconda3\libs -DMS_WIN64
> libraries = libpython34
