### PR TITLE
fixes #3556: more robust determination of python library name 

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1,4 +1,4 @@
-"""
+rator"""
 Generate and compile C modules for Python.
 
 """
@@ -1649,9 +1649,9 @@ def std_lib_dirs_and_libs():
     elif sys.platform == 'darwin':
         std_lib_dirs_and_libs.data = [], []
     else:
-        # assume Linux 
+        # assume Linux
         # Typical include directory: /usr/include/python2.6
-        
+
         # get the name of the python library (shared object)
         libname = distutils.sysconfig.get_config_var("LDLIBRARY")
 
@@ -1661,10 +1661,10 @@ def std_lib_dirs_and_libs():
         # remove extension if present
         if libname.endswith(".so"):
             libname = libname[:-3]
-    
+
         libdir = distutils.sysconfig.get_config_var("LIBDIR")
 
-        std_lib_dirs_and_libs.data = [ libname ], [ libdir ]
+        std_lib_dirs_and_libs.data = [libname], [libdir]
 
     # sometimes, the linker cannot find -lpython so we need to tell it
     # explicitly where it is located this returns

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1649,9 +1649,22 @@ def std_lib_dirs_and_libs():
     elif sys.platform == 'darwin':
         std_lib_dirs_and_libs.data = [], []
     else:
+        # assume Linux 
         # Typical include directory: /usr/include/python2.6
-        libname = os.path.basename(python_inc)
-        std_lib_dirs_and_libs.data = [libname], []
+        
+        # get the name of the python library (shared object)
+        libname = distutils.sysconfig.get_config_var("LDLIBRARY")
+
+        if libname.startswith("lib"):
+            libname = libname[3:]
+
+        # remove extension if present
+        if libname.endswith(".so"):
+            libname = libname[:-3]
+    
+        libdir = distutils.sysconfig.get_config_var("LIBDIR")
+
+        std_lib_dirs_and_libs.data = [ libname ], [ libdir ]
 
     # sometimes, the linker cannot find -lpython so we need to tell it
     # explicitly where it is located this returns

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1,4 +1,4 @@
-rator"""
+"""
 Generate and compile C modules for Python.
 
 """


### PR DESCRIPTION
fixes #3556: more robust determination of python library name and directory in function std_lib_dirs_and_libs(), now works on private python installations on Linux 