### PR TITLE
add missing return to GpuFromHost R_op

### DIFF
--- a/theano/sandbox/cuda/basic_ops.py
+++ b/theano/sandbox/cuda/basic_ops.py
@@ -152,7 +152,7 @@ class GpuFromHost(GpuOp):
 
     def R_op(self, inputs, eval_points):
         ev, = eval_points
-        [self(ev)]
+        return [self(ev)]
 
     def infer_shape(self, node, xshp):
         return xshp


### PR DESCRIPTION
Add missing `return` to the `R_op` for `GpuFromHost`.