### PR TITLE
LogAbsDet

### DIFF
--- a/theano/tensor/nlinalg.py
+++ b/theano/tensor/nlinalg.py
@@ -743,7 +743,8 @@ class LogAbsDet(Op):
     def perform(self, node, (x,), (z,)):
         try:
             s = numpy.linalg.svd(x, compute_uv=False)
-            z[0] = numpy.asarray(numpy.sum(numpy.log(s)), dtype=x.dtype)
+            log_abs_det = numpy.sum(numpy.log(numpy.abs(s)))
+            z[0] = numpy.asarray(log_abs_det, dtype=x.dtype)
         except Exception:
             print('Failed to compute logabsdet of {}.'.format(x))
             raise

--- a/theano/tensor/nlinalg.py
+++ b/theano/tensor/nlinalg.py
@@ -726,3 +726,37 @@ def norm(x, ord):
             raise ValueError(0)
     elif ndim > 2:
         raise NotImplementedError("We don't support norm witn ndim > 2")
+
+
+class LogAbsDet(Op):
+    """Computes the logarithm of absolute determinant of a square
+    matrix M, log(abs(det(M))), on CPU. Avoids det(M) overflow/
+    underflow.
+
+    TODO: add GPU code!
+    """
+    def make_node(self, x):
+        x = theano.tensor.as_tensor_variable(x)
+        o = theano.tensor.scalar(dtype=x.dtype)
+        return Apply(self, [x], [o])
+
+    def perform(self, node, (x,), (z,)):
+        try:
+            s = numpy.linalg.svd(x, compute_uv=False)
+            z[0] = numpy.asarray(numpy.sum(numpy.log(s)), dtype=x.dtype)
+        except Exception:
+            print('Failed to compute logabsdet of {}.'.format(x))
+            raise
+
+    def grad(self, inputs, g_outputs):
+        gz, = g_outputs
+        x, = inputs
+        return [gz * matrix_inverse(x).T]
+
+    def __str__(self):
+        return "LogAbsDet"
+
+logabsdet = LogAbsDet()
+
+
+

--- a/theano/tensor/tests/test_nlinalg.py
+++ b/theano/tensor/tests/test_nlinalg.py
@@ -36,7 +36,9 @@ from theano.tensor.nlinalg import ( MatrixInverse,
                                     qr,
                                     matrix_power,
                                     norm,
-                                    svd
+                                    svd,
+                                    LogAbsDet,
+                                    logabsdet
                                     )
 from nose.plugins.attrib import attr
 
@@ -516,3 +518,31 @@ class T_NormTests(unittest.TestCase):
             t_n = f(A[2][i])
             n_n = numpy.linalg.norm(A[2][i], A[3][i])
             assert _allclose(n_n, t_n)
+
+
+class TestLogAbsDet(unittest.TestCase):
+
+    def setUp(self):
+        utt.seed_rng()
+        self.op_class = LogAbsDet
+        self.op = logabsdet
+
+    def validate(self, input_mat):
+        x = theano.tensor.matrix()
+        f = theano.function([x], self.op(x))
+        out = f(input_mat)
+        numpy_out = numpy.sum(numpy.log(numpy.linalg.svd(input_mat, compute_uv=False)))
+
+        # Compare the result computed to the expected value.
+        utt.assert_allclose(numpy_out, out)
+
+        # Test gradient:
+        utt.verify_grad(self.op, [input_mat])
+
+    def test_basic(self):
+        # Calls validate with different params
+        self.validate(numpy.random.randn(3, 3))
+        self.validate(numpy.random.randn(10, 10))
+
+
+

--- a/theano/tensor/tests/test_nlinalg.py
+++ b/theano/tensor/tests/test_nlinalg.py
@@ -531,7 +531,8 @@ class TestLogAbsDet(unittest.TestCase):
         x = theano.tensor.matrix()
         f = theano.function([x], self.op(x))
         out = f(input_mat)
-        numpy_out = numpy.sum(numpy.log(numpy.linalg.svd(input_mat, compute_uv=False)))
+        svd_diag = numpy.linalg.svd(input_mat, compute_uv=False)
+        numpy_out = numpy.sum(numpy.log(numpy.abs(svd_diag)))
 
         # Compare the result computed to the expected value.
         utt.assert_allclose(numpy_out, out)


### PR DESCRIPTION
Hi! Go the LogAbsDet op done with gradient, but no GPU code so far... if anyone wants to help/ point me to PyCuda/CUDA implementation of SVD, let me know!

This is very similar to numpy.linalg.slogdet, except that the sign of the determinant is omitted, so it just computes log(abs(det(M))) for a matrix M.

Note that M does not need to be positive semidefinite, since we're taking the absolute value (as happens in e.g. maximum likelihood estimation).