### PR TITLE
Fix args with -Wl to nvcc

### DIFF
--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -251,6 +251,10 @@ class NVCC_compiler(Compiler):
         # nvcc argument
         preargs1 = []
         for pa in preargs:
+            if pa.startswith('-Wl,'):
+                preargs1.append('-Xlinker')
+                preargs1.append(pa[4:])
+                continue
             for pattern in ['-O', '-arch=', '-ccbin=', '-G', '-g', '-I',
                             '-L', '--fmad', '--ftz', '--maxrregcount',
                             '--prec-div', '--prec-sqrt',  '--use_fast_math',

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -265,8 +265,9 @@ class NVCC_compiler(Compiler):
 
                 if pa.startswith(pattern):
                     preargs1.append(pa)
-                else:
-                    preargs2.append(pa)
+                    break
+            else:
+                preargs2.append(pa)
 
         # Don't put -G by default, as it slow things down.
         # We aren't sure if -g slow things down, so we don't put it by default.

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -250,6 +250,7 @@ class NVCC_compiler(Compiler):
         # '--gpu-code=compute_13',
         # nvcc argument
         preargs1 = []
+        preargs2 = []
         for pa in preargs:
             if pa.startswith('-Wl,'):
                 preargs1.append('-Xlinker')
@@ -264,8 +265,8 @@ class NVCC_compiler(Compiler):
 
                 if pa.startswith(pattern):
                     preargs1.append(pa)
-        preargs2 = [pa for pa in preargs
-                    if pa not in preargs1]  # other arguments
+                else:
+                    preargs2.append(pa)
 
         # Don't put -G by default, as it slow things down.
         # We aren't sure if -g slow things down, so we don't put it by default.


### PR DESCRIPTION
We can't just stuff them in -Xcompiler since this splits the -Wl and the following arg.  I just rewrite them as -Xlinker.