### PR TITLE
h_softmax: removed three redundant parameters

### DIFF
--- a/theano/tensor/nnet/tests/test_nnet.py
+++ b/theano/tensor/nnet/tests/test_nnet.py
@@ -1596,12 +1596,10 @@ def test_h_softmax():
     y = tensor.ivector('y')
 
     # This only computes the output corresponding to the target
-    y_hat_tg = h_softmax(x, batch_size, output_size, h_softmax_level1_size,
-                         h_softmax_level2_size, W1, b1, W2, b2, y)
+    y_hat_tg = h_softmax(x, output_size, W1, b1, W2, b2, y)
 
     # This computes all the outputs
-    y_hat_all = h_softmax(x, batch_size, output_size, h_softmax_level1_size,
-                          h_softmax_level2_size, W1, b1, W2, b2)
+    y_hat_all = h_softmax(x, output_size, W1, b1, W2, b2)
 
     #############
     # Compile functions


### PR DESCRIPTION
Compared to the last version, there are some internal parameters derived from the weight matrices: (suggestions of @sisp)
- batch_size = x.shape[0], which could vary in each iteration; This is especially advantageous for the evaluation of the model;
- n_classes is derived from the W1.shape[1];
- n_outputs_per_class is derived from W2.shape[2];