### PR TITLE
Fix last DLT problem(s) with the new backend.

### DIFF
--- a/theano/sandbox/gpuarray/opt.py
+++ b/theano/sandbox/gpuarray/opt.py
@@ -451,7 +451,7 @@ def gpu_print_wrapper(op, cnda):
 @op_lifter([tensor.printing.Print])
 def local_gpu_print_op(node, context_name):
     x, = node.inputs
-    gpu_x, = x.owner.inputs
+    gpu_x = as_gpuarray_variable(x, context_name=context_name)
     new_op = node.op.__class__(global_fn=gpu_print_wrapper)
     new_op.old_op = node.op
     return new_op(gpu_x)

--- a/theano/sandbox/gpuarray/opt.py
+++ b/theano/sandbox/gpuarray/opt.py
@@ -327,8 +327,7 @@ def local_gpureshape(node, context_name):
 @register_opt('fast_compile')
 @op_lifter([tensor.Rebroadcast])
 def local_gpu_rebroadcast(node, context_name):
-    if isinstance(node.inputs[0].owner.op, HostFromGpu):
-        return node.op(node.inputs[0].owner.inputs[0])
+    return node.op(as_gpuarray_variable(node.inputs[0], context_name))
 
 
 @register_opt('fast_compile')
@@ -784,10 +783,9 @@ def local_gpua_softmaxwithbias(node, context_name):
 @register_opt('fast_compile')
 @op_lifter([theano.tensor.opt.Assert])
 def local_assert(node, context_name):
-    if (node.inputs[0].owner and
-            isinstance(node.inputs[0].owner.op, HostFromGpu)):
-        return [host_from_gpu(node.op(node.inputs[0].owner.inputs[0],
-                                      *node.inputs[1:]))]
+    return [host_from_gpu(node.op(as_gpuarray_variable(node.inputs[0],
+                                                       context_name),
+                                  node.inputs[1:]))]
 
 
 @register_opt('fast_compile')

--- a/theano/sandbox/gpuarray/opt.py
+++ b/theano/sandbox/gpuarray/opt.py
@@ -785,7 +785,7 @@ def local_gpua_softmaxwithbias(node, context_name):
 def local_assert(node, context_name):
     return [host_from_gpu(node.op(as_gpuarray_variable(node.inputs[0],
                                                        context_name),
-                                  node.inputs[1:]))]
+                                  *node.inputs[1:]))]
 
 
 @register_opt('fast_compile')

--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -235,6 +235,11 @@ class AbstractConv2d(BaseAbstractConv2d):
                                              filter_flip)
 
     def make_node(self, img, kern):
+        # Normalize the inputs types
+        ktype = img.type.clone(dtype=kern.dtype,
+                               broadcastable=kern.broadcastable)
+        kern = ktype.filter_variable(kern)
+
         if img.type.ndim != 4:
             raise TypeError('img must be 4D tensor')
         if kern.type.ndim != 4:
@@ -328,6 +333,11 @@ class AbstractConv2d_gradWeights(BaseAbstractConv2d):
 
     # Update shape/height_width
     def make_node(self, img, topgrad, shape):
+        # Normalize the inputs types
+        gtype = img.type.clone(dtype=topgrad.dtype,
+                               broadcastable=topgrad.broadcastable)
+        topgrad = gtype.filter_variable(topgrad)
+
         if img.type.ndim != 4:
             raise TypeError('img must be 4D tensor')
         if topgrad.type.ndim != 4:
@@ -415,6 +425,11 @@ class AbstractConv2d_gradInputs(BaseAbstractConv2d):
 
     # Update shape/height_width
     def make_node(self, kern, topgrad, shape):
+        # Normalize the inputs types
+        gtype = kern.type.clone(dtype=topgrad.dtype,
+                               broadcastable=topgrad.broadcastable)
+        topgrad = gtype.filter_variable(topgrad)
+
         if kern.type.ndim != 4:
             raise TypeError('kern must be 4D tensor')
         if topgrad.type.ndim != 4:

--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -235,7 +235,7 @@ class AbstractConv2d(BaseAbstractConv2d):
                                              filter_flip)
 
     def make_node(self, img, kern):
-        # Normalize the inputs types
+        # Make sure both inputs have the same Type
         ktype = img.type.clone(dtype=kern.dtype,
                                broadcastable=kern.broadcastable)
         kern = ktype.filter_variable(kern)
@@ -333,7 +333,7 @@ class AbstractConv2d_gradWeights(BaseAbstractConv2d):
 
     # Update shape/height_width
     def make_node(self, img, topgrad, shape):
-        # Normalize the inputs types
+        # Make sure both inputs have the same Type
         gtype = img.type.clone(dtype=topgrad.dtype,
                                broadcastable=topgrad.broadcastable)
         topgrad = gtype.filter_variable(topgrad)
@@ -425,9 +425,9 @@ class AbstractConv2d_gradInputs(BaseAbstractConv2d):
 
     # Update shape/height_width
     def make_node(self, kern, topgrad, shape):
-        # Normalize the inputs types
+        # Make sure both inputs have the same Type
         gtype = kern.type.clone(dtype=topgrad.dtype,
-                               broadcastable=topgrad.broadcastable)
+                                broadcastable=topgrad.broadcastable)
         topgrad = gtype.filter_variable(topgrad)
 
         if kern.type.ndim != 4:


### PR DESCRIPTION
This fixes a number of problems.

The main one is that the lifter for Pool was removing operations from the graph in certain circumstances.

Others are:
 - The lifter for Print was mostly broken
 - AbstractConv could stay unoptimized in certain cases of mixed input types.

There is now code in the AbstractConv ops to convert all inputs to be of the same type as the first one, which avoids the second problem.