### PR TITLE
Changes to GpuSolve op to improve compatibility with slingalg Solve op

### DIFF
--- a/theano/sandbox/cuda/cula.py
+++ b/theano/sandbox/cuda/cula.py
@@ -1,6 +1,7 @@
 import pkg_resources
 
 import theano
+from theano.tensor.slinalg import MATRIX_STRUCTURES
 from theano.sandbox.cuda.type import CudaNdarrayType
 from theano.sandbox.cuda import GpuOp
 from theano.sandbox.cuda.basic_ops import as_cuda_ndarray_variable
@@ -30,13 +31,18 @@ class GpuSolve(GpuOp):
     ----------
     trans
         Whether to take the transpose of the input matrix or not.
+    A_structure
+        Any special structure to matrix system being solved
 
     """
 
-    __props__ = ('trans',)
+    __props__ = ('trans', 'A_structure')
 
-    def __init__(self, trans='N'):
+    def __init__(self, trans='N', A_structure='general'):
+        if A_structure not in MATRIX_STRUCTURES:
+            raise ValueError('Invalid matrix structure argument', A_structure)
         self.trans = trans
+        self.A_structure = A_structure
         super(GpuSolve, self).__init__()
 
     def output_type(self, inp):
@@ -47,7 +53,7 @@ class GpuSolve(GpuOp):
         inp2 = as_cuda_ndarray_variable(inp2)
 
         assert inp1.ndim == 2
-        assert inp2.ndim == 2
+        assert inp2.ndim in [1, 2]
         return theano.Apply(self, [inp1, inp2], [self.output_type(inp1)()])
 
     def make_thunk(self,
@@ -86,8 +92,16 @@ class GpuSolve(GpuOp):
             else:
                 trans = 'T'
 
+            # If b is one-dimensional reshape to two-dimensional array with
+            # singleton second dimension
+            if b.ndim == 1:
+                b_2d = b.reshape((-1, 1))
+            else:
+                b_2d = b
+
             # Convert b to F-order from c-order.
-            b_cpy = dimshuffle(b, (1, 0)).reshape((b.shape[0], b.shape[1]))
+            b_cpy = dimshuffle(b_2d, (1, 0)).reshape((b_2d.shape[0],
+                                                      b_2d.shape[1]))
 
             # This copy forces allocation of a new C-contiguous buffer
             # and returns it.
@@ -128,9 +142,15 @@ class GpuSolve(GpuOp):
 
             A_pycuda, b_pycuda = cula_gpu_solve(A_cpy, b_cpy, trans)
 
-            # Convert b to F-order from c-order and assign it to output:
-            b_cpy = b_cpy.reshape(b.shape[::-1])
+            # Convert b to F-order from c-order:
+            b_cpy = b_cpy.reshape(b_2d.shape[::-1])
             b_cpy = dimshuffle(b_cpy, (1, 0))
+
+            # If b was originally a one-dimensional array reshape back
+            if b.ndim == 1:
+                b_cpy = b_cpy.reshape(b.shape[0])
+
+            # Assign result to output
             z[0] = b_cpy
 
         thunk.inputs = inputs

--- a/theano/sandbox/cuda/cula.py
+++ b/theano/sandbox/cuda/cula.py
@@ -95,7 +95,7 @@ class GpuSolve(GpuOp):
             # If b is one-dimensional reshape to two-dimensional array with
             # singleton second dimension
             if b.ndim == 1:
-                b_2d = b.reshape((-1, 1))
+                b_2d = b.reshape((b.shape[0], 1))
             else:
                 b_2d = b
 

--- a/theano/sandbox/cuda/opt.py
+++ b/theano/sandbox/cuda/opt.py
@@ -37,7 +37,7 @@ from theano.sandbox.cuda.blas import (
     GpuCorr3dMM, GpuCorr3dMM_gradInputs, GpuCorr3dMM_gradWeights)
 
 from theano.sandbox.cuda.blas import gpu_gemv_inplace
-from theano.sandbox.cuda.cula import gpu_solve
+from theano.sandbox.cuda.cula import GpuSolve
 
 from theano.sandbox.cuda.blas import gpu_gemv_no_inplace
 from theano.sandbox.cuda.blas import gpu_ger_inplace
@@ -696,6 +696,8 @@ def local_gpu_solve(node):
             isinstance(host_input.owner.op,
                        slinalg.Solve)):
             x, y = host_input.owner.inputs
+            A_structure = host_input.owner.op.A_structure
+            gpu_solve = GpuSolve(A_structure=A_structure)
             return [gpu_solve(as_cuda_ndarray_variable(x),
                               as_cuda_ndarray_variable(y))]
 
@@ -703,6 +705,8 @@ def local_gpu_solve(node):
         if any([i.owner and isinstance(i.owner.op, HostFromGpu)
                 for i in node.inputs]):
             x, y = node.inputs
+            A_structure = node.op.A_structure
+            gpu_solve = GpuSolve(A_structure=A_structure)
             return [host_from_gpu(
                     gpu_solve(as_cuda_ndarray_variable(x),
                               as_cuda_ndarray_variable(y)))]

--- a/theano/sandbox/cuda/tests/test_cula.py
+++ b/theano/sandbox/cuda/tests/test_cula.py
@@ -32,13 +32,22 @@ class TestCula(unittest.TestCase):
     def run_gpu_solve(self, A_val, x_val):
         b_val = numpy.dot(A_val, x_val)
         A = theano.tensor.matrix("A", dtype="float32")
-        b = theano.tensor.matrix("b", dtype="float32")
-
+        if x_val.ndim == 1:
+            b = theano.tensor.vector("b", dtype="float32")
+        else:
+            b = theano.tensor.matrix("b", dtype="float32")
         solver = cula.gpu_solve(A, b)
         fn = theano.function([A, b], [solver])
         res = fn(A_val, b_val)
         x_res = numpy.array(res[0])
         utt.assert_allclose(x_res, x_val)
+
+    def test_invalid_input_fail_3D(self):
+        def invalid_input_func():
+            A = theano.tensor.tensor3("A", dtype="float32")
+            b = theano.tensor.matrix("b", dtype="float32")
+            solve = cula.gpu_solve(A, b)
+        self.assertRaises(AssertionError, invalid_input_func)
 
     def test_diag_solve(self):
         """ Diagonal solve test case with 1D vector as 2D matrix RHS. """

--- a/theano/sandbox/cuda/tests/test_cula.py
+++ b/theano/sandbox/cuda/tests/test_cula.py
@@ -26,6 +26,9 @@ else:
 
 
 class TestCula(unittest.TestCase):
+    def setUp(self):
+        utt.seed_rng()
+
     def run_gpu_solve(self, A_val, x_val):
         b_val = numpy.dot(A_val, x_val)
         A = theano.tensor.matrix("A", dtype="float32")
@@ -39,7 +42,6 @@ class TestCula(unittest.TestCase):
 
     def test_diag_solve(self):
         """ Diagonal solve test case with 1D vector as 2D matrix RHS. """
-        numpy.random.seed(1)
         A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
                               dtype="float32")
         x_val = numpy.random.uniform(-0.4, 0.4, (A_val.shape[1],
@@ -48,7 +50,6 @@ class TestCula(unittest.TestCase):
 
     def test_sym_solve(self):
         """ Symmetric solve test case with 1D vector as 2D matrix RHS. """
-        numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_sym = (A_val + A_val.T) / 2.0
         x_val = numpy.random.uniform(-0.4, 0.4, (A_val.shape[1],
@@ -57,7 +58,6 @@ class TestCula(unittest.TestCase):
 
     def test_orth_solve(self):
         """ Orthogonal solve test case with 1D vector as 2D matrix RHS. """
-        numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_orth = numpy.linalg.svd(A_val)[0]
         x_val = numpy.random.uniform(-0.4, 0.4, (A_orth.shape[1],
@@ -66,7 +66,6 @@ class TestCula(unittest.TestCase):
 
     def test_uni_rand_solve(self):
         """ Uniform random solve test case with 2D matrix RHS. """
-        numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         x_val = numpy.random.uniform(-0.4, 0.4,
                                      (A_val.shape[1], 4)).astype("float32")
@@ -74,7 +73,6 @@ class TestCula(unittest.TestCase):
 
     def test_diag_solve_1d(self):
         """ Diagonal solve test case with 1D vector RHS. """
-        numpy.random.seed(1)
         A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
                               dtype="float32")
         x_val = numpy.random.uniform(-0.4, 0.4,
@@ -83,7 +81,6 @@ class TestCula(unittest.TestCase):
 
     def test_sym_solve_1d(self):
         """ Symmetric solve test case with 1D vector RHS. """
-        numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_sym = (A_val + A_val.T) / 2.0
         x_val = numpy.random.uniform(-0.4, 0.4,
@@ -92,7 +89,6 @@ class TestCula(unittest.TestCase):
 
     def test_orth_solve_1d(self):
         """ Orthogonal solve test case with 1D vector RHS. """
-        numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_orth = numpy.linalg.svd(A_val)[0]
         x_val = numpy.random.uniform(-0.4, 0.4,

--- a/theano/sandbox/cuda/tests/test_cula.py
+++ b/theano/sandbox/cuda/tests/test_cula.py
@@ -38,6 +38,7 @@ class TestCula(unittest.TestCase):
         utt.assert_allclose(x_res, x_val)
 
     def test_diag_solve(self):
+        """ Diagonal solve test case with 1D vector as 2D matrix RHS. """
         numpy.random.seed(1)
         A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
                               dtype="float32")
@@ -46,6 +47,7 @@ class TestCula(unittest.TestCase):
         self.run_gpu_solve(A_val, x_val)
 
     def test_sym_solve(self):
+        """ Symmetric solve test case with 1D vector as 2D matrix RHS. """
         numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_sym = (A_val + A_val.T) / 2.0
@@ -54,6 +56,7 @@ class TestCula(unittest.TestCase):
         self.run_gpu_solve(A_sym, x_val)
 
     def test_orth_solve(self):
+        """ Orthogonal solve test case with 1D vector as 2D matrix RHS. """
         numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_orth = numpy.linalg.svd(A_val)[0]
@@ -62,8 +65,36 @@ class TestCula(unittest.TestCase):
         self.run_gpu_solve(A_orth, x_val)
 
     def test_uni_rand_solve(self):
+        """ Uniform random solve test case with 2D matrix RHS. """
         numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         x_val = numpy.random.uniform(-0.4, 0.4,
                                      (A_val.shape[1], 4)).astype("float32")
         self.run_gpu_solve(A_val, x_val)
+
+    def test_diag_solve_1d(self):
+        """ Diagonal solve test case with 1D vector RHS. """
+        numpy.random.seed(1)
+        A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
+                              dtype="float32")
+        x_val = numpy.random.uniform(-0.4, 0.4,
+                                     A_val.shape[1]).astype("float32")
+        self.run_gpu_solve(A_val, x_val)
+
+    def test_sym_solve_1d(self):
+        """ Symmetric solve test case with 1D vector RHS. """
+        numpy.random.seed(1)
+        A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
+        A_sym = (A_val + A_val.T) / 2.0
+        x_val = numpy.random.uniform(-0.4, 0.4,
+                                     A_val.shape[1]).astype("float32")
+        self.run_gpu_solve(A_sym, x_val)
+
+    def test_orth_solve_1d(self):
+        """ Orthogonal solve test case with 1D vector RHS. """
+        numpy.random.seed(1)
+        A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
+        A_orth = numpy.linalg.svd(A_val)[0]
+        x_val = numpy.random.uniform(-0.4, 0.4,
+                                     A_orth.shape[1]).astype("float32")
+        self.run_gpu_solve(A_orth, x_val)

--- a/theano/sandbox/cuda/tests/test_cula.py
+++ b/theano/sandbox/cuda/tests/test_cula.py
@@ -42,46 +42,55 @@ class TestCula(unittest.TestCase):
         x_res = numpy.array(res[0])
         utt.assert_allclose(x_res, x_val)
 
-    def test_invalid_input_fail_3D(self):
+    def test_invalid_input_fail_1d(self):
+        """ Invalid solve input test case with 1D vector as first input. """
         def invalid_input_func():
             A = theano.tensor.tensor3("A", dtype="float32")
             b = theano.tensor.matrix("b", dtype="float32")
             solve = cula.gpu_solve(A, b)
         self.assertRaises(AssertionError, invalid_input_func)
 
-    def test_diag_solve(self):
-        """ Diagonal solve test case with 1D vector as 2D matrix RHS. """
+    def test_invalid_input_fail_3d(self):
+        """ Invalid solve input test case with 3D tensor as first input. """
+        def invalid_input_func():
+            A = theano.tensor.vector("A", dtype="float32")
+            b = theano.tensor.matrix("b", dtype="float32")
+            solve = cula.gpu_solve(A, b)
+        self.assertRaises(AssertionError, invalid_input_func)
+
+    def test_diag_solve_2d(self):
+        """ Diagonal solve test case with 2D array as second input. """
         A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
                               dtype="float32")
         x_val = numpy.random.uniform(-0.4, 0.4, (A_val.shape[1],
                                      1)).astype("float32")
         self.run_gpu_solve(A_val, x_val)
 
-    def test_sym_solve(self):
-        """ Symmetric solve test case with 1D vector as 2D matrix RHS. """
+    def test_sym_solve_2d(self):
+        """ Symmetric solve test case with 2D array as second input. """
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_sym = (A_val + A_val.T) / 2.0
         x_val = numpy.random.uniform(-0.4, 0.4, (A_val.shape[1],
                                      1)).astype("float32")
         self.run_gpu_solve(A_sym, x_val)
 
-    def test_orth_solve(self):
-        """ Orthogonal solve test case with 1D vector as 2D matrix RHS. """
+    def test_orth_solve_2d(self):
+        """ Orthogonal solve test case with 2D array as second input. """
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_orth = numpy.linalg.svd(A_val)[0]
         x_val = numpy.random.uniform(-0.4, 0.4, (A_orth.shape[1],
                                      1)).astype("float32")
         self.run_gpu_solve(A_orth, x_val)
 
-    def test_uni_rand_solve(self):
-        """ Uniform random solve test case with 2D matrix RHS. """
+    def test_uni_rand_solve_2d(self):
+        """ Uniform random solve test case with 2D array as second input. """
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         x_val = numpy.random.uniform(-0.4, 0.4,
                                      (A_val.shape[1], 4)).astype("float32")
         self.run_gpu_solve(A_val, x_val)
 
     def test_diag_solve_1d(self):
-        """ Diagonal solve test case with 1D vector RHS. """
+        """ Diagonal solve test case with 1D array as second input. """
         A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
                               dtype="float32")
         x_val = numpy.random.uniform(-0.4, 0.4,
@@ -89,7 +98,7 @@ class TestCula(unittest.TestCase):
         self.run_gpu_solve(A_val, x_val)
 
     def test_sym_solve_1d(self):
-        """ Symmetric solve test case with 1D vector RHS. """
+        """ Symmetric solve test case with 1D array as second input. """
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_sym = (A_val + A_val.T) / 2.0
         x_val = numpy.random.uniform(-0.4, 0.4,
@@ -97,9 +106,16 @@ class TestCula(unittest.TestCase):
         self.run_gpu_solve(A_sym, x_val)
 
     def test_orth_solve_1d(self):
-        """ Orthogonal solve test case with 1D vector RHS. """
+        """ Orthogonal solve test case with 1D array as second input. """
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_orth = numpy.linalg.svd(A_val)[0]
         x_val = numpy.random.uniform(-0.4, 0.4,
                                      A_orth.shape[1]).astype("float32")
         self.run_gpu_solve(A_orth, x_val)
+
+    def test_uni_rand_solve_1d(self):
+        """ Uniform random solve test case with 1D array as second input. """
+        A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
+        x_val = numpy.random.uniform(-0.4, 0.4,
+                                     A_val.shape[1]).astype("float32")
+        self.run_gpu_solve(A_val, x_val)


### PR DESCRIPTION
## Reason for PR

The current CULA `GpuSolve` op implementation is not entirely consistent in functionality with the `scipy.linalg` based `Solve` op. In particular it:

  1. Only allows two dimensional `b` second inputs (while `Solve` correctly handles either solving for a vector or matrix `b`).
  2. Does not allow specification of any information about the structure of the matrix `A` first input (while `Solve` takes an argument `A_structure` which can be used to specify whether the matrix has some special structure which may be useful for applying a more efficient and/or numerically stable solve implementation).

As the `local_gpu_solve` optimization replaces `Solve` with `GpuSolve` where possible, the first of the above issues can lead to cases where a graph will compile and run successfully when running on a CPU but fail when optimized to run on a GPU when a `Solve` instance with a one-dimensional `b` input is replaced with a `GpuSolve` instance.

The second issue does not cause any direct problems at the moment but it means that the `local_gpu_solve` optimization is lossy - information about any structure in the `A` input is lost on transforming from a `Solve` to `GpuSolve` op, preventing a further optimizer from potentially exploiting this structure to substitute a more specialized GPU based solver op.

## Description of proposed changes

This PR is a first attempt at fixing both these issues. 

I have added a `A_structure` property to the `GpuSolve` op which can be optionally specified in `__init__` (with string checked against same tuple of valid options as in `slingalg.Solve` op). At the moment nothing is done with this but it allows the information to at least be retained. I have also changed the `local_gpu_solve` optimization so that the `A_structure` property value is passed through when transforming from a `Solve` op to a `GpuSolve` instance.

I have also added some logic to allow for one-dimensional `b` second inputs, with a reshaped 2D view created if a 1D input is provided before passing to the CULA based solver implementation and the 2D output reshaped back to 1D before returning if appropriate. I have added some further test cases for 1D second inputs and some test cases to check that exceptions are raised if a one- or three-dimensional first input is passed to `GpuSolve`.

## Questions

  * Currently the boolean `lower` property in `Solve` is not passed through to `GpuSolve` as this seems to be redundant as `A_structure` can only be specifically specified as `upper_triangular` or `lower_triangular` which already encodes this information (assuming `lower` is a flag to specify if lower or upper triangular). Would it be worth also having this property retained by `GpuSolve`?
  * Most of the existing GPU optimizations seem to use aliased ops (e.g. `gpu_solve` as opposed to `GpuSolve`) in the optimization definition. Because of the need to pass the `A_structure` property through when instantiating the op currently `GpuSolve` is used directly. Is this problematic?
  * When implementing the unit test cases I noticed the current tests manually set the `numpy` random seed rather than using `unittest_tools.seed_rng()` as recommended in the [developer guide](http://deeplearning.net/software/theano/extending/unittest.html). Given I was adding further tests using random inputs I implemented these to follow the guidelines and changed the existing tests to be consistent with this. Were these special cases which should have been left with manual seeding?

Cheers