### PR TITLE
GPU Cholesky decomposition op

### DIFF
--- a/theano/sandbox/cuda/cula.py
+++ b/theano/sandbox/cuda/cula.py
@@ -191,8 +191,8 @@ class GpuCholesky(GpuOp):
             cula.culaInitialize()
             cula_initialized = True
 
-        # import util functions here to avoid circular import errors
-        from theano.misc.pycuda_utils import to_gpuarray, to_cudandarray
+        # import util function here to avoid circular import errors
+        from theano.misc.pycuda_utils import to_gpuarray
 
         inputs = [storage_map[v] for v in node.inputs]
         outputs = [storage_map[v] for v in node.outputs]
@@ -257,18 +257,18 @@ class GpuCholesky(GpuOp):
             # function to convert CudaNdArray -> GPUArray, applying this
             # before any transpose operation to ensure A_cpy buffer is still
             # C-contiguous as so can be shared with GPUArray object without
-            # any copy required.
+            # any copy required this meaning triu/tril operations occur in
+            # place on A_cpy buffer.
             if self.lower:
                 # extract only upper triangle in C-ordering i.e. lower triangle
                 # in F-ordering
-                A_copy_tri = linalg.triu(to_gpuarray(A_cpy), overwrite=True)
+                linalg.triu(to_gpuarray(A_cpy), overwrite=True)
             else:
                 # extract only lower triangle in C-ordering i.e. upper triangle
                 # in F-ordering
-                A_copy_tri = linalg.tril(to_gpuarray(A_cpy), overwrite=True)
-            # Convert back to CudaNdArray and assign output as transposed array
-            # to move from F to C ordering.
-            A_chol[0] = to_cudandarray(A_copy_tri).T
+                linalg.tril(to_gpuarray(A_cpy), overwrite=True)
+            # Assign output as transposed array to move from F to C ordering.
+            A_chol[0] = dimshuffle(A_cpy, (1, 0))
 
         thunk.inputs = inputs
         thunk.outputs = outputs

--- a/theano/sandbox/cuda/cula.py
+++ b/theano/sandbox/cuda/cula.py
@@ -4,6 +4,7 @@ import theano
 from theano.sandbox.cuda.type import CudaNdarrayType
 from theano.sandbox.cuda import GpuOp
 from theano.sandbox.cuda.basic_ops import as_cuda_ndarray_variable
+from theano.misc.pycuda_init import pycuda_available
 
 try:
     from theano.sandbox.cuda import cuda_ndarray
@@ -185,6 +186,10 @@ class GpuCholesky(GpuOp):
 
         if not cula_available:
             raise RuntimeError('Cula is not available and '
+                               'GpuCholesky Op can not be constructed.')
+
+        if not pycuda_available:
+            raise RuntimeError('pycuda is not available and '
                                'GpuCholesky Op can not be constructed.')
 
         if not cula_initialized:

--- a/theano/sandbox/cuda/cula.py
+++ b/theano/sandbox/cuda/cula.py
@@ -4,7 +4,6 @@ import theano
 from theano.sandbox.cuda.type import CudaNdarrayType
 from theano.sandbox.cuda import GpuOp
 from theano.sandbox.cuda.basic_ops import as_cuda_ndarray_variable
-from theano.misc.pycuda_utils import to_gpuarray, to_cudandarray
 
 try:
     from theano.sandbox.cuda import cuda_ndarray
@@ -191,6 +190,9 @@ class GpuCholesky(GpuOp):
         if not cula_initialized:
             cula.culaInitialize()
             cula_initialized = True
+
+        # import util functions here to avoid circular import errors
+        from theano.misc.pycuda_utils import to_gpuarray, to_cudandarray
 
         inputs = [storage_map[v] for v in node.inputs]
         outputs = [storage_map[v] for v in node.outputs]

--- a/theano/sandbox/cuda/cula.py
+++ b/theano/sandbox/cuda/cula.py
@@ -4,6 +4,7 @@ import theano
 from theano.sandbox.cuda.type import CudaNdarrayType
 from theano.sandbox.cuda import GpuOp
 from theano.sandbox.cuda.basic_ops import as_cuda_ndarray_variable
+from theano.misc.pycuda_utils import to_gpuarray, to_cudandarray
 
 try:
     from theano.sandbox.cuda import cuda_ndarray
@@ -14,9 +15,11 @@ except ImportError:
 cula_available = False
 
 try:
-    from scikits.cuda import cula
+    from skcuda import cula
+    from skcuda import linalg
     cula_available = True
-except (ImportError, OSError, RuntimeError, pkg_resources.DistributionNotFound):
+except (ImportError, OSError, RuntimeError,
+        pkg_resources.DistributionNotFound):
     pass
 
 cula_initialized = False
@@ -161,7 +164,7 @@ class GpuCholesky(GpuOp):
     __props__ = ('lower',)
 
     def __init__(self, lower=True):
-        self.lower = True
+        self.lower = lower
         super(GpuCholesky, self).__init__()
 
     def output_type(self, inp):
@@ -193,42 +196,77 @@ class GpuCholesky(GpuOp):
         outputs = [storage_map[v] for v in node.outputs]
 
         def thunk():
-            # size of the matrices to invert
-            z = outputs[0]
 
-            # Matrix
+            # Matrix to decompose is first (and only) input
             A = inputs[0][0]
 
-            # This copy forces allocation of a new C-contiguous buffer
-            # and returns it.
+            # Cholesky decomposition of matrix is first (and only) output
+            A_chol = outputs[0]
+
+            # CULA Cholesky function is destructive as it assigns calculated
+            # decomposition to lower / upper triangle of input array therefore
+            # force copy of array with allocation of a new C-contiguous buffer.
+            # CULA operation assumes Fortran ordering however input matrix must
+            # be symmetric therefore no need to alter order.
             A_cpy = A.copy()
 
             def cula_gpu_cholesky(A_, lower=True):
 
                 A_shape = A_.shape
 
-                assert(len(A_shape) == 2)
+                # Decomposition only valid for matrix inputs.
+                if len(A_shape) != 2:
+                    raise ValueError('A must be two-dimensional.')
 
                 m, n = A_shape
 
+                # Decomposition only exists for square matrix inputs.
                 if m != n:
                     raise ValueError('A must be square.')
 
-                # construct pointer arrays needed for culaDeviceSpotrf
-                # Cula requires a pointer for A.
+                # Get pointer to A array data needed for culaDeviceSpotrf.
                 A_ptr = A_.gpudata
 
+                # culaDeviceSpotrf takes upper-lower argument as string.
                 uplo = 'L' if lower else 'U'
+
+                # Leading dimension of input array A.
                 lda = max(1, n)
 
+                # CULA may raise exception if input matrix found not to be
+                # positive-definite therefore make sure buffers freed even
+                # in error cases.
                 try:
                     cula.culaDeviceSpotrf(uplo, n, A_ptr, lda)
                 finally:
                     cula.culaFreeBuffers()
 
+            # Decomposition assigned in-place to A_cpy
             cula_gpu_cholesky(A_cpy, self.lower)
 
-            z[0] = A_cpy
+            # CULA assumes Fortran ordering and assigns the calculated
+            # decomposition to the relevant triangle of A_cpy (i.e. lower
+            # triangle if lower=True and upper otherwise) in Fortran ordering.
+            # The remaining elements in A_cpy are left as the original values
+            # in A i.e. A_cpy is not enforced to be lower / upper triangular.
+            # Therefore use skcuda.linalg triu/tril functions to extract
+            # relevant triangle elements only, others set to zero. These
+            # require a pycuda GPUArray type as input therefore use util
+            # function to convert CudaNdArray -> GPUArray, applying this
+            # before any transpose operation to ensure A_cpy buffer is still
+            # C-contiguous as so can be shared with GPUArray object without
+            # any copy required.
+            if self.lower:
+                # extract only upper triangle in C-ordering i.e. lower triangle
+                # in F-ordering
+                A_copy_tri = linalg.triu(to_gpuarray(A_cpy), overwrite=True)
+            else:
+                # extract only lower triangle in C-ordering i.e. upper triangle
+                # in F-ordering
+                A_copy_tri = linalg.tril(to_gpuarray(A_cpy), overwrite=True)
+            # Convert back to CudaNdArray and assign output as transposed array
+            # to move from F to C ordering.
+            A_chol[0] = to_cudandarray(A_copy_tri).T
 
         thunk.inputs = inputs
         thunk.outputs = outputs

--- a/theano/sandbox/cuda/opt.py
+++ b/theano/sandbox/cuda/opt.py
@@ -727,7 +727,7 @@ def local_gpu_cholesky(node):
             lower = host_input.owner.op.lower
             return [gpu_cholesky(as_cuda_ndarray_variable(A), lower)]
 
-    if isinstance(node.op, slinalg.Solve):
+    if isinstance(node.op, slinalg.Cholesky):
         if any([i.owner and isinstance(i.owner.op, HostFromGpu)
                 for i in node.inputs]):
             A = node.inputs[0]

--- a/theano/sandbox/cuda/tests/test_cula.py
+++ b/theano/sandbox/cuda/tests/test_cula.py
@@ -92,7 +92,7 @@ class TestGpuCholesky(unittest.TestCase):
         """ Invalid Cholesky input test with non-square matrix as input. """
         def invalid_input_func():
             A_val = numpy.random.normal(size=(3, 2)).astype("float32")
-            fn = self.get_gpu_cholesk_func(True)
+            fn = self.get_gpu_cholesky_func(True)
             fn(A_val)
         self.assertRaises(ValueError, invalid_input_func)
 
@@ -101,7 +101,7 @@ class TestGpuCholesky(unittest.TestCase):
         def invalid_input_func():
             M_val = numpy.random.normal(size=(3, 3)).astype("float32")
             A_val = -M_val.dot(M_val.T)
-            fn = self.get_gpu_cholesk_func(True)
+            fn = self.get_gpu_cholesky_func(True)
             fn(A_val)
         self.assertRaises(cula.cula.culaError, invalid_input_func)
 
@@ -122,7 +122,7 @@ class TestGpuCholesky(unittest.TestCase):
     def test_diag_chol(self):
         """ Diagonal matrix input with positive entries Cholesky test. """
         A_val = numpy.diag(numpy.random.uniform(size=5).astype("float32") + 1.)
-        self.run_gpu_cholesky(A_val)
+        self.run_gpu_cholesky(A_val, lower=True)
 
     def test_dense_chol_lower(self):
         """ Dense matrix input lower-triangular Cholesky test. """

--- a/theano/sandbox/cuda/tests/test_cula.py
+++ b/theano/sandbox/cuda/tests/test_cula.py
@@ -67,3 +67,66 @@ class TestCula(unittest.TestCase):
         x_val = numpy.random.uniform(-0.4, 0.4,
                                      (A_val.shape[1], 4)).astype("float32")
         self.run_gpu_solve(A_val, x_val)
+
+
+class TestGpuCholesky(unittest.TestCase):
+
+    def setUp(self):
+        utt.seed_rng()
+
+    def run_gpu_cholesky(self, A_val, lower):
+        chol_A_val = numpy.linalg.cholesky(A_val)
+        if not lower:
+            chol_A_val = chol_A_val.T
+        A = theano.tensor.matrix("A", dtype="float32")
+        chol_A = cula.gpu_cholesky(A, lower)
+        fn = theano.function([A], chol_A)
+        res = fn(A_val)
+        chol_A_res = numpy.tril(res) if lower else numpy.triu(res)
+        utt.assert_allclose(chol_A_res, chol_A_val)
+
+    def test_invalid_input_fail_non_square(self):
+        """ Invalid Cholesky input test with non-square matrix as input. """
+        def invalid_input_func():
+            A_val = numpy.random.normal(size=(3, 2)).astype("float32")
+            self.run_gpu_cholesky(A_val, True)
+        self.assertRaises(ValueError, invalid_input_func)
+
+    def test_invalid_input_fail_non_positive_definite(self):
+        """ Invalid Cholesky input test with non positive-definite input. """
+        def invalid_input_func():
+            M_val = numpy.random.normal(size=(3, 3)).astype("float32")
+            A_val = -M_val.dot(M_val.T)
+            self.run_gpu_cholesky(A_val, True)
+        self.assertRaises(cula.culaError, invalid_input_func)
+
+    def test_invalid_input_fail_vector(self):
+        """ Invalid Cholesky input test with vector as input. """
+        def invalid_input_func():
+            A = theano.tensor.vector("A", dtype="float32")
+            cula.gpu_cholesky(A, True)
+        self.assertRaises(ValueError, invalid_input_func)
+
+    def test_invalid_input_fail_tensor3(self):
+        """ Invalid Cholesky input test with vector as input. """
+        def invalid_input_func():
+            A = theano.tensor.tensor3("A", dtype="float32")
+            cula.gpu_cholesky(A, True)
+        self.assertRaises(ValueError, invalid_input_func)
+
+    def test_diag_chol(self):
+        """ Diagonal matrix input with positive entries Cholesky test. """
+        A_val = numpy.diag(numpy.random.uniform(size=5).astype("float32") + 1.)
+        self.run_gpu_cholesky(A_val)
+
+    def test_dense_chol_lower(self):
+        """ Dense matrix input lower-triangular Cholesky test. """
+        M_val = numpy.random.normal(size=(3, 3)).astype("float32")
+        A_val = M_val.dot(M_val.T)
+        self.run_gpu_cholesky(A_val, lower=True)
+
+    def test_dense_chol_upper(self):
+        """ Dense matrix input lower-triangular Cholesky test. """
+        M_val = numpy.random.normal(size=(3, 3)).astype("float32")
+        A_val = M_val.dot(M_val.T)
+        self.run_gpu_cholesky(A_val, lower=False)

--- a/theano/sandbox/cuda/tests/test_opt.py
+++ b/theano/sandbox/cuda/tests/test_opt.py
@@ -24,6 +24,7 @@ if not cuda.cuda_available:
     raise SkipTest('Optional package cuda disabled')
 
 import theano.sandbox.cuda.cula as cula
+from theano.misc.pycuda_init import pycuda_available
 
 from theano.sandbox.cuda import basic_ops
 from theano.sandbox.cuda.type import CudaNdarrayType
@@ -790,15 +791,16 @@ def test_local_gpu_cholesky():
 
     if not cula.cula_available:
         raise SkipTest('Optional dependency CULA not available')
+    if not pycuda_available:
+        raise SkipTest('Optional dependency pycuda not available')
 
     numpy.random.seed(1)
 
-    def cmp(A_dim):
+    def cmp(A_dim, lower):
         M = numpy.random.normal(size=(A_dim, A_dim)).astype('float32')
         A_val = M.dot(M.T)
         A = cuda.shared_constructor(A_val, 'A')
 
-        lower = True
         cholesky_op = tensor.slinalg.Cholesky(lower=lower)
         f = pfunc([], cholesky_op(A), mode=mode_with_gpu)
 
@@ -810,14 +812,14 @@ def test_local_gpu_cholesky():
         assert cuda.opt.local_gpu_cholesky.transform(
             tensor.slinalg.cholesky(A).owner)
 
-        A_chol_res = f()
+        chol_A_res = f()
         # numpy cholesky always returns lower-triangular matrix
-        A_chol_np = numpy.linalg.cholesky(A_val)
+        chol_A_val = numpy.linalg.cholesky(A_val)
 
-        assert numpy.allclose(A_chol_np, A_chol_res)
+        utt.assert_allclose(chol_A_res, chol_A_val)
 
-    cmp(3)
-    cmp(6)
+    cmp(3, True)
+    cmp(6, False)
 
 
 def test_local_gpu_dot_to_dot22dot():

--- a/theano/sandbox/cuda/tests/test_opt.py
+++ b/theano/sandbox/cuda/tests/test_opt.py
@@ -815,6 +815,7 @@ def test_local_gpu_cholesky():
         chol_A_res = f()
         # numpy cholesky always returns lower-triangular matrix
         chol_A_val = numpy.linalg.cholesky(A_val)
+        chol_A_val = chol_A_val if lower else chol_A_val.T
 
         utt.assert_allclose(chol_A_res, chol_A_val)
 


### PR DESCRIPTION
## Reason for PR

There is currently no GPU Cholesky decomposition op to correspond to the `scipy.linalg` based `slingalg.Cholesky` op, and no existing PR implementing one as far as I can see (though an implementation of one might be useful for #2059). 

Cholesky decompositions are among other things useful in allowing more numerically stable and efficient solving of positive definite matrix systems (particularly if solving multiple systems sequentially as it allows an initial expensive decomposition to be reused without the normal numerical issues involved in precomputing a direct matrix inverse) and for use in generating samples from a multivariate Gaussian with a specified covariance matrix. Both of these uses crop up quite a lot in machine learning and statistics problems, and the O(D<sup>3</sup>) cost of computing the Cholesky decomposition means that such operations can often be a dominant cost in an algorithm so having a GPU accelerated operation can potentially give big gains.

## Description of proposed changes

This PR adds a CULA based GPU Cholesky decomposition op `GpuCholesky` which complements the exisiting CULA based `GpuSolve` op. 

For consistency with the existing `slinalg.Cholesky` op this returns a matrix in which only the entries below or above the diagonal (depending on value of `lower` parameter) are non-zero. This involves some further calls to `pycuda` based functions in `skcuda.linalg` for setting the above / below diagonal elements to zero as the CULA Cholesky decomposition function `culaDeviceSpotrf` acts destructively on the matrix it is decomposing and assigns the decomposition to the lower or upper triangular elements while leaving the existing values in the other elements in place (this is also the case for other LAPACK `*potrf` based Cholesky implementations e.g. `scipy.linalg.cho_factor`).

As well as the `GpuCholesky` op a corresponding `local_gpu_cholesky` optimization has been added which replaces `slinalg.Cholesky` op instances with `GpuCholesky` were possible. Unit tests for both the new op and optimization have also been added.

## Questions

  * The op currently creates a copy of the input matrix before performing the decomposition due to the destructive behaviour of the CULA `spotrf` function described above. In some cases maybe the original matrix does not need to be retained so an inplace / destructive operation would be permissible.   Would it be worth implementing this? Currently the corresponding `slinalg.Cholesky` op has a flag for this but it seems to not be implemented. If it was worthwhile adding this, are there any other requirements than defining a `destroy_map` attribute for the op as described [here](http://deeplearning.net/software/theano/extending/inplace.html) to make this work correctly (as well as obviously implementing the logic to do the operation in place)?