### PR TITLE
GPU triangular solve op

### DIFF
--- a/theano/sandbox/cuda/cublas.py
+++ b/theano/sandbox/cuda/cublas.py
@@ -155,12 +155,14 @@ class GpuTriangularSolve(GpuOp):
                 A_ptr = A_.gpudata
                 b_ptr = b_.gpudata
 
-                alpha = 1.0  # unit scalar used for multiplicatio
-                side = 'l'  # indicates matrix A is on right of B
-                uplo = 'l' if lower else 'u'  # set whether upper or lower
-                                              # part of matrix A stored
-                diag = 'n'  # indicates elements on diagonal of matrix A may
-                            # not be unity
+                # unit scalar used for multiplication
+                alpha = 1.0
+                # indicates matrix A is on left of B
+                side = 'l'
+                # set whether upper or lower part of matrix A stored
+                uplo = 'l' if lower else 'u'
+                # indicates elements on diagonal of matrix A may not be unity
+                diag = 'n'
 
                 cublas.cublasStrsm(cublas_handle, side, uplo, trans, diag,
                                    n, m, alpha, A_ptr, lda, b_ptr, ldb)

--- a/theano/sandbox/cuda/cublas.py
+++ b/theano/sandbox/cuda/cublas.py
@@ -1,0 +1,191 @@
+import pkg_resources
+import atexit
+
+import theano
+from theano.sandbox.cuda.type import CudaNdarrayType
+from theano.sandbox.cuda import GpuOp
+from theano.sandbox.cuda.basic_ops import as_cuda_ndarray_variable
+
+try:
+    from theano.sandbox.cuda import cuda_ndarray
+    dimshuffle = cuda_ndarray.cuda_ndarray.dimshuffle
+except ImportError:
+    pass
+
+cublas_available = False
+cublas_initialized = False
+cublas_handle = None
+
+try:
+    from skcuda import cublas
+    cublas_available = True
+except (ImportError, OSError, RuntimeError,
+        pkg_resources.DistributionNotFound):
+    pass
+
+
+def initialize_cublas():
+    """ Initializes CUBLAS handle and ensures resource release on exit. """
+    global cublas_initialized
+    global cublas_handle
+    cublas_handle = cublas.cublasCreate()
+    cublas_initialized = True
+    atexit.register(release_cublas_resources)
+
+
+def release_cublas_resources():
+    global cublas_initialized
+    if cublas_initialized:
+        cublas.cublasDestroy(cublas_handle)
+        cublas_initialized = False
+
+
+class GpuTriangularSolve(GpuOp):
+    """
+    CUBLAS GPU triangular linear system solver OP.
+    Parameters
+    ----------
+    trans
+        Whether to take the transpose of the input matrix or not.
+    lower
+        Whether system is lower-triangular (True) or upper-triangular (False).
+    """
+
+    __props__ = ('trans', 'lower',)
+
+    def __init__(self, trans='N', lower=True):
+        self.trans = trans
+        self.lower = lower
+        super(GpuTriangularSolve, self).__init__()
+
+    def output_type(self, inp):
+        return CudaNdarrayType(broadcastable=[False] * inp.type.ndim)
+
+    def make_node(self, inp1, inp2):
+        inp1 = as_cuda_ndarray_variable(inp1)
+        inp2 = as_cuda_ndarray_variable(inp2)
+
+        assert inp1.ndim == 2
+        assert inp2.ndim in [1, 2]
+        return theano.Apply(self, [inp1, inp2], [self.output_type(inp1)()])
+
+    def make_thunk(self,
+                   node,
+                   storage_map, _,
+                   no_recycling=[]):
+
+        # Initialize CULA the first time it is needed
+
+        if not cublas_available:
+            raise RuntimeError('Cublas is not available and '
+                               'GpuTriangularSolve Op can not be constructed.')
+
+        global cublas_initialized
+
+        if not cublas_initialized:
+            initialize_cublas()
+
+        inputs = [storage_map[v] for v in node.inputs]
+        outputs = [storage_map[v] for v in node.outputs]
+
+        def thunk():
+
+            # Solution vector(s) of system to return as output.
+            x = outputs[0]
+
+            # Matrix
+            A = inputs[0][0]
+
+            # Vector(s) to solve system for.
+            b = inputs[1][0]
+
+            # A is not explicitly converted between C and F order, instead we
+            # switch the "transpose" and "lower" flags
+            if self.trans in ('T', 'C'):
+                trans = 'N'
+            else:
+                trans = 'T'
+            lower = not self.lower
+
+            # If b is one-dimensional reshape to two-dimensional array with
+            # singleton second dimension
+            if b.ndim == 1:
+                b_2d = b.reshape((b.shape[0], 1))
+            else:
+                b_2d = b
+
+            # Convert b to F-order from c-order.
+            b_cpy = dimshuffle(b_2d, (1, 0)).reshape((b_2d.shape[0],
+                                                      b_2d.shape[1]))
+
+            # This copy forces allocation of a new C-contiguous buffer
+            # and returns it.
+            A_cpy = A.copy()
+            b_cpy = b_cpy.copy()
+
+            def cublas_gpu_triangular_solve(A_, b_, trans='T', lower=False):
+
+                A_shape = A_.shape
+                b_shape = b_.shape
+
+                assert(len(A_shape) == 2)
+                assert(len(b_shape) == 2)
+
+                if trans in ['T', 'C']:
+                    l, n = A_shape
+                    k, m = b_shape
+                    if n != k:
+                        raise ValueError('A and b must be aligned.')
+                elif trans in ['N']:
+                    n, l = A_shape
+                    k, m = b_shape
+                    if l != m:
+                        raise ValueError('A and b must be aligned.')
+                else:
+                    raise ValueError('Invalid value for trans')
+
+                if l != n:
+                    raise ValueError('A must be square.')
+
+                lda = max(1, n)
+                ldb = max(1, n)
+
+                # construct pointer arrays needed for culaDeviceSgels
+                # Cula requires you to pass a pointer for A and b.
+                A_ptr = A_.gpudata
+                b_ptr = b_.gpudata
+
+                alpha = 1.0  # unit scalar used for multiplicatio
+                side = 'l'  # indicates matrix A is on right of B
+                uplo = 'l' if lower else 'u'  # set whether upper or lower
+                                              # part of matrix A stored
+                diag = 'n'  # indicates elements on diagonal of matrix A may
+                            # not be unity
+
+                cublas.cublasStrsm(cublas_handle, side, uplo, trans, diag,
+                                   n, m, alpha, A_ptr, lda, b_ptr, ldb)
+
+                return A_, b_
+
+            A_pycuda, b_pycuda = cublas_gpu_triangular_solve(
+                A_cpy, b_cpy, trans, lower)
+
+            # Convert b to F-order from c-order:
+            b_cpy = b_cpy.reshape(b_2d.shape[::-1])
+            b_cpy = dimshuffle(b_cpy, (1, 0))
+
+            # If b was originally a one-dimensional array reshape back
+            if b.ndim == 1:
+                b_cpy = b_cpy.reshape(b.shape[0])
+
+            # Assign result to output
+            x[0] = b_cpy
+
+        thunk.inputs = inputs
+        thunk.outputs = outputs
+        thunk.lazy = False
+
+        return thunk
+
+gpu_lower_triangular_solve = GpuTriangularSolve(trans='N', lower=True)
+gpu_upper_triangular_solve = GpuTriangularSolve(trans='N', lower=False)

--- a/theano/sandbox/cuda/cula.py
+++ b/theano/sandbox/cuda/cula.py
@@ -1,6 +1,7 @@
 import pkg_resources
 
 import theano
+from theano.tensor.slinalg import MATRIX_STRUCTURES
 from theano.sandbox.cuda.type import CudaNdarrayType
 from theano.sandbox.cuda import GpuOp
 from theano.sandbox.cuda.basic_ops import as_cuda_ndarray_variable
@@ -30,13 +31,18 @@ class GpuSolve(GpuOp):
     ----------
     trans
         Whether to take the transpose of the input matrix or not.
+    A_structure
+        Any special structure to matrix system being solved
 
     """
 
-    __props__ = ('trans',)
+    __props__ = ('trans', 'A_structure')
 
-    def __init__(self, trans='N'):
+    def __init__(self, trans='N', A_structure='general'):
+        if A_structure not in MATRIX_STRUCTURES:
+            raise ValueError('Invalid matrix structure argument', A_structure)
         self.trans = trans
+        self.A_structure = A_structure
         super(GpuSolve, self).__init__()
 
     def output_type(self, inp):
@@ -47,7 +53,7 @@ class GpuSolve(GpuOp):
         inp2 = as_cuda_ndarray_variable(inp2)
 
         assert inp1.ndim == 2
-        assert inp2.ndim == 2
+        assert inp2.ndim in [1, 2]
         return theano.Apply(self, [inp1, inp2], [self.output_type(inp1)()])
 
     def make_thunk(self,
@@ -86,8 +92,16 @@ class GpuSolve(GpuOp):
             else:
                 trans = 'T'
 
+            # If b is one-dimensional reshape to two-dimensional array with
+            # singleton second dimension
+            if b.ndim == 1:
+                b_2d = b.reshape((-1, 1))
+            else:
+                b_2d = b
+
             # Convert b to F-order from c-order.
-            b_cpy = dimshuffle(b, (1, 0)).reshape((b.shape[0], b.shape[1]))
+            b_cpy = dimshuffle(b_2d, (1, 0)).reshape((b_2d.shape[0],
+                                                      b_2d.shape[1]))
 
             # This copy forces allocation of a new C-contiguous buffer
             # and returns it.
@@ -128,9 +142,15 @@ class GpuSolve(GpuOp):
 
             A_pycuda, b_pycuda = cula_gpu_solve(A_cpy, b_cpy, trans)
 
-            # Convert b to F-order from c-order and assign it to output:
-            b_cpy = b_cpy.reshape(b.shape[::-1])
+            # Convert b to F-order from c-order:
+            b_cpy = b_cpy.reshape(b_2d.shape[::-1])
             b_cpy = dimshuffle(b_cpy, (1, 0))
+
+            # If b was originally a one-dimensional array reshape back
+            if b.ndim == 1:
+                b_cpy = b_cpy.reshape(b.shape[0])
+
+            # Assign result to output
             z[0] = b_cpy
 
         thunk.inputs = inputs

--- a/theano/sandbox/cuda/cula.py
+++ b/theano/sandbox/cuda/cula.py
@@ -95,7 +95,7 @@ class GpuSolve(GpuOp):
             # If b is one-dimensional reshape to two-dimensional array with
             # singleton second dimension
             if b.ndim == 1:
-                b_2d = b.reshape((-1, 1))
+                b_2d = b.reshape((b.shape[0], 1))
             else:
                 b_2d = b
 

--- a/theano/sandbox/cuda/opt.py
+++ b/theano/sandbox/cuda/opt.py
@@ -37,7 +37,7 @@ from theano.sandbox.cuda.blas import (
     GpuCorr3dMM, GpuCorr3dMM_gradInputs, GpuCorr3dMM_gradWeights)
 
 from theano.sandbox.cuda.blas import gpu_gemv_inplace
-from theano.sandbox.cuda.cula import gpu_solve
+from theano.sandbox.cuda.cula import GpuSolve
 
 from theano.sandbox.cuda.blas import gpu_gemv_no_inplace
 from theano.sandbox.cuda.blas import gpu_ger_inplace
@@ -696,6 +696,8 @@ def local_gpu_solve(node):
             isinstance(host_input.owner.op,
                        slinalg.Solve)):
             x, y = host_input.owner.inputs
+            A_structure = host_input.owner.op.A_structure
+            gpu_solve = GpuSolve(A_structure=A_structure)
             return [gpu_solve(as_cuda_ndarray_variable(x),
                               as_cuda_ndarray_variable(y))]
 
@@ -703,6 +705,8 @@ def local_gpu_solve(node):
         if any([i.owner and isinstance(i.owner.op, HostFromGpu)
                 for i in node.inputs]):
             x, y = node.inputs
+            A_structure = node.op.A_structure
+            gpu_solve = GpuSolve(A_structure=A_structure)
             return [host_from_gpu(
                     gpu_solve(as_cuda_ndarray_variable(x),
                               as_cuda_ndarray_variable(y)))]

--- a/theano/sandbox/cuda/tests/test_cublas.py
+++ b/theano/sandbox/cuda/tests/test_cublas.py
@@ -1,0 +1,103 @@
+import unittest
+import numpy
+
+import theano
+from theano.tests import unittest_tools as utt
+
+# Skip tests if cuda_ndarray is not available.
+from nose.plugins.skip import SkipTest
+import theano.sandbox.cuda as cuda_ndarray
+from theano.misc.pycuda_init import pycuda_available
+from theano.sandbox.cuda.cublas import cublas_available
+from theano.sandbox.cuda import cublas
+
+if not cuda_ndarray.cuda_available:
+    raise SkipTest('Optional package cuda not available')
+if not pycuda_available:
+    raise SkipTest('Optional package pycuda not available')
+if not cublas_available:
+    raise SkipTest('Optional package skcuda.cublas not available')
+
+if theano.config.mode == 'FAST_COMPILE':
+    mode_with_gpu = theano.compile.mode.get_mode('FAST_RUN').including('gpu')
+else:
+    mode_with_gpu = theano.compile.mode.get_default_mode().including('gpu')
+
+
+class TestGpuTriangularSolve(unittest.TestCase):
+
+    def setUp(self):
+        utt.seed_rng()
+
+    def check_gpu_triangular_solve(self, A_val, x_val, lower):
+        b_val = numpy.dot(A_val, x_val)
+        A = theano.tensor.matrix("A", dtype="float32")
+        if x_val.ndim == 1:
+            b = theano.tensor.vector("b", dtype="float32")
+        else:
+            b = theano.tensor.matrix("b", dtype="float32")
+        if lower:
+            x = cublas.gpu_lower_triangular_solve(A, b)
+        else:
+            x = cublas.gpu_upper_triangular_solve(A, b)
+        fn = theano.function([A, b], x)
+        x_res = numpy.array(fn(A_val, b_val))
+        utt.assert_allclose(x_res, x_val)
+
+    def test_invalid_input_fail_1d(self):
+        """ Invalid input test case with 1D vector as first input. """
+        def invalid_input_func():
+            A = theano.tensor.tensor3("A", dtype="float32")
+            b = theano.tensor.matrix("b", dtype="float32")
+            cublas.gpu_lower_triangular_solve(A, b)
+            cublas.gpu_upper_triangular_solve(A, b)
+        self.assertRaises(AssertionError, invalid_input_func)
+
+    def test_invalid_input_fail_3d(self):
+        """ Invalid input test case with 3D tensor as first input. """
+        def invalid_input_func():
+            A = theano.tensor.vector("A", dtype="float32")
+            b = theano.tensor.matrix("b", dtype="float32")
+            cublas.gpu_lower_triangular_solve(A, b)
+            cublas.gpu_upper_triangular_solve(A, b)
+        self.assertRaises(AssertionError, invalid_input_func)
+
+    def test_diag_solve_2d(self):
+        """ Diagonal solve test case with 2D array as second input. """
+        A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
+                              dtype="float32")
+        x_val = numpy.random.uniform(-0.4, 0.4, (A_val.shape[1],
+                                     1)).astype("float32")
+        self.check_gpu_triangular_solve(A_val, x_val, True)
+        self.check_gpu_triangular_solve(A_val, x_val, False)
+
+    def test_tri_solve_2d(self):
+        """ Triangular solve test cases with 2D array as second input. """
+        A_val = (numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32") +
+                 numpy.eye(5, dtype="float32"))
+        L_val = numpy.tril(A_val)
+        U_val = numpy.triu(A_val)
+        x_val = numpy.random.uniform(-0.4, 0.4, (A_val.shape[1],
+                                     1)).astype("float32")
+        self.check_gpu_triangular_solve(L_val, x_val, True)
+        self.check_gpu_triangular_solve(U_val, x_val, False)
+
+    def test_diag_solve_1d(self):
+        """ Diagonal solve test case with 1D array as second input. """
+        A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
+                              dtype="float32")
+        x_val = numpy.random.uniform(-0.4, 0.4,
+                                     A_val.shape[1]).astype("float32")
+        self.check_gpu_triangular_solve(A_val, x_val, True)
+        self.check_gpu_triangular_solve(A_val, x_val, False)
+
+    def test_tri_solve_1d(self):
+        """ Triangular solve test cases with 1D array as second input. """
+        A_val = (numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32") +
+                 numpy.eye(5, dtype="float32"))
+        L_val = numpy.tril(A_val)
+        U_val = numpy.triu(A_val)
+        x_val = numpy.random.uniform(-0.4, 0.4,
+                                     A_val.shape[1]).astype("float32")
+        self.check_gpu_triangular_solve(L_val, x_val, True)
+        self.check_gpu_triangular_solve(U_val, x_val, False)

--- a/theano/sandbox/cuda/tests/test_cula.py
+++ b/theano/sandbox/cuda/tests/test_cula.py
@@ -32,13 +32,22 @@ class TestCula(unittest.TestCase):
     def run_gpu_solve(self, A_val, x_val):
         b_val = numpy.dot(A_val, x_val)
         A = theano.tensor.matrix("A", dtype="float32")
-        b = theano.tensor.matrix("b", dtype="float32")
-
+        if x_val.ndim == 1:
+            b = theano.tensor.vector("b", dtype="float32")
+        else:
+            b = theano.tensor.matrix("b", dtype="float32")
         solver = cula.gpu_solve(A, b)
         fn = theano.function([A, b], [solver])
         res = fn(A_val, b_val)
         x_res = numpy.array(res[0])
         utt.assert_allclose(x_res, x_val)
+
+    def test_invalid_input_fail_3D(self):
+        def invalid_input_func():
+            A = theano.tensor.tensor3("A", dtype="float32")
+            b = theano.tensor.matrix("b", dtype="float32")
+            solve = cula.gpu_solve(A, b)
+        self.assertRaises(AssertionError, invalid_input_func)
 
     def test_diag_solve(self):
         """ Diagonal solve test case with 1D vector as 2D matrix RHS. """

--- a/theano/sandbox/cuda/tests/test_cula.py
+++ b/theano/sandbox/cuda/tests/test_cula.py
@@ -26,6 +26,9 @@ else:
 
 
 class TestCula(unittest.TestCase):
+    def setUp(self):
+        utt.seed_rng()
+
     def run_gpu_solve(self, A_val, x_val):
         b_val = numpy.dot(A_val, x_val)
         A = theano.tensor.matrix("A", dtype="float32")
@@ -39,7 +42,6 @@ class TestCula(unittest.TestCase):
 
     def test_diag_solve(self):
         """ Diagonal solve test case with 1D vector as 2D matrix RHS. """
-        numpy.random.seed(1)
         A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
                               dtype="float32")
         x_val = numpy.random.uniform(-0.4, 0.4, (A_val.shape[1],
@@ -48,7 +50,6 @@ class TestCula(unittest.TestCase):
 
     def test_sym_solve(self):
         """ Symmetric solve test case with 1D vector as 2D matrix RHS. """
-        numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_sym = (A_val + A_val.T) / 2.0
         x_val = numpy.random.uniform(-0.4, 0.4, (A_val.shape[1],
@@ -57,7 +58,6 @@ class TestCula(unittest.TestCase):
 
     def test_orth_solve(self):
         """ Orthogonal solve test case with 1D vector as 2D matrix RHS. """
-        numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_orth = numpy.linalg.svd(A_val)[0]
         x_val = numpy.random.uniform(-0.4, 0.4, (A_orth.shape[1],
@@ -66,7 +66,6 @@ class TestCula(unittest.TestCase):
 
     def test_uni_rand_solve(self):
         """ Uniform random solve test case with 2D matrix RHS. """
-        numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         x_val = numpy.random.uniform(-0.4, 0.4,
                                      (A_val.shape[1], 4)).astype("float32")
@@ -74,7 +73,6 @@ class TestCula(unittest.TestCase):
 
     def test_diag_solve_1d(self):
         """ Diagonal solve test case with 1D vector RHS. """
-        numpy.random.seed(1)
         A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
                               dtype="float32")
         x_val = numpy.random.uniform(-0.4, 0.4,
@@ -83,7 +81,6 @@ class TestCula(unittest.TestCase):
 
     def test_sym_solve_1d(self):
         """ Symmetric solve test case with 1D vector RHS. """
-        numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_sym = (A_val + A_val.T) / 2.0
         x_val = numpy.random.uniform(-0.4, 0.4,
@@ -92,7 +89,6 @@ class TestCula(unittest.TestCase):
 
     def test_orth_solve_1d(self):
         """ Orthogonal solve test case with 1D vector RHS. """
-        numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_orth = numpy.linalg.svd(A_val)[0]
         x_val = numpy.random.uniform(-0.4, 0.4,

--- a/theano/sandbox/cuda/tests/test_cula.py
+++ b/theano/sandbox/cuda/tests/test_cula.py
@@ -38,6 +38,7 @@ class TestCula(unittest.TestCase):
         utt.assert_allclose(x_res, x_val)
 
     def test_diag_solve(self):
+        """ Diagonal solve test case with 1D vector as 2D matrix RHS. """
         numpy.random.seed(1)
         A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
                               dtype="float32")
@@ -46,6 +47,7 @@ class TestCula(unittest.TestCase):
         self.run_gpu_solve(A_val, x_val)
 
     def test_sym_solve(self):
+        """ Symmetric solve test case with 1D vector as 2D matrix RHS. """
         numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_sym = (A_val + A_val.T) / 2.0
@@ -54,6 +56,7 @@ class TestCula(unittest.TestCase):
         self.run_gpu_solve(A_sym, x_val)
 
     def test_orth_solve(self):
+        """ Orthogonal solve test case with 1D vector as 2D matrix RHS. """
         numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_orth = numpy.linalg.svd(A_val)[0]
@@ -62,8 +65,36 @@ class TestCula(unittest.TestCase):
         self.run_gpu_solve(A_orth, x_val)
 
     def test_uni_rand_solve(self):
+        """ Uniform random solve test case with 2D matrix RHS. """
         numpy.random.seed(1)
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         x_val = numpy.random.uniform(-0.4, 0.4,
                                      (A_val.shape[1], 4)).astype("float32")
         self.run_gpu_solve(A_val, x_val)
+
+    def test_diag_solve_1d(self):
+        """ Diagonal solve test case with 1D vector RHS. """
+        numpy.random.seed(1)
+        A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
+                              dtype="float32")
+        x_val = numpy.random.uniform(-0.4, 0.4,
+                                     A_val.shape[1]).astype("float32")
+        self.run_gpu_solve(A_val, x_val)
+
+    def test_sym_solve_1d(self):
+        """ Symmetric solve test case with 1D vector RHS. """
+        numpy.random.seed(1)
+        A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
+        A_sym = (A_val + A_val.T) / 2.0
+        x_val = numpy.random.uniform(-0.4, 0.4,
+                                     A_val.shape[1]).astype("float32")
+        self.run_gpu_solve(A_sym, x_val)
+
+    def test_orth_solve_1d(self):
+        """ Orthogonal solve test case with 1D vector RHS. """
+        numpy.random.seed(1)
+        A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
+        A_orth = numpy.linalg.svd(A_val)[0]
+        x_val = numpy.random.uniform(-0.4, 0.4,
+                                     A_orth.shape[1]).astype("float32")
+        self.run_gpu_solve(A_orth, x_val)

--- a/theano/sandbox/cuda/tests/test_cula.py
+++ b/theano/sandbox/cuda/tests/test_cula.py
@@ -42,46 +42,55 @@ class TestCula(unittest.TestCase):
         x_res = numpy.array(res[0])
         utt.assert_allclose(x_res, x_val)
 
-    def test_invalid_input_fail_3D(self):
+    def test_invalid_input_fail_1d(self):
+        """ Invalid solve input test case with 1D vector as first input. """
         def invalid_input_func():
             A = theano.tensor.tensor3("A", dtype="float32")
             b = theano.tensor.matrix("b", dtype="float32")
             solve = cula.gpu_solve(A, b)
         self.assertRaises(AssertionError, invalid_input_func)
 
-    def test_diag_solve(self):
-        """ Diagonal solve test case with 1D vector as 2D matrix RHS. """
+    def test_invalid_input_fail_3d(self):
+        """ Invalid solve input test case with 3D tensor as first input. """
+        def invalid_input_func():
+            A = theano.tensor.vector("A", dtype="float32")
+            b = theano.tensor.matrix("b", dtype="float32")
+            solve = cula.gpu_solve(A, b)
+        self.assertRaises(AssertionError, invalid_input_func)
+
+    def test_diag_solve_2d(self):
+        """ Diagonal solve test case with 2D array as second input. """
         A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
                               dtype="float32")
         x_val = numpy.random.uniform(-0.4, 0.4, (A_val.shape[1],
                                      1)).astype("float32")
         self.run_gpu_solve(A_val, x_val)
 
-    def test_sym_solve(self):
-        """ Symmetric solve test case with 1D vector as 2D matrix RHS. """
+    def test_sym_solve_2d(self):
+        """ Symmetric solve test case with 2D array as second input. """
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_sym = (A_val + A_val.T) / 2.0
         x_val = numpy.random.uniform(-0.4, 0.4, (A_val.shape[1],
                                      1)).astype("float32")
         self.run_gpu_solve(A_sym, x_val)
 
-    def test_orth_solve(self):
-        """ Orthogonal solve test case with 1D vector as 2D matrix RHS. """
+    def test_orth_solve_2d(self):
+        """ Orthogonal solve test case with 2D array as second input. """
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_orth = numpy.linalg.svd(A_val)[0]
         x_val = numpy.random.uniform(-0.4, 0.4, (A_orth.shape[1],
                                      1)).astype("float32")
         self.run_gpu_solve(A_orth, x_val)
 
-    def test_uni_rand_solve(self):
-        """ Uniform random solve test case with 2D matrix RHS. """
+    def test_uni_rand_solve_2d(self):
+        """ Uniform random solve test case with 2D array as second input. """
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         x_val = numpy.random.uniform(-0.4, 0.4,
                                      (A_val.shape[1], 4)).astype("float32")
         self.run_gpu_solve(A_val, x_val)
 
     def test_diag_solve_1d(self):
-        """ Diagonal solve test case with 1D vector RHS. """
+        """ Diagonal solve test case with 1D array as second input. """
         A_val = numpy.asarray([[2, 0, 0], [0, 1, 0], [0, 0, 1]],
                               dtype="float32")
         x_val = numpy.random.uniform(-0.4, 0.4,
@@ -89,7 +98,7 @@ class TestCula(unittest.TestCase):
         self.run_gpu_solve(A_val, x_val)
 
     def test_sym_solve_1d(self):
-        """ Symmetric solve test case with 1D vector RHS. """
+        """ Symmetric solve test case with 1D array as second input. """
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_sym = (A_val + A_val.T) / 2.0
         x_val = numpy.random.uniform(-0.4, 0.4,
@@ -97,9 +106,16 @@ class TestCula(unittest.TestCase):
         self.run_gpu_solve(A_sym, x_val)
 
     def test_orth_solve_1d(self):
-        """ Orthogonal solve test case with 1D vector RHS. """
+        """ Orthogonal solve test case with 1D array as second input. """
         A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
         A_orth = numpy.linalg.svd(A_val)[0]
         x_val = numpy.random.uniform(-0.4, 0.4,
                                      A_orth.shape[1]).astype("float32")
         self.run_gpu_solve(A_orth, x_val)
+
+    def test_uni_rand_solve_1d(self):
+        """ Uniform random solve test case with 1D array as second input. """
+        A_val = numpy.random.uniform(-0.4, 0.4, (5, 5)).astype("float32")
+        x_val = numpy.random.uniform(-0.4, 0.4,
+                                     A_val.shape[1]).astype("float32")
+        self.run_gpu_solve(A_val, x_val)

--- a/theano/sandbox/cuda/tests/test_cula.py
+++ b/theano/sandbox/cuda/tests/test_cula.py
@@ -47,7 +47,7 @@ class TestCula(unittest.TestCase):
         def invalid_input_func():
             A = theano.tensor.tensor3("A", dtype="float32")
             b = theano.tensor.matrix("b", dtype="float32")
-            solve = cula.gpu_solve(A, b)
+            cula.gpu_solve(A, b)
         self.assertRaises(AssertionError, invalid_input_func)
 
     def test_invalid_input_fail_3d(self):
@@ -55,7 +55,7 @@ class TestCula(unittest.TestCase):
         def invalid_input_func():
             A = theano.tensor.vector("A", dtype="float32")
             b = theano.tensor.matrix("b", dtype="float32")
-            solve = cula.gpu_solve(A, b)
+            cula.gpu_solve(A, b)
         self.assertRaises(AssertionError, invalid_input_func)
 
     def test_diag_solve_2d(self):

--- a/theano/sandbox/cuda/tests/test_opt.py
+++ b/theano/sandbox/cuda/tests/test_opt.py
@@ -24,6 +24,7 @@ if not cuda.cuda_available:
     raise SkipTest('Optional package cuda disabled')
 
 import theano.sandbox.cuda.cula as cula
+import theano.sandbox.cuda.cublas as cublas
 
 from theano.sandbox.cuda import basic_ops
 from theano.sandbox.cuda.type import CudaNdarrayType
@@ -788,13 +789,13 @@ def test_local_gpu_solve():
 
 def test_local_gpu_triangular_solve():
 
-    if not cula.cula_available:
-        raise SkipTest('Optional dependency CULA not available')
+    if not cublas.cublas_available:
+        raise SkipTest('Optional dependency CUBLAS not available')
 
     numpy.random.seed(1)
 
     def cmp(A_shp, b_shp, lower):
-        A_val = numpy.random.uniform(-0.4, 0.4, a_shp).astype('float32')
+        A_val = numpy.random.uniform(-0.4, 0.4, A_shp).astype('float32')
         A_val = numpy.tril(A_val) if lower else numpy.triu(A_val)
 
         A = cuda.shared_constructor(A_val, 'A')
@@ -804,7 +805,7 @@ def test_local_gpu_triangular_solve():
 
         A_structure = 'lower_triangular' if lower else 'upper_triangular'
         solve_op = tensor.slinalg.Solve(A_structure=A_structure, lower=lower)
-        f = pfunc([], solve_op((A, b), mode=mode_with_gpu)
+        f = pfunc([], solve_op((A, b), mode=mode_with_gpu))
 
         assert isinstance(f.maker.fgraph.toposort()[1].inputs[0].owner.op,
                           cuda.cublas.GpuTriangularSolve)

--- a/theano/sandbox/cuda/tests/test_opt.py
+++ b/theano/sandbox/cuda/tests/test_opt.py
@@ -805,7 +805,7 @@ def test_local_gpu_triangular_solve():
 
         A_structure = 'lower_triangular' if lower else 'upper_triangular'
         solve_op = tensor.slinalg.Solve(A_structure=A_structure, lower=lower)
-        f = pfunc([], solve_op((A, b), mode=mode_with_gpu))
+        f = pfunc([], solve_op(A, b), mode=mode_with_gpu)
 
         assert isinstance(f.maker.fgraph.toposort()[1].inputs[0].owner.op,
                           cuda.cublas.GpuTriangularSolve)


### PR DESCRIPTION
## Reason for PR

This in some way extends on from #3994 which makes some proposed changes to the general CULA based `GpuSolve` op with the aim of making it more compatible with the `slinalg.Solve` op. 

The current `slinalg.Solve` op has an `A_structure` property which can be used to provide information about special structure in the matrix system being solved. Currently as well as the normal general dense solver the `slinalg.Solve` op also uses a specific solver for triangular systems if `A_structure` is one of `lower_triangular` or `upper_triangular`. Having a GPU triangular solve op would make the GPU based functionality equivalent and potentially give significant performance gains over using a general solver when the system is known to be triangular given the O(D<sup>2</sup>) cost compared to O(D<sup>3</sup>) cost for a general solver (this is ignoring however possible differences in degree of parallelism and so GPU speed up).

Combined with #4006 this PR would also allow efficient and numerically stable GPU-based solving of positive definite linear systems via the Cholesky decomposition of the matrix.
## Description of proposed changes

A new CUBLAS based `GpuTriangularSolve` op is defined in a new module `cublas.py`, this mainly just a wrapper around the `skcuda.cublas.cublasStrsm` single-precision triangular linear system solver function and very closely following the structure of the existing CULA based `GpuSolve` op.

The `local_gpu_solve` optimization is also updated to replace `slinalg.Solve` ops in which the `A_structure` property is set to one of `lower_triangular` or `upper_triangular` with instances of the new `GpuTriangularSolve` op, with the current `GpuSolve` op used as the fallback for other `A_structure` values.

Tests for the new op and edited optimization are also defined.
## Questions
- Is there a more logical existing module for the `GpuTriangularSolve` op to exist in rather than creating a new `cublas.py` module? One possibility seems to be the existing [sandbox/cuda/blas.py](https://github.com/Theano/Theano/blob/master/theano/sandbox/cuda/blas.py) however this currently only contains ops directly implemented with CUDA / CUBLAS C-code as opposed to this op which just wraps a `skcuda.cublas` function. Another option would be to combine with the op(s) in [sandbox/cuda/cula.py](https://github.com/Theano/Theano/blob/master/theano/sandbox/cuda/cula.py) to group all the `skcuda` based ops together.
- I am not sure if the `atexit` based method of making sure the `cublas.cublasDestroy` function is called on any initialized CUBLAS handle before exiting is the best approach?
