### PR TITLE
Temp disable warn64

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4957,7 +4957,7 @@ class ARange(Op):
         inputs = [start, stop, step]
         outputs = [tensor(self.dtype, (False,))]
         return Apply(self, inputs, outputs)
-        
+
     @theano.configparser.change_flags(warn_float64='ignore')
     def infer_shape(self, node, i_shapes):
         # Note start, stop and step can be float numbers.

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4957,7 +4957,7 @@ class ARange(Op):
         inputs = [start, stop, step]
         outputs = [tensor(self.dtype, (False,))]
         return Apply(self, inputs, outputs)
-    
+    @theano.configparser.change_flags(warn_float64 = 'ignore')
     def infer_shape(self, node, i_shapes):
         # Note start, stop and step can be float numbers.
         start, stop, step = node.inputs

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4957,7 +4957,7 @@ class ARange(Op):
         inputs = [start, stop, step]
         outputs = [tensor(self.dtype, (False,))]
         return Apply(self, inputs, outputs)
-
+    
     def infer_shape(self, node, i_shapes):
         # Note start, stop and step can be float numbers.
         start, stop, step = node.inputs

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4957,7 +4957,8 @@ class ARange(Op):
         inputs = [start, stop, step]
         outputs = [tensor(self.dtype, (False,))]
         return Apply(self, inputs, outputs)
-    @theano.configparser.change_flags(warn_float64 = 'ignore')
+        
+    @theano.configparser.change_flags(warn_float64='ignore')
     def infer_shape(self, node, i_shapes):
         # Note start, stop and step can be float numbers.
         start, stop, step = node.inputs


### PR DESCRIPTION
Fixing Issue #3985 ,
Temporarily setting the 'warn_float64' flag to 'ignore' in  Arange.infer_shape()