### PR TITLE
(#4024) cutting the *.a extension in ldlibrary file

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1661,6 +1661,8 @@ def std_lib_dirs_and_libs():
         # remove extension if present
         if libname.endswith(".so"):
             libname = libname[:-3]
+        elif libname.endswith(".a"):
+            libname = libname[:-2]
 
         libdir = distutils.sysconfig.get_config_var("LIBDIR")
 


### PR DESCRIPTION
Small change to resolve problems when LDLIBRARY points to a *.a file instead of *.so.