### PR TITLE
cuDNN header / library paths fix

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -2122,8 +2122,8 @@ class GCC_compiler(Compiler):
             preargs = list(preargs)
 
         include_dirs = include_dirs + std_include_dirs()
-        libs = std_libs() + libs
-        lib_dirs = std_lib_dirs() + lib_dirs
+        libs = libs + std_libs()
+        lib_dirs = lib_dirs + std_lib_dirs()
 
         cppfilename = os.path.join(location, 'mod.cpp')
         with open(cppfilename, 'w') as cppfile:

--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -355,8 +355,14 @@ class DnnVersion(GpuOp):
     def c_headers(self):
         return ['cudnn.h']
 
+    def c_header_dirs(self):
+        return [config.dnn.include_path]
+
     def c_libraries(self):
         return ['cudnn']
+
+    def c_lib_dirs(self):
+        return [config.dnn.library_path]
 
     def c_support_code(self):
         return """

--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -86,10 +86,13 @@ class DnnBase(GpuOp, COp):
         return ['cudnn.h', 'cudnn_helper.h']
 
     def c_header_dirs(self):
-        return [os.path.dirname(__file__)]
+        return [os.path.dirname(__file__), config.dnn.include_path]
 
     def c_libraries(self):
         return ['cudnn']
+
+    def c_lib_dirs(self):
+        return [config.dnn.library_path]
 
 
 class GpuDnnConvDesc(GpuOp):
@@ -107,10 +110,13 @@ class GpuDnnConvDesc(GpuOp):
         return ['cudnn.h', 'cudnn_helper.h']
 
     def c_header_dirs(self):
-        return [os.path.dirname(__file__)]
+        return [os.path.dirname(__file__), config.dnn.include_path]
 
     def c_libraries(self):
         return ['cudnn']
+
+    def c_lib_dirs(self):
+        return [config.dnn.library_path]
 
     def c_compiler(self):
         return NVCC_compiler
@@ -1256,10 +1262,13 @@ class GpuDnnPoolDesc(GpuOp):
         return ['cudnn.h', 'cudnn_helper.h']
 
     def c_header_dirs(self):
-        return [os.path.dirname(__file__)]
+        return [os.path.dirname(__file__), config.dnn.include_path]
 
     def c_libraries(self):
         return ['cudnn']
+
+    def c_lib_dirs(self):
+        return [config.dnn.library_path]
 
     def c_compiler(self):
         return NVCC_compiler

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -214,7 +214,7 @@ class NVCC_compiler(Compiler):
         if os.path.abspath(os.path.split(__file__)[0]) not in include_dirs:
             include_dirs.append(os.path.abspath(os.path.split(__file__)[0]))
 
-        libs = std_libs() + libs
+        libs = libs + std_libs()
         if 'cudart' not in libs:
             libs.append('cudart')
 

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -218,7 +218,7 @@ class NVCC_compiler(Compiler):
         if 'cudart' not in libs:
             libs.append('cudart')
 
-        lib_dirs = std_lib_dirs() + lib_dirs
+        lib_dirs = lib_dirs + std_lib_dirs()
         if any(ld == os.path.join(cuda_root, 'lib') or
                ld == os.path.join(cuda_root, 'lib64') for ld in lib_dirs):
             warnings.warn("You have the cuda library directory in your "


### PR DESCRIPTION
## Reason for PR

This is a proposed fix #4082.

## Description of proposed changes

The PR causes  `config.dnn.include_path` and `config.dnn.library_path` to be included in the compile commands for CUDA backend cuDNN ops by adding them to the lists returned by the `c_header_dirs` and `c_lib_dirs` methods of the cuDNN related ops in `sandbox/cuda/__init__.py` and `sandbox/cuda/dnn.py`.

To make sure the user specified library paths are given greater precedence by the compiler it also switches the order in which the `lib_dirs` list is constructed in `NVCC_compiler.compile_str` in `sandbox/cuda/nvcc_compiler`, with the user specified library paths put at the start of the list (rather than being added after the standard libraries returned by `std_lib_dirs()` as currently). This is already the behaviour for the `include_dirs`. For consistency I also switched the order for `libs` analagously as well though this isn't actually needed to fix #4082.