### PR TITLE
fix potential nan

### DIFF
--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -1918,19 +1918,19 @@ def local_dot22_to_ger_or_gemv(node):
             # x and y are both vectors so this qualifies for a sdot / ddot
             # TODO: Theano doesn't have a sdot, but gemv is better than _dot22
             xv = x.dimshuffle(1)
-            zeros = T.AllocEmpty(x.dtype)(1)
+            zeros = T.zeros([1], x.dtype)
             rval = gemv_no_inplace(zeros, one, y.T, xv, zero)
             return [rval.dimshuffle('x', 0)]
         if xb[0] and not yb[0] and not yb[1]:
             # x is vector, y is matrix so try gemv
             xv = x.dimshuffle(1)
-            zeros = T.AllocEmpty(x.dtype)(y.shape[1])
+            zeros = T.zeros([y.shape[1]], x.dtype)
             rval = gemv_no_inplace(zeros, one, y.T, xv, zero)
             return [rval.dimshuffle('x', 0)]
         if not xb[0] and not xb[1] and yb[1]:
             # x is matrix, y is vector, try gemv
             yv = y.dimshuffle(0)
-            zeros = T.AllocEmpty(x.dtype)(x.shape[0])
+            zeros = T.zeros([x.shape[0]], x.dtype)
             rval = gemv_no_inplace(zeros, one, x, yv, zero)
             return [rval.dimshuffle(0, 'x')]
 


### PR DESCRIPTION
The `local_dot22_to_ger_or_gemv` optimizer uses AllocEmpty for some cases. Usually this is fine, as it is multiplied by zero. However, on rare cases the allocated memory might contain nan values, in which case the product will be nan instead of zero. I've somehow encountered this rare case in my experiments.