### PR TITLE
Fix stale import of cuda_enabled in rng_mrg.py (#4098)

### DIFF
--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -21,8 +21,9 @@ from theano.compile import optdb
 from theano.gof import local_optimizer
 from . import multinomial
 
-from theano.sandbox.cuda import cuda_available, cuda_enabled, GpuOp
-if cuda_available:
+import theano.sandbox.cuda
+from theano.sandbox.cuda import GpuOp
+if theano.sandbox.cuda.cuda_available:
     from theano.sandbox.cuda import (CudaNdarrayType,
                                      float32_shared_constructor)
 
@@ -1091,7 +1092,7 @@ class MRG_RandomStreams(object):
         self.set_rstate(seed)
 
         if use_cuda is None:
-            self.use_cuda = cuda_enabled
+            self.use_cuda = theano.sandbox.cuda.cuda_enabled            
         else:
             self.use_cuda = use_cuda
 


### PR DESCRIPTION
This change fixes issue #4098 , in which rng_mrg.py was no longer using CUDA at all due to a stale import of `cuda_enabled`. Apparently, a recent commit (adb02ac) changed the timing of some imports, which exposed this existing "import of a mutable variable" bug.

Testing: ran the minimal test case in #4098 and ran `theano/sandbox/test_rng_mrg.py`.

fix gh-4098