### PR TITLE
Added confusion matrix op, issue #3637

### DIFF
--- a/theano/tensor/nnet/__init__.py
+++ b/theano/tensor/nnet/__init__.py
@@ -16,7 +16,8 @@ from .nnet import (
     graph_merge_softmax_with_crossentropy_softmax, h_softmax,
     logsoftmax, logsoftmax_op, prepend_0_to_each_row, prepend_1_to_each_row,
     prepend_scalar_to_each_row, relu, softmax, softmax_grad, softmax_graph,
-    softmax_op, softmax_simplifier, softmax_with_bias, elu)
+    softmax_op, softmax_simplifier, softmax_with_bias, elu,
+    confusion_matrix)
 from . import opt
 from .conv import ConvOp
 from .Conv3D import *

--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -2381,7 +2381,7 @@ def confusion_matrix(actual, pred):
        Actual  |
                |
 
-    order : Order of entries in terms of original data
+    order : 1-d array of order of entries in rows and columns
 
     Examples
     --------
@@ -2398,12 +2398,10 @@ def confusion_matrix(actual, pred):
             [2, 1, 0],
             [0, 0, 1]]), array([ 0.,  1.,  2.])]
     """
-    if actual.type.ndim != 1:
+    if actual.ndim != 1:
         raise ValueError('actual must be 1-d tensor variable')
-    if pred.type.ndim != 1:
+    if pred.ndim != 1:
         raise ValueError('pred must be 1-d tensor variable')
-    if actual.shape[0] != pred.shape[0]:
-        raise ValueError('actual and pred must have the same length')
 
     order = extra_ops.Unique(False, False, False)(tensor.concatenate([actual, pred]))
 
@@ -2414,5 +2412,4 @@ def confusion_matrix(actual, pred):
     oneHotP = tensor.eq(colP, order).astype('int64')
 
     conf_mat = tensor.dot(oneHotA.T, oneHotP)
-
     return [conf_mat, order]

--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -2360,3 +2360,66 @@ def elu(x, alpha=1):
         Exponential Linear Units (ELUs)" <http://arxiv.org/abs/1511.07289>`.
     """
     return tensor.switch(x > 0, x, alpha * (tensor.exp(x) - 1))
+
+
+class ConfusionMatrix(gof.Op):
+    """
+    Computes the confusion matrix of given vectors containing 
+    actual observations and predicted observations.
+
+    Parameters
+    ----------
+    actual : 1-d tensor
+    pred : 1-d tensor
+
+    Returns
+    -------
+    conf_mat : Confusion matrix of actual and predictions observations as shown below.
+
+               | Predicted 
+    ___________|___________
+       Actual  |
+               |
+
+    order : Order of entries in terms of original data
+
+    """
+
+    __props__ = ()
+
+    def make_node(self, actual, pred):
+        actual = tensor.as_tensor_variable(actual)
+        pred = tensor.as_tensor_variable(pred)
+        
+        if actual.type.ndim != 1:
+            raise ValueError('actual must be 1-d tensor')
+
+        if pred.type.ndim != 1:
+            raise ValueError('pred must be 1-d tensor')
+        
+        conf = tensor.TensorType(dtype='int64', broadcastable=(False, False)).make_variable()
+        order = actual.type()
+
+        node = Apply(op=self, inputs=[actual, pred], outputs=[conf, order])
+        return node
+
+
+    def perform(self, node, input_storage, output_storage):
+        actual, pred = input_storage
+
+        if len(actual) != len(pred):
+            raise ValueError('Lengths of actual and pred must be the same.')
+
+        order = numpy.union1d(actual, pred)
+        order = order[~numpy.isnan(order)]
+
+        colA = numpy.matrix(actual).T
+        colP = numpy.matrix(pred).T
+
+        oneHotA = colA.__eq__(order).astype('int64')
+        oneHotP = colP.__eq__(order).astype('int64')
+
+        conf_mat = numpy.dot(oneHotA.T, oneHotP)
+
+        output_storage[0][0] = conf_mat
+        output_storage[1][0] = order

--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -2364,7 +2364,7 @@ def elu(x, alpha=1):
 
 def confusion_matrix(actual, pred):
     """
-    Computes the confusion matrix of given vectors containing 
+    Computes the confusion matrix of given vectors containing
     actual observations and predicted observations.
 
     Parameters
@@ -2376,7 +2376,7 @@ def confusion_matrix(actual, pred):
     -------
     conf_mat : Confusion matrix of actual and predictions observations as shown below.
 
-               | Predicted 
+               | Predicted
     ___________|___________
        Actual  |
                |
@@ -2397,7 +2397,6 @@ def confusion_matrix(actual, pred):
     [array([[0, 0, 1],
             [2, 1, 0],
             [0, 0, 1]]), array([ 0.,  1.,  2.])]
-
     """
     if actual.type.ndim != 1:
         raise ValueError('actual must be 1-d tensor variable')

--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -20,6 +20,7 @@ import theano
 from theano import gof
 from theano import scalar
 from theano.tensor import basic as tensor, subtensor, opt
+from theano.tensor import extra_ops
 from theano.tensor.type import (values_eq_approx_remove_inf,
                                 values_eq_approx_remove_nan)
 from theano.tensor.opt import copy_stack_trace
@@ -30,7 +31,6 @@ from theano.tensor.nnet.sigm import sigmoid, softplus
 from theano.gradient import DisconnectedType
 from theano.gradient import grad_not_implemented
 from theano.tensor.nnet.blocksparse import sparse_block_dot
-
 
 ############
 #
@@ -2362,15 +2362,15 @@ def elu(x, alpha=1):
     return tensor.switch(x > 0, x, alpha * (tensor.exp(x) - 1))
 
 
-class ConfusionMatrix(gof.Op):
+def confusion_matrix(actual, pred):
     """
     Computes the confusion matrix of given vectors containing 
     actual observations and predicted observations.
 
     Parameters
     ----------
-    actual : 1-d tensor
-    pred : 1-d tensor
+    actual : 1-d tensor variable
+    pred : 1-d tensor variable
 
     Returns
     -------
@@ -2383,43 +2383,37 @@ class ConfusionMatrix(gof.Op):
 
     order : Order of entries in terms of original data
 
+    Examples
+    --------
+    >>> import theano
+    >>> from theano.tensor.nnet import confusion_matrix
+
+    >>> x = theano.tensor.vector()
+    >>> y = theano.tensor.vector()
+    >>> f = theano.function([x, y], confusion_matrix(x, y))
+    >>> a = [0, 1, 2, 1, 0]
+    >>> b = [0, 0, 2, 1, 2]
+    >>> print(f(a, b))
+    [array([[0, 0, 1],
+            [2, 1, 0],
+            [0, 0, 1]]), array([ 0.,  1.,  2.])]
+
     """
+    if actual.type.ndim != 1:
+        raise ValueError('actual must be 1-d tensor variable')
+    if pred.type.ndim != 1:
+        raise ValueError('pred must be 1-d tensor variable')
+    if actual.shape[0] != pred.shape[0]:
+        raise ValueError('actual and pred must have the same length')
 
-    __props__ = ()
+    order = extra_ops.Unique(False, False, False)(tensor.concatenate([actual, pred]))
 
-    def make_node(self, actual, pred):
-        actual = tensor.as_tensor_variable(actual)
-        pred = tensor.as_tensor_variable(pred)
-        
-        if actual.type.ndim != 1:
-            raise ValueError('actual must be 1-d tensor')
+    colA = actual.dimshuffle(0, 'x')
+    colP = pred.dimshuffle(0, 'x')
 
-        if pred.type.ndim != 1:
-            raise ValueError('pred must be 1-d tensor')
-        
-        conf = tensor.TensorType(dtype='int64', broadcastable=(False, False)).make_variable()
-        order = actual.type()
+    oneHotA = tensor.eq(colA, order).astype('int64')
+    oneHotP = tensor.eq(colP, order).astype('int64')
 
-        node = Apply(op=self, inputs=[actual, pred], outputs=[conf, order])
-        return node
+    conf_mat = tensor.dot(oneHotA.T, oneHotP)
 
-
-    def perform(self, node, input_storage, output_storage):
-        actual, pred = input_storage
-
-        if len(actual) != len(pred):
-            raise ValueError('Lengths of actual and pred must be the same.')
-
-        order = numpy.union1d(actual, pred)
-        order = order[~numpy.isnan(order)]
-
-        colA = numpy.matrix(actual).T
-        colP = numpy.matrix(pred).T
-
-        oneHotA = colA.__eq__(order).astype('int64')
-        oneHotP = colP.__eq__(order).astype('int64')
-
-        conf_mat = numpy.dot(oneHotA.T, oneHotP)
-
-        output_storage[0][0] = conf_mat
-        output_storage[1][0] = order
+    return [conf_mat, order]

--- a/theano/tensor/nnet/tests/test_nnet.py
+++ b/theano/tensor/nnet/tests/test_nnet.py
@@ -30,7 +30,8 @@ from theano.tensor.nnet import (categorical_crossentropy,
                                 Prepend_scalar_to_each_row,
                                 relu,
                                 h_softmax,
-                                elu)
+                                elu,
+                                confusion_matrix)
 from theano.tensor import matrix, vector, lvector, scalar
 
 
@@ -1648,3 +1649,30 @@ def test_elu():
     for alpha in 1.5, 2, -1, -1.5, -2:
         y = elu(x, alpha).eval({x: X})
         utt.assert_allclose(y, numpy.where(X > 0, X, alpha * (numpy.exp(X) - 1)))
+
+
+def test_confusion_matrix():
+    # Defining numpy implementation of confusion matrix
+    def numpy_conf_mat(actual, pred):
+        order = numpy.union1d(actual, pred)
+        colA = numpy.matrix(actual).T
+        colP = numpy.matrix(pred).T
+        oneHotA = colA.__eq__(order).astype('int64')
+        oneHotP = colP.__eq__(order).astype('int64')
+        conf_mat = numpy.dot(oneHotA.T, oneHotP)
+        conf_mat = numpy.asarray(conf_mat)
+        return [conf_mat, order]
+
+    x = tensor.vector()
+    y = tensor.vector()
+    f = theano.function([x, y], confusion_matrix(x, y))
+    list_inputs = [[[0, 1, 2, 1, 0], [0, 0, 2, 1, 2]], 
+                   [[2, 0, 2, 2, 0, 1], [0, 0, 2, 2, 0, 2]]]
+
+    for case in list_inputs:
+        a = numpy.asarray(case[0])
+        b = numpy.asarray(case[1])
+        out_exp = numpy_conf_mat(a, b)
+        outs = f(case[0], case[1])
+        for exp, out in zip(out_exp, outs):
+            utt.assert_allclose(exp, out)


### PR DESCRIPTION
Hi, I've added the confusion matrix operation from https://github.com/Theano/Theano/issues/3637 to `theano/tensor/nnet/nnet.py`, since it's frequently used in Machine Learning and I assumed this to be the correct file. Please let me know if I need to change the location of the operation, and I'll accordingly add tests for the op to the appropriate file.

Thanks!