### PR TITLE
Revert "cuDNN header / library paths fix"

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -2122,8 +2122,8 @@ class GCC_compiler(Compiler):
             preargs = list(preargs)
 
         include_dirs = include_dirs + std_include_dirs()
-        libs = libs + std_libs()
-        lib_dirs = lib_dirs + std_lib_dirs()
+        libs = std_libs() + libs
+        lib_dirs = std_lib_dirs() + lib_dirs
 
         cppfilename = os.path.join(location, 'mod.cpp')
         with open(cppfilename, 'w') as cppfile:

--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -354,14 +354,8 @@ class DnnVersion(GpuOp):
     def c_headers(self):
         return ['cudnn.h']
 
-    def c_header_dirs(self):
-        return [config.dnn.include_path]
-
     def c_libraries(self):
         return ['cudnn']
-
-    def c_lib_dirs(self):
-        return [config.dnn.library_path]
 
     def c_support_code(self):
         return """

--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -86,13 +86,10 @@ class DnnBase(GpuOp, COp):
         return ['cudnn.h', 'cudnn_helper.h']
 
     def c_header_dirs(self):
-        return [os.path.dirname(__file__), config.dnn.include_path]
+        return [os.path.dirname(__file__)]
 
     def c_libraries(self):
         return ['cudnn']
-
-    def c_lib_dirs(self):
-        return [config.dnn.library_path]
 
 
 class GpuDnnConvDesc(GpuOp):
@@ -110,13 +107,10 @@ class GpuDnnConvDesc(GpuOp):
         return ['cudnn.h', 'cudnn_helper.h']
 
     def c_header_dirs(self):
-        return [os.path.dirname(__file__), config.dnn.include_path]
+        return [os.path.dirname(__file__)]
 
     def c_libraries(self):
         return ['cudnn']
-
-    def c_lib_dirs(self):
-        return [config.dnn.library_path]
 
     def c_compiler(self):
         return NVCC_compiler
@@ -1262,13 +1256,10 @@ class GpuDnnPoolDesc(GpuOp):
         return ['cudnn.h', 'cudnn_helper.h']
 
     def c_header_dirs(self):
-        return [os.path.dirname(__file__), config.dnn.include_path]
+        return [os.path.dirname(__file__)]
 
     def c_libraries(self):
         return ['cudnn']
-
-    def c_lib_dirs(self):
-        return [config.dnn.library_path]
 
     def c_compiler(self):
         return NVCC_compiler

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -214,11 +214,11 @@ class NVCC_compiler(Compiler):
         if os.path.abspath(os.path.split(__file__)[0]) not in include_dirs:
             include_dirs.append(os.path.abspath(os.path.split(__file__)[0]))
 
-        libs = libs + std_libs()
+        libs = std_libs() + libs
         if 'cudart' not in libs:
             libs.append('cudart')
 
-        lib_dirs = lib_dirs + std_lib_dirs()
+        lib_dirs = std_lib_dirs() + lib_dirs
         if any(ld == os.path.join(cuda_root, 'lib') or
                ld == os.path.join(cuda_root, 'lib64') for ld in lib_dirs):
             warnings.warn("You have the cuda library directory in your "


### PR DESCRIPTION
Reverts Theano/Theano#4084

This cause many problems. I prefer to revert as not having the PR seem better until we make it work correctly.