### PR TITLE
We need to import gof.compiledir in theano-cache.

### DIFF
--- a/bin/theano-cache
+++ b/bin/theano-cache
@@ -6,6 +6,7 @@ import sys
 
 import theano
 from theano import config
+import theano.gof.compiledir
 from theano.gof.cc import get_module_cache
 
 _logger = logging.getLogger('theano.bin.theano-cache')


### PR DESCRIPTION
I don't know when that changed, but it is now necessary.