### PR TITLE
Symbolic Cholesky gradient implementation

### DIFF
--- a/theano/tensor/slinalg.py
+++ b/theano/tensor/slinalg.py
@@ -62,8 +62,27 @@ class Cholesky(Op):
         z[0] = scipy.linalg.cholesky(x, lower=self.lower).astype(x.dtype)
 
     def grad(self, inputs, gradients):
-        return [CholeskyGrad(self.lower)(inputs[0], self(inputs[0]),
-                                         gradients[0])]
+
+        x = inputs[0]
+        dz = gradients[0]
+        chol_x = self(x)
+        chol_x = theano.printing.Print('Cholesky:')(chol_x)
+
+        def tril_and_halve_diagonal(mtx):
+            """Extracts lower triangle of square matrix and halves diagonal."""
+            return tensor.tril(mtx) - tensor.diag(tensor.diagonal(mtx) / 2.)
+
+        def conjugate_solve_triangular(outer, inner):
+            """Computes P^{-T} Q P^{-1} for lower-triangular P."""
+            return solve_upper_triangular(
+                outer.T, solve_upper_triangular(outer.T, inner.T).T)
+
+        s = conjugate_solve_triangular(
+            chol_x, tril_and_halve_diagonal(chol_x.T.dot(dz)))
+
+        s = theano.printing.Print('S:')(s)
+
+        return [tensor.tril(s + s.T) - tensor.diag(tensor.diagonal(s))]
 
 cholesky = Cholesky()
 
@@ -194,8 +213,9 @@ class Solve(Op):
             return [(rows, cols)]
 
 solve = Solve()  # general solve
-
-# TODO : SolveTriangular
+# lower and upper triangular solves
+solve_lower_triangular = Solve(A_structure='lower_triangular', lower=True)
+solve_upper_triangular = Solve(A_structure='upper_triangular', lower=False)
 
 # TODO: Optimizations to replace multiplication by matrix inverse
 #      with solve() Op (still unwritten)

--- a/theano/tensor/slinalg.py
+++ b/theano/tensor/slinalg.py
@@ -65,11 +65,11 @@ class Cholesky(Op):
         """
         Cholesky decomposition reverse-mode gradient update.
 
-        Symbolic expression for reverse-mode Cholesky gradient taken from [1]_
+        Symbolic expression for reverse-mode Cholesky gradient taken from [0]_
 
         References
         ----------
-        .. [1] I. Murray, "Differentiation of the Cholesky decomposition",
+        .. [0] I. Murray, "Differentiation of the Cholesky decomposition",
            http://arxiv.org/abs/1602.07527
 
         """

--- a/theano/tensor/slinalg.py
+++ b/theano/tensor/slinalg.py
@@ -62,6 +62,16 @@ class Cholesky(Op):
         z[0] = scipy.linalg.cholesky(x, lower=self.lower).astype(x.dtype)
 
     def grad(self, inputs, gradients):
+        """
+        Cholesky decomposition reverse-mode gradient update.
+
+        Notes
+        -----
+        Symbolic expression for reverse-mode Cholesky gradient taken from [1]_
+
+        [1] I. Murray, "Differentiation of the Cholesky decomposition",
+            http://arxiv.org/abs/1602.07527
+        """
 
         x = inputs[0]
         dz = gradients[0]

--- a/theano/tensor/slinalg.py
+++ b/theano/tensor/slinalg.py
@@ -66,7 +66,6 @@ class Cholesky(Op):
         x = inputs[0]
         dz = gradients[0]
         chol_x = self(x)
-        chol_x = theano.printing.Print('Cholesky:')(chol_x)
 
         def tril_and_halve_diagonal(mtx):
             """Extracts lower triangle of square matrix and halves diagonal."""
@@ -79,8 +78,6 @@ class Cholesky(Op):
 
         s = conjugate_solve_triangular(
             chol_x, tril_and_halve_diagonal(chol_x.T.dot(dz)))
-
-        s = theano.printing.Print('S:')(s)
 
         return [tensor.tril(s + s.T) - tensor.diag(tensor.diagonal(s))]
 


### PR DESCRIPTION
## Reason for PR

The existing `CholeskyGrad` implementation is implemented with triply nested Python loops which is very slow as noted in #2058, #207 and #208. It also does not have a `grad` method specified meaning it is not possible to differentiate through a `Cholesky` op multiple times. Given it is an atomic op defined directly in python it will also not be optimised to run on the GPU.

There has recently been a [note put on arXiv](http://arxiv.org/abs/1602.07527) giving a simple symbolic expression for the reverse-mode gradient updates for the Cholesky decomposition, which has been used to update the Cholesky gradient implementations in [autograd](https://github.com/HIPS/autograd/commit/024909c58f53b84f5a1c1ab60488c4668284898c#diff-580a144ef545fa15f38dd963feb9aa80) (just for full disclosure, the author of the note, Iain Murray @imurray, is an academic in the department I am PhD student in and this PR in partially in response to discussions with him).

This symbolic definition of the Cholesky gradient can be implemented entirely using existing Theano atomic ops with this PR implementing a first attempt at this. This version already gives a significant speed up on the CPU over the existing implementation for larger matrices (mean of >250× speedup for 200×200 inputs) and no obvious penalty even for small inputs:

![profiling_results](https://cloud.githubusercontent.com/assets/6746980/13436129/ab638b5a-dfd5-11e5-99eb-4f149fb0ddae.png)

It's probable that further performance gains could be achieved some adding some graph optimisations, adding an in-place mode to the `slinalg.Cholesky` op and/or defining a new atomic `CholeskyGrad` op which uses the blocked algorithms also discussed in the arXiv note for larger inputs (there are existing reference python implementations for these by @imurray [here](https://github.com/imurray/chol-rev/blob/master/python/chol_diff.py).

Currently with this alternative `grad` implementation the `Cholesky` op still cannot be differentiated through multiple times as the current `Solve` op does not have a `grad` method implemented. This should be easy to address however (I will add a separate PR for this).

To enable evaluation of gradients of functions involving the Cholesky Op on the GPU should also be much easier with this implementation - most of the atomic ops used in the symbolic expression should already optimise to GPU equivalents, with the major exception being the Cholesky decomposition itself though there has been some work done implementing this in #4006. Currently there is also only a general dense GPU solve op with information about triangular structure ignored however there is a start at attempting to deal with this in #4007 and #3994.

## Description of changes

Rather than creating a `CholeskyGrad` op instance in the `Cholesky.grad` method, here this is replaced instead with a direct symbolic implementation of the gradient updates following the method described in the arXiv note.

Additionally `solve_lower_triangular` and `solve_upper_triangular` op instances are defined to make the calls to the `slinalg.Solve` op more legible.

## Questions

  * I've currently left the existing `CholeskyGrad` implementation in place and just defined the symbolic reverse-mode gradient updates directly in the `Cholesky.grad` method. Is there any way to wrap a symbolic expression as an op so that a new `CholeskyGrad` op could be defined from this (assuming some separate `CholeskyGrad` op should be provided for backwards compatibility)? 
  * Rather than defining the `solve_lower_triangular` and `solve_upper_triangular`  instances globally I could just define them locally inside the method if preferred?
  * I'm not sure if I am using the most efficient method for halving the diagonal of a matrix - I couldn't see any obvious better solution though as `fill_diagonal` can only be used with a scalar and it doesn't seem to be feasible to use `inc_subtensor`. Possibly an optimisation could be added for patterns like `mtx_1 + scalar * tensor.diag(tensor.diagonal(mtx_2))` to make this an in place update to the diagonal were possible? Or would this already be dealt with?