### PR TITLE
Fix typo and clarify cuDNN config documentation

### DIFF
--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -567,19 +567,17 @@ import theano and print the config variable, as in:
 
     A directory with bin/, lib/, include/ folders containing cuda utilities.
 
-.. attribute:: dnn.enabled
+.. attribute:: config.dnn.enabled
 
   String value: ``auto``, ``True``, ``False``
 
-  Default ``auto``
+  Default: ``auto``
 
-  If ``auto``, auto detect if cudnn is there, if not, do not use it,
-  but do not raise an error.
+  If ``auto``, automatically detect and use [cuDNN](https://developer.nvidia.com/cudnn) if it is available.  If cuDNN is unavailable, raise no error.
 
-  If ``True``, if we can't use cudnn, raise an error.
+  If ``True``, require the use of cuDNN.  If cuDNN is unavailable, raise an error.
 
-  If ``False``, do not test if cudnn is there and don't use it.
-  Useful to disable it completely when the auto detection crashes.
+  If ``False``, do not use cuDNN or check if it is available.
 
 .. attribute:: config.dnn.conv.workmem
 


### PR DESCRIPTION
Fixed the typo noted in #4182, and improved the documentation of the `config.dnn.enabled` (cuDNN) flag.

fix gh-4182