### PR TITLE
Fix typo and clarify CNMeM config documentation

### DIFF
--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -402,27 +402,27 @@ import theano and print the config variable, as in:
 
     Float value: >= 0
 
-    Do we enable `CNMeM <https://github.com/NVIDIA/cnmem>`_ or not (a
+    Controls the use of `CNMeM <https://github.com/NVIDIA/cnmem>`_ (a
     faster CUDA memory allocator). In Theano dev version until 0.7.1
     is released.
 
-    That library is included in Theano, you do not need to install it.
+    The CNMeM library is included in Theano and does not need to be separately installed.
 
-    The value represents the start size (in MB or % of total GPU
-    memory) of the memory pool. If more memory are needed, it will
-    try to get more, but this can cause more memory fragmentation:
+    The value represents the start size (either in MB or the fraction of total GPU
+    memory) of the memory pool. If more memory is needed, Theano will
+    try to obtain more, but this can cause memory fragmentation.
 
         * 0: not enabled.
-        * 0 < N <= 1: % of the total GPU memory (clipped to .985 for driver memory)
-        * > 0: use that number of MB of memory.
+        * 0 < N <= 1: use this fraction of the total GPU memory (clipped to .985 for driver memory)
+        * > 1: use this number in megabytes (MB) of memory.
 
 
-    Default 0 (but should change later)
+    Default: 0 (but should change later)
 
     .. note::
 
         This could cause memory fragmentation. So if you have a
-        memory error while using cnmem, try to allocate more memory at
+        memory error while using CNMeM, try to allocate more memory at
         the start or disable it. If you try this, report your result
         on :ref`theano-dev`.
 


### PR DESCRIPTION
Fixed the typo noted in #4183, and improved the documentation of the `config.lib.cnmem` (CNMeM) flag.