### PR TITLE
Added the polygamma function, implemented digamma gradient

### DIFF
--- a/doc/library/tensor/basic.txt
+++ b/doc/library/tensor/basic.txt
@@ -1484,6 +1484,11 @@ Mathematical
 
    Returns a variable representing the logarithm of the gamma function.
 
+.. function:: polygamma(a,k)
+
+   Returns a variable representing the kth derivative of 
+   the digamma function (derivative of the logarithm of the gamma function).
+
 .. function:: psi(a)
 
    Returns a variable representing the derivative of the logarithm of

--- a/theano/tensor/inplace.py
+++ b/theano/tensor/inplace.py
@@ -275,6 +275,11 @@ def gammaln_inplace(a):
 
 
 @_scal_inplace
+def polygamma_inplace(a, k):
+    """polygamma function"""
+
+
+@_scal_inplace
 def psi_inplace(a):
     """derivative of log gamma function"""
 

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -1681,7 +1681,7 @@ if imported_scipy_special:
     expected_erfcinv = scipy.special.erfcinv
     expected_gamma = scipy.special.gamma
     expected_gammaln = scipy.special.gammaln
-    expected_polygamma = lambda x, k: scipy.special.polygamma(x, k).astype(x.dtype)
+    expected_polygamma = lambda x, k: scipy.special.polygamma(k, x).astype(x.dtype)
     expected_psi = scipy.special.psi
     expected_chi2sf = lambda x, df: scipy.stats.chi2.sf(x, df).astype(x.dtype)
     expected_j0 = scipy.special.j0

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -1681,6 +1681,7 @@ if imported_scipy_special:
     expected_erfcinv = scipy.special.erfcinv
     expected_gamma = scipy.special.gamma
     expected_gammaln = scipy.special.gammaln
+    expected_polygamma = lambda x, k: scipy.special.polygamma(x, k).astype(x.dtype)
     expected_psi = scipy.special.psi
     expected_chi2sf = lambda x, df: scipy.stats.chi2.sf(x, df).astype(x.dtype)
     expected_j0 = scipy.special.j0
@@ -1700,6 +1701,7 @@ else:
     expected_erfcinv = []
     expected_gamma = []
     expected_gammaln = []
+    expected_polygamma = []
     expected_psi = []
     expected_chi2sf = []
     expected_j0 = []
@@ -1824,14 +1826,45 @@ GammalnInplaceTester = makeBroadcastTester(
     inplace=True,
     skip=skip_scipy)
 
+# like chi2sf, polygamma takes two inputs, a value (x) and the order (k).  
+# also not sure how to deal with that here...   
+_good_broadcast_unary_polygamma = dict(
+    normal=(rand_ranged(1, 10, (2, 3)),),
+    empty=(numpy.asarray([], dtype=config.floatX),),)
+_grad_broadcast_unary_polygamma = dict(
+    normal=(rand_ranged(1, 10, (2, 3)),),)
+
+PolygammaTester = makeBroadcastTester(
+    op=tensor.polygamma,
+    expected=expected_polygamma,
+    good=_good_broadcast_unary_polygamma,
+    grad=_grad_broadcast_unary_polygamma,
+    eps=2e-10,
+    mode=mode_no_scipy,
+    skip=skip_scipy,
+    name='Polygamma')
+PolygammaInplaceTester = makeBroadcastTester(
+    op=inplace.polygamma_inplace,
+    expected=expected_polygamma,
+    good=_good_broadcast_unary_polygamma,
+    grad=_grad_broadcast_unary_polygamma,
+    eps=2e-10,
+    mode=mode_no_scipy,
+    inplace=True,
+    skip=skip_scipy,
+    name='Polygamma')
+
 _good_broadcast_unary_psi = dict(
     normal=(rand_ranged(1, 10, (2, 3)),),
     empty=(numpy.asarray([], dtype=config.floatX),),)
+_grad_broadcast_unary_psi = dict(
+    normal=(rand_ranged(1, 10, (2, 3)),),)
 
 PsiTester = makeBroadcastTester(
     op=tensor.psi,
     expected=expected_psi,
     good=_good_broadcast_unary_psi,
+    grad=_grad_broadcast_unary_psi,
     eps=2e-10,
     mode=mode_no_scipy,
     skip=skip_scipy)
@@ -1839,6 +1872,7 @@ PsiInplaceTester = makeBroadcastTester(
     op=inplace.psi_inplace,
     expected=expected_psi,
     good=_good_broadcast_unary_psi,
+    grad=_grad_broadcast_unary_psi,
     eps=2e-10,
     mode=mode_no_scipy,
     inplace=True,


### PR DESCRIPTION
Added the polygamma function to basic_scipy.py, which allowed the
gradient of Psi() (the digamma function) to be implemented.

Tested with theano/misc/do_nightly_build:

Executing tests with mode=FAST_COMPILE
THEANO_FLAGS=on_shape_error=raise,on_opt_error=raise,,warn.argmax_pushdo
wn_bug=False,warn.gpusum_01_011_0111_bug=False,warn.sum_sum_bug=False,wa
rn.sum_div_dimshuffle_bug=False,warn.subtensor_merge_bug=False,,device=c
pu,floatX=float64,mode=FAST_COMPILE
/Users/enalisnick/GitHub/Theano/theano/../bin/theano-nose
/Users/enalisnick/GitHub/Theano/theano/misc/pycuda_init.py:34:
UserWarning: PyCUDA import failed in theano.misc.pycuda_init
warnings.warn("PyCUDA import failed in theano.misc.pycuda_init")
SS..S...SSS
----------------------------------------------------------------------
Ran 11 tests in 0.050s

OK (SKIP=6)
Number of elements in the compiledir:
139