### PR TITLE
(#4196) increase the tolerance of test_gc_never_pickles

### DIFF
--- a/theano/tensor/tests/test_gc.py
+++ b/theano/tensor/tests/test_gc.py
@@ -92,7 +92,7 @@ def test_gc_never_pickles_temporaries():
         # that weren't collected shouldn't be pickled anyway
         # Allow for a couple of bytes of difference, since timing info,
         # for instance, can be represented as text of varying size.
-        assert abs(len_post_f - len_post_g) < 128, (
+        assert abs(len_post_f - len_post_g) < 256, (
             f_linker, len_post_f, len_post_g)
 
 


### PR DESCRIPTION
Increased the tolerance of the test, due to reported false positives.

fix gh-4196