### PR TITLE
Pass -rpath to linker only, not to compiler

### DIFF
--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -362,9 +362,6 @@ class DnnVersion(GpuOp):
     def c_lib_dirs(self):
         return [config.dnn.library_path]
 
-    def c_compile_args(self):
-        return ['-rpath', config.dnn.library_path]
-
     def c_support_code(self):
         return """
 #if PY_MAJOR_VERSION >= 3

--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -94,9 +94,6 @@ class DnnBase(GpuOp, COp):
     def c_lib_dirs(self):
         return [config.dnn.library_path]
 
-    def c_compile_args(self):
-        return ['-rpath', config.dnn.library_path]
-
 
 class GpuDnnConvDesc(GpuOp):
     """

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -55,7 +55,7 @@ def is_nvcc_available():
             return False
 
 
-rpath_defaults = []
+rpath_defaults = [config.dnn.library_path]
 
 
 def add_standard_rpath(rpath):


### PR DESCRIPTION
Fixes compilation failure introduced in #4208, mentioned in https://github.com/Theano/Theano/pull/4208#issuecomment-195521755.

Warning: This does not address the changes in the new backend. Let me know if I can easily extend this PR, or feel free to create your own PR based on mine.