### PR TITLE
Fix for #3487.

### DIFF
--- a/theano/compile/ops.py
+++ b/theano/compile/ops.py
@@ -675,6 +675,7 @@ class Rebroadcast(gof.Op):
     def make_node(self, x):
         if self.axis.keys() and (x.ndim <= max(self.axis.keys())):
             raise ValueError('Trying to rebroadcast non-existent dimension')
+        self.axis = OrderedDict([(k % x.ndim, v) if k < 0 else (k, v) for k, v in self.axis.items()])
         t = x.type.clone(
             broadcastable=[self.axis.get(i, b)
                            for i, b in enumerate(x.type.broadcastable)])


### PR DESCRIPTION
Fix for [#3487](https://github.com/Theano/Theano/issues/3487)

Added support for negative indices for 'addbroadcast' and 'unbroadcast'.

When addboadcast function is called with a negative value, the corresponding positive indices is found and it is made braodcastable.