### PR TITLE
Fix the last problems identified for the release.

### DIFF
--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -362,6 +362,9 @@ class DnnVersion(GpuOp):
     def c_lib_dirs(self):
         return [config.dnn.library_path]
 
+    def c_compile_args(self):
+        return ['-Wl,-rpath,'+config.dnn.library_path]
+
     def c_support_code(self):
         return """
 #if PY_MAJOR_VERSION >= 3

--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -363,7 +363,7 @@ class DnnVersion(GpuOp):
         return [config.dnn.library_path]
 
     def c_compile_args(self):
-        return ['-Wl,-rpath,'+config.dnn.library_path]
+        return ['-Wl,-rpath,' + config.dnn.library_path]
 
     def c_support_code(self):
         return """

--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -98,7 +98,7 @@ class DnnBase(GpuOp, COp):
         return [config.dnn.library_path]
 
     def c_compile_args(self):
-        return ['-Wl,-rpath,'+config.dnn.library_path]
+        return ['-Wl,-rpath,' + config.dnn.library_path]
 
 
 class GpuDnnConvDesc(GpuOp):

--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -97,6 +97,9 @@ class DnnBase(GpuOp, COp):
     def c_lib_dirs(self):
         return [config.dnn.library_path]
 
+    def c_compile_args(self):
+        return ['-Wl,-rpath,'+config.dnn.library_path]
+
 
 class GpuDnnConvDesc(GpuOp):
     """

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -55,7 +55,7 @@ def is_nvcc_available():
             return False
 
 
-rpath_defaults = [config.dnn.library_path]
+rpath_defaults = []
 
 
 def add_standard_rpath(rpath):

--- a/theano/sandbox/gpuarray/dnn.py
+++ b/theano/sandbox/gpuarray/dnn.py
@@ -174,7 +174,7 @@ class DnnBase(COp):
         return [config.dnn.library_path]
 
     def c_compile_args(self):
-        return ['-Wl,-rpath,'+config.dnn.library_path]
+        return ['-Wl,-rpath,' + config.dnn.library_path]
 
     def c_code_cache_version(self):
         return (super(DnnBase, self).c_code_cache_version(), version())
@@ -196,7 +196,7 @@ class DnnVersion(Op):
         return [config.dnn.library_path]
 
     def c_compile_args(self):
-        return ['-Wl,-rpath,'+config.dnn.library_path]
+        return ['-Wl,-rpath,' + config.dnn.library_path]
 
     def c_support_code(self):
         return """

--- a/theano/sandbox/gpuarray/dnn.py
+++ b/theano/sandbox/gpuarray/dnn.py
@@ -174,7 +174,7 @@ class DnnBase(COp):
         return [config.dnn.library_path]
 
     def c_compile_args(self):
-        return ['-rpath', config.dnn.library_path]
+        return ['-Wl,-rpath,'+config.dnn.library_path]
 
     def c_code_cache_version(self):
         return (super(DnnBase, self).c_code_cache_version(), version())
@@ -196,7 +196,7 @@ class DnnVersion(Op):
         return [config.dnn.library_path]
 
     def c_compile_args(self):
-        return ['-rpath', config.dnn.library_path]
+        return ['-Wl,-rpath,'+config.dnn.library_path]
 
     def c_support_code(self):
         return """


### PR DESCRIPTION
This completely fixes the -rpath problem and it works on mac and linux, with or without cudnn present.

I might add a few fixes for windows onto this later (if it isnt merged yet).