### PR TITLE
Manually set cuda_ndarray.__file__ if it is absent

### DIFF
--- a/theano/sandbox/cuda/type.py
+++ b/theano/sandbox/cuda/type.py
@@ -21,11 +21,16 @@ try:
     import cuda_ndarray.cuda_ndarray as cuda
     from theano.sandbox.cuda.nvcc_compiler import NVCC_compiler
     import cuda_ndarray
-    # Python 3 does not necessarily set __file__. May need manual setting
+    # Python 3 does not necessarily set __file__. May need manual setting.
+    # The problem is known to occur on Windows 10 with Python 3.4 installed by Anaconda.
     try:
         cuda_ndarray.__file__
     except AttributeError:
-        cuda_ndarray.__file__ = os.path.join(cuda_ndarray.__path__._path[0], 'cuda_ndarray.pyd')
+        from theano.gof.cmodule import get_lib_extension
+        # Only works with Python 3, but it's fine, because Python 2
+        # guarantees to set __file__ when importing any module.
+        cuda_ndarray.__file__ = os.path.join(cuda_ndarray.__path__._path[0],
+                                             'cuda_ndarray.' + get_lib_extension())
 except ImportError:
     # Used to know that `cuda` could not be properly imported.
     cuda = None

--- a/theano/sandbox/cuda/type.py
+++ b/theano/sandbox/cuda/type.py
@@ -21,6 +21,11 @@ try:
     import cuda_ndarray.cuda_ndarray as cuda
     from theano.sandbox.cuda.nvcc_compiler import NVCC_compiler
     import cuda_ndarray
+    # Python 3 does not necessarily set __file__. May need manual setting
+    try:
+        cuda_ndarray.__file__
+    except AttributeError:
+        cuda_ndarray.__file__ = os.path.join(cuda_ndarray.__path__._path[0], 'cuda_ndarray.pyd')
 except ImportError:
     # Used to know that `cuda` could not be properly imported.
     cuda = None


### PR DESCRIPTION
Python 3 does not necessarily set `__file__` when importing (See [Python documentation](https://docs.python.org/3/reference/import.html#__file__)), and it happens that it is not set on my system (Windows 10, Python 3.4) and causes an exception.