### PR TITLE
Decoding nvcc outputs in correct encoding.

### DIFF
--- a/theano/compat/__init__.py
+++ b/theano/compat/__init__.py
@@ -44,6 +44,9 @@ if PY3:
     def decode_iter(itr):
         for x in itr:
             yield x.decode()
+
+    def decode_with(x, encoding):
+        return x.decode(encoding)
 else:
     from six import get_unbound_function
     from operator import div as operator_div
@@ -63,6 +66,9 @@ else:
     def decode_iter(x):
         return x
 
+    def decode_with(x, encoding):
+        return x
+        
 __all__ += ['cmp', 'operator_div', 'DictMixin', 'OrderedDict', 'decode',
             'decode_iter', 'get_unbound_function', 'imap', 'izip', 'ifilter']
 

--- a/theano/compat/__init__.py
+++ b/theano/compat/__init__.py
@@ -68,7 +68,7 @@ else:
 
     def decode_with(x, encoding):
         return x
-        
+
 __all__ += ['cmp', 'operator_div', 'DictMixin', 'OrderedDict', 'decode',
             'decode_iter', 'get_unbound_function', 'imap', 'izip', 'ifilter']
 

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 import warnings
+from locale import getpreferredencoding
 
 import numpy
 
@@ -357,9 +358,10 @@ class NVCC_compiler(Compiler):
             os.chdir(location)
             p = subprocess.Popen(
                     cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            nvcc_stdout, nvcc_stderr = p.communicate()[:2]
-            nvcc_stdout = decode_with(nvcc_stdout, p.stdout.encoding)
-            nvcc_stderr = decode_with(nvcc_stderr, p.stderr.encoding)
+            nvcc_stdout_raw, nvcc_stderr_raw = p.communicate()[:2]
+            console_encoding = getpreferredencoding()
+            nvcc_stdout = decode_with(nvcc_stdout_raw, console_encoding)
+            nvcc_stderr = decode_with(nvcc_stderr_raw, console_encoding)
         finally:
             os.chdir(orig_dir)
 

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -9,7 +9,7 @@ import warnings
 import numpy
 
 from theano import config
-from theano.compat import decode, decode_iter
+from theano.compat import decode, decode_with
 from theano.configdefaults import local_bitwidth
 from theano.gof.utils import hash_from_file
 from theano.gof.cmodule import (std_libs, std_lib_dirs,
@@ -357,7 +357,9 @@ class NVCC_compiler(Compiler):
             os.chdir(location)
             p = subprocess.Popen(
                     cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            nvcc_stdout, nvcc_stderr = decode_iter(p.communicate()[:2])
+            nvcc_stdout, nvcc_stderr = p.communicate()[:2]
+            nvcc_stdout = decode_with(nvcc_stdout, p.stdout.encoding)
+            nvcc_stderr = decode_with(nvcc_stderr, p.stderr.encoding)
         finally:
             os.chdir(orig_dir)
 


### PR DESCRIPTION
`nvcc` calls `cl` (Visula Studio C/C++ compiler), and `cl` outputs are in "current ANSI console codepage" (see [Visual Studio Documentation](https://msdn.microsoft.com/en-us/library/xwy0e8f2%28v=vs.120%29.aspx)). If the encoding is not UTF8 and the output contains non-ASCII characters (very likely to happen if the VS installation is in Asian languages), the default `decode()` will result in an exception.
There had been an issue #3551 that reported the problem, but remained untreated for long.
This pull request fixed the problem by adding a function that can decode in specified encoding and compatible with both Python 2 and 3, and detecting encodings of stdout and stderr.