### PR TITLE
Repair the -rpath linker option in Windows System

### DIFF
--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -261,7 +261,7 @@ class NVCC_compiler(Compiler):
         for pa in preargs:
             if pa.startswith('-Wl,'):
                 # the -rpath option is not understood by the Microsoft linker
-                if sys.platform != 'win32':
+                if sys.platform != 'win32' or not pa.startswith('-Wl,-rpath'):
                     preargs1.append('-Xlinker')
                     preargs1.append(pa[4:])
                 continue

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -260,8 +260,10 @@ class NVCC_compiler(Compiler):
         preargs2 = []
         for pa in preargs:
             if pa.startswith('-Wl,'):
-                preargs1.append('-Xlinker')
-                preargs1.append(pa[4:])
+                # the -rpath option is not understood by the Microsoft linker
+                if sys.platform != 'win32':
+                    preargs1.append('-Xlinker')
+                    preargs1.append(pa[4:])
                 continue
             for pattern in ['-O', '-arch=', '-ccbin=', '-G', '-g', '-I',
                             '-L', '--fmad', '--ftz', '--maxrregcount',


### PR DESCRIPTION
Due to the '-rpath,' option is not understood by the Microsoft linker, I add an judgement to ignore this linker option when running in Windows System. Please see the code for details.

Best wishes,

Mang