### PR TITLE
[WIP] Scan with checkpoint

### DIFF
--- a/theano/__init__.py
+++ b/theano/__init__.py
@@ -73,7 +73,8 @@ from theano.misc.safe_asarray import _asarray
 
 from theano.printing import pprint, pp
 
-from theano.scan_module import scan, map, reduce, foldl, foldr, clone
+from theano.scan_module import (scan, map, reduce, foldl, foldr, clone,
+                                scan_with_checkpoints)
 
 from theano.updates import OrderedUpdates
 

--- a/theano/scan_module/__init__.py
+++ b/theano/scan_module/__init__.py
@@ -39,5 +39,6 @@ __contact__ = "Razvan Pascanu <r.pascanu@gmail>"
 
 from theano.scan_module import scan_opt
 from theano.scan_module.scan import scan
+from theano.scan_module.scan_checkpoint import scan_with_checkpoints
 from theano.scan_module.scan_views import map, reduce, foldl, foldr
 from theano.scan_module.scan_utils import clone, until

--- a/theano/scan_module/scan_checkpoint.py
+++ b/theano/scan_module/scan_checkpoint.py
@@ -1,0 +1,82 @@
+import theano
+import theano.tensor as T
+
+def scan_with_checkpoints(fn, sequences=[], outputs_info=None,
+                          non_sequences=[], name="checkpointscan_fn",
+                          n_steps=None, save_every_N=10):
+
+    """
+    Current assumptions : 
+    - Every sequence has the same length
+    - If n_steps is specified, it has the same value as the length of any sequence
+    - The value of "save_every_N" divides the number of steps the Scan will
+      run without remainder
+    - Only singly-recurrent and non-recurrent outputs are used.
+      No multiple recurrences.
+    - Only the last timestep of any output will ever be used.
+    """
+    
+    # Standardize the format of input arguments
+    if not isinstance(sequences, list):
+        sequences = [sequences]
+    if not isinstance(outputs_info, list):
+        outputs_info = [outputs_info]
+    if not isinstance(non_sequences, list):
+        non_sequences = [non_sequences]
+    
+    # Determine how many steps the original scan would run
+    if n_steps is None:
+        n_steps = sequences[0].shape[0]
+    else:
+        n_steps = n_steps
+
+    # Compute the number of steps of the inner and of the outer scan
+    o_n_steps = n_steps / save_every_N
+    i_n_steps = save_every_N
+
+    # Establish the input variables of the outer scan
+    o_sequences = [s.reshape([s.shape[0] / save_every_N, save_every_N] +
+                             [s.shape[i] for i in range(1, s.ndim)], s.ndim + 1) for s in sequences]
+    new_nitsots = [i for i in outputs_info if i is None]
+    new_sitsots = [i for i in outputs_info if i is not None]
+    o_nonsequences = non_sequences + [i_n_steps]
+
+    def outer_step(*args):
+        # Separate the received arguments into their respective (seq, outputs
+        # from previous iterations, nonseqs) categories
+        i_sequences = list(args[:len(o_sequences)])
+        i_prev_outputs = list(args[len(o_sequences):-len(o_nonsequences)])
+        i_non_sequences = list(args[-len(o_nonsequences):])
+        
+        # Assemble the correct outputs_info list for the inner_scan
+        i_outputs_info = []
+
+        # Call the user-provided function with the proper arguments
+        results, updates = theano.scan(fn=fn,
+                                       sequences=i_sequences,
+                                       outputs_info=i_prev_outputs + [None,] * len(new_nitsots),
+                                       non_sequences=i_non_sequences[:-1],
+                                       name=name + "_inner",
+                                       n_steps=i_non_sequences[-1])
+        if not isinstance(results, list):
+            results = [results]
+
+        # Keep only the last timestep of every output but keep all the updates
+        if not isinstance(results, list):
+            return results[-1], updates
+        else:
+            return [r[-1] for r in results], updates       
+
+    results, updates = theano.scan(fn=outer_step,
+                                  sequences=o_sequences,
+                                  outputs_info=outputs_info,
+                                  non_sequences=o_nonsequences,
+                                  name=name + "_outer",
+                                  n_steps=o_n_steps, allow_gc=True)
+                                  
+    # Keep only the last timestep of every output but keep all the updates
+    return results, updates
+    if not isinstance(results, list):
+        return results[-1:], updates
+    else:
+        return [r[-1:] for r in results], updates

--- a/theano/scan_module/tests/test_scan_checkpoint.py
+++ b/theano/scan_module/tests/test_scan_checkpoint.py
@@ -1,0 +1,95 @@
+import numpy
+import time
+
+import theano
+import theano.tensor as T
+
+
+def example1(checkpoint=True):
+
+    k = T.iscalar("k")
+    A = T.vector("A")
+
+    # Symbolic description of the result
+    if checkpoint:
+        result, updates = theano.scan_with_checkpoints(
+                                    fn=lambda prior_result, A: prior_result * A,
+                                    outputs_info=T.ones_like(A),
+                                    non_sequences=A,
+                                    n_steps=k,
+                                    save_every_N=20)
+    else:
+        result, updates = theano.scan(fn=lambda prior_result, A: prior_result * A,
+                                      outputs_info=T.ones_like(A),
+                                      non_sequences=A,
+                                      n_steps=k)
+
+    # We only care about A**k, but scan has provided us with A**1 through A**k.
+    # Discard the values that we don't care about. Scan is smart enough to
+    # notice this and not waste memory saving them.
+    result = result[-1]
+
+    # compiled function that returns A**k
+    start_compile = time.time()
+    power = theano.function(inputs=[A,k], outputs=result, updates=updates)
+    time_compile = time.time() - start_compile
+
+    start_exec = time.time()
+    out = power(range(10), 100)
+    time_exec = time.time() - start_exec
+    
+    if checkpoint:
+        print("Example 1 with checkpoints")
+    else:
+        print("Example 1 without checkpoints")
+    print("Compile time:", time_compile)
+    print("Exec time:", time_exec)
+    print("Output:", out)
+    
+
+def example2(checkpoint=True):
+
+    up_to = T.iscalar("up_to")
+
+    # define a named function, rather than using lambda
+    def accumulate_by_adding(arange_val, sum_to_date):
+        return sum_to_date + arange_val
+    seq = T.arange(up_to)
+
+    outputs_info = T.as_tensor_variable(numpy.asarray(0, seq.dtype))
+    
+    if checkpoint:
+        scan_result, scan_updates = theano.scan_with_checkpoints(
+                                                fn=accumulate_by_adding,
+                                                outputs_info=outputs_info,
+                                                sequences=seq,
+                                                save_every_N=10)
+    else:
+        scan_result, scan_updates = theano.scan(fn=accumulate_by_adding,
+                                                outputs_info=outputs_info,
+                                                sequences=seq)
+        
+    start_compile = time.time()    
+    triangular_sequence = theano.function(inputs=[up_to], outputs=scan_result)
+    time_compile = time.time() - start_compile
+    
+    start_exec = time.time()
+    out = triangular_sequence(100)[-1]
+    time_exec = time.time() - start_exec
+    
+    if checkpoint:
+        print("Example 2 with checkpoints")
+    else:
+        print("Example 2 without checkpoints")
+    print("Compile time:", time_compile)
+    print("Exec time:", time_exec)
+    print("Output:", out)
+
+
+def test_scan_checkpoint():
+    example1(False)
+    example1(True)
+    print("----")
+    example2(False)
+    example2(True)
+    print("----")


### PR DESCRIPTION
This is work in progress. It will probably need more documentation, more (and more rigorous, the current ones only print stuff) tests, more features, better default value for the new function argument, etc. I'm only making a PR so that there is a trace of this work.

This adds a new function `theano.scan_with_checkpoints` with an interface similar to scan but it is designed to reduce memory usage as much as possible compared to the original, at the cost of additional computation. The general idea is, during the fprop, only save the states every `n` timesteps instead of every timestep. This means that, during the bprop, a partial recomputation of the fprop will be required but much less data will ever need to be in memory at the same time. 

Currently, the code has several assumptions :
    - Every sequence has the same length
    - If n_steps is specified, it has the same value as the length of any sequence
    - The value of "save_every_N" divides the number of steps the Scan will
      run without remainder
    - Only singly-recurrent and non-recurrent outputs are used.
      No multiple recurrences.
    - Only the last timestep of any output will ever be used.