### PR TITLE
Add local_zero_div to specialize phase

### DIFF
--- a/theano/tensor/nnet/tests/test_nnet.py
+++ b/theano/tensor/nnet/tests/test_nnet.py
@@ -1690,10 +1690,12 @@ def test_elu():
 def test_binary_crossentropy_reshape():
     # Reported as https://github.com/Theano/Theano/issues/4086
     a = tensor.tensor4('a')
-    c = binary_crossentropy(sigmoid(a.reshape((-1, 1))), 1).sum()
-    ga = theano.grad(c, a)
-    # This only works when "specialize" options are included
-    mode = theano.compile.get_default_mode().including('fast_run')
-    fga = theano.function([a], ga, mode=mode)
-    utt.assert_allclose(fga(numpy.array([[[[30.]]]], dtype=config.floatX)),
-                        numpy.zeros((1, 1, 1, 1), dtype=config.floatX))
+    for c in (binary_crossentropy(sigmoid(a.reshape((-1, 1))), 1).sum(),
+              binary_crossentropy(sigmoid(a).reshape((-1, 1)), 1).sum()):
+
+        ga = theano.grad(c, a)
+        # This only works when "specialize" options are included
+        mode = theano.compile.get_default_mode().including('fast_run')
+        fga = theano.function([a], ga, mode=mode)
+        utt.assert_allclose(fga(numpy.array([[[[30.]]]], dtype=config.floatX)),
+                            numpy.zeros((1, 1, 1, 1), dtype=config.floatX))

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -5270,6 +5270,7 @@ def local_intdiv_by_one(node):
 
 
 @register_canonicalize
+@register_specialize
 @gof.local_optimizer([T.int_div, T.true_div])
 def local_zero_div(node):
     """0 / x -> 0


### PR DESCRIPTION
Add a test that this is enough to solve the binary_crossentropy(reshape) case.
Follow-up to #4216, finally fixes #4086.