### PR TITLE
Prevents subprocess from importing Theano

### DIFF
--- a/theano/sandbox/cuda/__init__.py
+++ b/theano/sandbox/cuda/__init__.py
@@ -22,6 +22,7 @@ from theano.tensor.basic import register_transfer
 # ignore_newtrees is to speed the optimization as this is the pattern
 # we use for optimization. Otherwise, we can iterate 100s of time on
 # the graph and apply only a few optimizations each time.
+
 gpu_optimizer = EquilibriumDB(ignore_newtrees=False)
 gpu_seqopt = SequenceDB()
 
@@ -481,6 +482,16 @@ def use(device,
         If the gpu is correctly enabled, set the variable cuda_enabled to True.
 
     """
+
+    # Check if theano is being imported from a child process
+    # If yes, raises error, refer issue #1064
+    if 'THEANO_MAX_GPU' in os.environ:
+        if os.environ['THEANO_MAX_GPU'] == '0':
+            raise ImportError("Parent process holds lock on GPU."
+                              " Need to release it first")
+    else:
+        os.environ['THEANO_MAX_GPU'] = '0'
+    
     global cuda_enabled, cuda_initialization_error_message
     if force and not cuda_available and device.startswith('gpu'):
         if not nvcc_compiler.is_nvcc_available():

--- a/theano/sandbox/cuda/tests/test_basic_ops.py
+++ b/theano/sandbox/cuda/tests/test_basic_ops.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, division
 import time
 import unittest
+import os
 
 from theano.compile.pfunc import pfunc
 from theano import tensor
@@ -1372,6 +1373,17 @@ def speed_reduce10():
                         mode=mode_with_gpu)
     f(data)
 
+
+def test_gpu_lock():
+    # Ensures that if the parent process is using the GPU,
+    # the child process cannot get a lock on it.
+    os.environ['THEANO_MAX_GPU'] = 0
+    pid = os.fork()
+    if pid == 0:
+        try:
+            import theano.sandbox.cuda as tcn
+        except Exception as e:
+            assert e.__class__.__name__ == 'ImportError'
 
 if __name__ == '__main__':
     #test_many_arg_elemwise()

--- a/theano/sandbox/cuda/tests/test_basic_ops.py
+++ b/theano/sandbox/cuda/tests/test_basic_ops.py
@@ -1377,7 +1377,7 @@ def speed_reduce10():
 def test_gpu_lock():
     # Ensures that if the parent process is using the GPU,
     # the child process cannot get a lock on it.
-    os.environ['THEANO_MAX_GPU'] = 0
+    os.environ['THEANO_MAX_GPU'] = '0'
     pid = os.fork()
     if pid == 0:
         try:

--- a/theano/sandbox/gpuarray/__init__.py
+++ b/theano/sandbox/gpuarray/__init__.py
@@ -3,6 +3,7 @@ import sys
 import logging
 import sys
 import warnings
+import os
 
 import theano
 from theano import config
@@ -41,6 +42,15 @@ register_transfer(transfer)
 
 
 def init_dev(dev, name=None):
+    # Check if theano is being imported from a child process
+    # If yes, raises error, refer issue #1064
+    if 'THEANO_MAX_GPU' in os.environ:
+        if os.environ['THEANO_MAX_GPU'] == '0':
+            raise ImportError("Parent process holds lock on GPU."
+                              " Need to release it first")
+    else:
+        os.environ['THEANO_MAX_GPU'] = '0'
+    
     v = pygpu.gpuarray.api_version()
     if v[0] != -10000:
         raise RuntimeError("Wrong major API version for gpuarray:", v[0],

--- a/theano/sandbox/gpuarray/tests/test_basic_ops.py
+++ b/theano/sandbox/gpuarray/tests/test_basic_ops.py
@@ -436,7 +436,7 @@ def test_hostfromgpu_shape_i():
 def test_gpu_lock():
     # Ensures that if the parent process is using the GPU,
     # the child process cannot get a lock on it.
-    os.environ['THEANO_MAX_GPU'] = 0
+    os.environ['THEANO_MAX_GPU'] = '0'
     pid = os.fork()
     if pid == 0:
         try:

--- a/theano/sandbox/gpuarray/tests/test_basic_ops.py
+++ b/theano/sandbox/gpuarray/tests/test_basic_ops.py
@@ -3,6 +3,7 @@ import unittest
 from theano.compat import izip
 
 from six import iteritems
+import os
 
 import numpy
 import theano
@@ -430,3 +431,15 @@ def test_hostfromgpu_shape_i():
     assert isinstance(topo[1].op, theano.compile.Shape_i)
     assert isinstance(topo[2].op, theano.tensor.opt.MakeVector)
     assert tuple(f(cv)) == (5, 4)
+
+
+def test_gpu_lock():
+    # Ensures that if the parent process is using the GPU,
+    # the child process cannot get a lock on it.
+    os.environ['THEANO_MAX_GPU'] = 0
+    pid = os.fork()
+    if pid == 0:
+        try:
+            import theano.sandbox.gpuarray as tga
+        except Exception as e:
+            assert e.__class__.__name__ == 'ImportError'


### PR DESCRIPTION
This PR fixes issue #1064 by adding a new environment variable to keep track of whether the GPU is locked by a parent process or not. Earlier sent as PR #4226 