### PR TITLE
Adding clang-omp++ as an alternative compiler to clang++ as it suppots OpenMP

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1825,7 +1825,8 @@ class GCC_compiler(Compiler):
                     break
 
         if ('g++' not in theano.config.cxx and
-                'clang++' not in theano.config.cxx):
+                'clang++' not in theano.config.cxx and
+                'clang-omp++' not in theano.config.cxx):
             _logger.warn(
                 "OPTIMIZATION WARNING: your Theano flag `cxx` seems not to be"
                 " the g++ compiler. So we disable the compiler optimization"


### PR DESCRIPTION
This PR is related to the issue https://github.com/Theano/Theano/issues/4307.