### PR TITLE
Fix for glibc 2.23

### DIFF
--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -141,6 +141,9 @@ class NVCC_compiler(Compiler):
                 flags.append('-arch=sm_' + str(p['major']) +
                              str(p['minor']))
 
+        # Needed for glibc 2.23
+        flags.append('-D_FORCE_INLINES')
+
         return flags
 
     @staticmethod


### PR DESCRIPTION
Avoid "error: 'memcpy' was not declared in the scope" with glibc 2.23.

Found in Ubuntu 16.04 with cuda 7.5.18, gcc 5.3.1 and glibc 2.23.