### PR TITLE
Fix crash in GpuAdvanvedIncSubtensor1 when unbroadcasting the value.

### DIFF
--- a/theano/sandbox/cuda/basic_ops.py
+++ b/theano/sandbox/cuda/basic_ops.py
@@ -2888,7 +2888,7 @@ class GpuAdvancedIncSubtensor1(tensor.AdvancedIncSubtensor1, GpuOp):
         out[0] = x
 
     def c_code_cache_version(self):
-        return (7,)
+        return (8,)
 
     def c_code(self, node, name, inputs, outputs, sub):
         if (node.inputs[0].ndim != node.inputs[1].ndim):
@@ -2961,7 +2961,7 @@ class GpuAdvancedIncSubtensor1(tensor.AdvancedIncSubtensor1, GpuOp):
                   %(fail)s;
              }
              if (%(set_instead_of_inc)s) {
-                 ret = CudaNdarray_CopyFromCudaNdarray((CudaNdarray *) row_x, (CudaNdarray *) row_y);
+                 ret = CudaNdarray_CopyFromCudaNdarray((CudaNdarray *) row_x, (CudaNdarray *) row_y, 1);
              } else {
                  ret = CudaNdarray_inplace_elemwise(row_x, row_y, IADD);
              }

--- a/theano/tensor/tests/test_subtensor.py
+++ b/theano/tensor/tests/test_subtensor.py
@@ -560,6 +560,25 @@ class T_subtensor(unittest.TestCase, utt.TestOptimizationMixin):
         utt.verify_grad(fun, [numpy.random.rand(5, 5).astype(self.dtype),
                               numpy.random.rand(2, 5).astype(self.dtype)])
 
+        # test set_subtensor broadcast
+        self.dtype = 'float32'
+        from theano.sandbox.cuda.dnn import dnn_conv
+
+        x = tensor.tensor4('x', dtype=self.dtype)
+        indexes = theano.shared(numpy.int32([1, 2, 3, 4]))
+        W = self.shared(numpy.random.random(
+            (10, 10, 3, 3)).astype(self.dtype))
+
+        h = x + W
+        h = tensor.set_subtensor(h[indexes], h[indexes])
+        g = tensor.grad(h.sum(), W)
+        N = 2
+        if theano.config.mode == "FAST_COMPILE" and self.adv_incsub1 is tensor.AdvancedIncSubtensor1:
+            N = 3
+        f = self.function([x], g, op=self.adv_incsub1, N=N)
+
+        f(numpy.random.random((10, 10, 3, 3)).astype(self.dtype))
+
     def test_adv_sub1_idx_broadcast(self):
         # The idx can be a broadcastable vector.
         ones = numpy.ones((4, 3), dtype=self.dtype)


### PR DESCRIPTION
It fail in GpuArray on my computer and I don't understand the error:

```
E
======================================================================
ERROR: test_adv_sub1_broadcast (theano.sandbox.gpuarray.tests.test_subtensor.G_subtensor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/u/bastienf/repos/Theano/theano/tensor/tests/test_subtensor.py", line 543, in test_adv_sub1_broadcast
    g_0 = g([0])
  File "/u/bastienf/repos/Theano/theano/compile/function_module.py", line 871, in __call__
    storage_map=getattr(self.fn, 'storage_map', None))
  File "/u/bastienf/repos/Theano/theano/gof/link.py", line 314, in raise_with_op
    reraise(exc_type, exc_value, exc_trace)
  File "/u/bastienf/repos/Theano/theano/compile/function_module.py", line 859, in __call__
    outputs = self.fn()
RuntimeError: Can't fetch error buffer
Apply node that caused the error: GpuAdvancedIncSubtensor1_dev20{inplace,inc}(GpuAlloc<None>{memset_0=True}.0, GpuArrayConstant{[[ 1.]]}, GpuFromHost<None>.0)
Toposort index: 3
Inputs types: [GpuArrayType<None>(float32, (True, False)), GpuArrayType<None>(float32, (True, True)), GpuArrayType<None>(int64, (False,))]
Inputs shapes: [(1, 3), (1, 1), (1,)]
Inputs strides: [(12, 4), (4, 4), (8,)]
Inputs values: [<pygpu.gpuarray.GpuArray object at 0x7fd1e5e8ff30>, <pygpu.gpuarray.GpuArray object at 0x7fd1e5e8fea8>, <pygpu.gpuarray.GpuArray object at 0x7fd1e4358050>]
Outputs clients: [['output']]

Debugprint of the apply node: 
GpuAdvancedIncSubtensor1_dev20{inplace,inc} [id A] <GpuArrayType<None>(float32, (True, False))> ''   
 |GpuAlloc<None>{memset_0=True} [id B] <GpuArrayType<None>(float32, (True, False))> ''   
 | |GpuArrayConstant{[[ 0.]]} [id C] <GpuArrayType<None>(float32, (True, True))>
 | |TensorConstant{1} [id D] <TensorType(int64, scalar)>
 | |Shape_i{1} [id E] <TensorType(int64, scalar)> ''   
 |   |<GpuArrayType<None>(float32, (True, False))> [id F] <GpuArrayType<None>(float32, (True, False))>
 |GpuArrayConstant{[[ 1.]]} [id G] <GpuArrayType<None>(float32, (True, True))>
 |GpuFromHost<None> [id H] <GpuArrayType<None>(int64, (False,))> ''   
   |<TensorType(int64, vector)> [id I] <TensorType(int64, vector)>

Storage map footprint:
 - GpuAlloc<None>{memset_0=True}.0, Shape: (1, 3), ElemSize: 4 Byte(s), TotalSize: 12 Byte(s)
 - <GpuArrayType<None>(float32, (True, False))>, Shared Input, Shape: (1, 3), ElemSize: 4 Byte(s), TotalSize: 12 Byte(s)
 - GpuFromHost<None>.0, Shape: (1,), ElemSize: 8 Byte(s), TotalSize: 8 Byte(s)
 - TensorConstant{1}, Shape: (), ElemSize: 8 Byte(s), TotalSize: 8.0 Byte(s)
 - <TensorType(int64, vector)>, Input, Shape: (1,), ElemSize: 8 Byte(s), TotalSize: 8 Byte(s)
 - GpuArrayConstant{[[ 1.]]}, Shape: (1, 1), ElemSize: 4 Byte(s), TotalSize: 4 Byte(s)
 - GpuArrayConstant{[[ 0.]]}, Shape: (1, 1), ElemSize: 4 Byte(s), TotalSize: 4 Byte(s)
 TotalSize: 56.0 Byte(s) 0.000 GB
 TotalSize inputs: 36.0 Byte(s) 0.000 GB
```

Otherwise, it fix it in the current GPU back-end