### PR TITLE
Make stack trace tests in `tensor/tests/test_opt.py` use `check_stack_trace`.

### DIFF
--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -2717,11 +2717,6 @@ def check_stack_trace(f_or_fgraph, ops_to_check='last', bug_print='raise'):
         for output in node.outputs:
             if (not hasattr(output.tag, 'trace') or
                 not output.tag.trace):
-                # work around some optimization inserting DeepCopyOp and Elemwise without copying the trace.
-                from theano.compile import deep_copy_op, DeepCopyOp
-                if isinstance(fgraph.toposort()[-1].op,
-                              (DeepCopyOp, theano.tensor.Elemwise)):
-                    return True
                 return False
 
     return True

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -2716,7 +2716,12 @@ def check_stack_trace(f_or_fgraph, ops_to_check='last', bug_print='raise'):
     for node in apply_nodes_to_check:
         for output in node.outputs:
             if (not hasattr(output.tag, 'trace') or
-                    not output.tag.trace):
+                not output.tag.trace):
+                # work around some optimization inserting DeepCopyOp and Elemwise without copying the trace.
+                from theano.compile import deep_copy_op, DeepCopyOp
+                if isinstance(fgraph.toposort()[-1].op,
+                              (DeepCopyOp, theano.tensor.Elemwise)):
+                    return True
                 return False
 
     return True

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -2715,8 +2715,7 @@ def check_stack_trace(f_or_fgraph, ops_to_check='last', bug_print='raise'):
 
     for node in apply_nodes_to_check:
         for output in node.outputs:
-            if (not hasattr(output.tag, 'trace') or
-                not output.tag.trace):
+            if (not hasattr(output.tag, 'trace') or not output.tag.trace):
                 return False
 
     return True

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -2667,7 +2667,7 @@ def check_stack_trace(f_or_fgraph, ops_to_check='last', bug_print='raise'):
     # if ops_to_check is a string
     if isinstance(ops_to_check, string_types):
         if ops_to_check == 'last':
-            apply_nodes_to_check = [fgraph.outputs[0].owner]
+            apply_nodes_to_check = [fgraph.outputs[i].owner for i in range(len(fgraph.outputs))]
         elif ops_to_check == 'all':
             apply_nodes_to_check = fgraph.apply_nodes
         else:

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -2667,7 +2667,8 @@ def check_stack_trace(f_or_fgraph, ops_to_check='last', bug_print='raise'):
     # if ops_to_check is a string
     if isinstance(ops_to_check, string_types):
         if ops_to_check == 'last':
-            apply_nodes_to_check = [fgraph.outputs[i].owner for i in range(len(fgraph.outputs))]
+            apply_nodes_to_check = [fgraph.outputs[i].owner for i in range(
+                len(fgraph.outputs))]
         elif ops_to_check == 'all':
             apply_nodes_to_check = fgraph.apply_nodes
         else:
@@ -2711,6 +2712,13 @@ def check_stack_trace(f_or_fgraph, ops_to_check='last', bug_print='raise'):
             pass
         else:
             raise ValueError('The string bug_print is not recognised')
+
+    elif hasattr(ops_to_check, '__call__'):  # if ops_to_check is a function
+        apply_nodes_to_check = [node for node in fgraph.apply_nodes
+                                if ops_to_check(node)]
+
+    else:  # if ops_to_check is an op or a list of ops
+        raise ValueError('The value of ops_to_check is not supported')
 
     for node in apply_nodes_to_check:
         for output in node.outputs:

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -2717,5 +2717,8 @@ def check_stack_trace(f_or_fgraph, ops_to_check='last', bug_print='raise'):
             if (not hasattr(output.tag, 'trace') or
                     not output.tag.trace):
                 return False
+            # check if trace is not empty
+            if not len(output.tag.trace) > 0:
+                return False
 
     return True

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -2713,20 +2713,10 @@ def check_stack_trace(f_or_fgraph, ops_to_check='last', bug_print='raise'):
         else:
             raise ValueError('The string bug_print is not recognised')
 
-    elif hasattr(ops_to_check, '__call__'):  # if ops_to_check is a function
-        apply_nodes_to_check = [node for node in fgraph.apply_nodes
-                                if ops_to_check(node)]
-
-    else:  # if ops_to_check is an op or a list of ops
-        raise ValueError('The value of ops_to_check is not supported')
-
     for node in apply_nodes_to_check:
         for output in node.outputs:
             if (not hasattr(output.tag, 'trace') or
                     not output.tag.trace):
-                return False
-            # check if trace is not empty
-            if not len(output.tag.trace) > 0:
                 return False
 
     return True

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -112,6 +112,7 @@ class test_dimshuffle_lift(unittest.TestCase):
         dimshuffle_lift.optimize(g)
         self.assertTrue(str(g) == "[x]")
         # Check stacktrace was copied over correctly after opt was applied
+        # Optimization may remove all apply_nodes, so we ignore these cases
         self.assertTrue(check_stack_trace(g, ops_to_check='all',
                                           bug_print='ignore'))
 
@@ -138,6 +139,7 @@ class test_dimshuffle_lift(unittest.TestCase):
         dimshuffle_lift.optimize(g)
         self.assertTrue(str(g) == "[x]", str(g))
         # Check stacktrace was copied over correctly after opt was applied
+        # Optimization may remove all apply_nodes, so we ignore these cases
         self.assertTrue(check_stack_trace(g, ops_to_check='all',
                                           bug_print='ignore'))
 
@@ -2551,6 +2553,7 @@ class test_local_subtensor_merge(unittest.TestCase):
             f = theano.function([x] + input_vars, sub_x, mode=mode_opt)
 
             # Check stacktrace was copied over correctly after opt was applied
+            # Optimization may remove all Subtensors, so we ignore these cases
             self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor,
                                               bug_print='ignore'))
 
@@ -5946,8 +5949,7 @@ def test_local_useless_split():
     # | |x [id D]
     # ...
 
-    #assert check_stack_trace(f_opt, ops_to_check=[
-    #    Assert], bug_print='ignore')
+    #assert check_stack_trace(f_opt, ops_to_check=[Assert])
     assert check_stack_trace(f_nonopt, ops_to_check='all')
 
 

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -2125,7 +2125,7 @@ class test_local_subtensor_merge(unittest.TestCase):
                 'local_subtensor_merge'))
 
             # Check stacktrace was copied over correctly after opt was applied
-            self.assertTrue(check_stack_trace(f, ops_to_check='last'))
+            self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
 
             topo = f.maker.fgraph.toposort()
             assert len([t for t in topo
@@ -5929,9 +5929,7 @@ def test_local_useless_split():
 
     # Check that stacktraces have been copied over properly
     assert check_stack_trace(f_opt, ops_to_check='all')
-    assert len(f_opt.outputs[0].variable.tag.trace) > 0
     assert check_stack_trace(f_nonopt, ops_to_check='all')
-    assert len(f_nonopt.outputs[0].variable.tag.trace) > 0
 
 
 def test_local_flatten_lift():

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -2960,8 +2960,10 @@ def test_local_IncSubtensor_serialize():
 
     # Now test that the stack trace is copied over properly,
     # if we return the gradients. We need to use same mode as before.
+    # the optimizer may delete all instances of AdvancedIncSubtensor
     f = theano.function([i, j, t], dW, mode=mode)
-    assert check_stack_trace(f, ops_to_check=tensor.AdvancedIncSubtensor)
+    assert check_stack_trace(f, ops_to_check=tensor.AdvancedIncSubtensor,
+                             bug_print='ignore')
         
 def test_local_set_to_inc_subtensor():
     v = theano.tensor.fmatrix()

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -112,7 +112,8 @@ class test_dimshuffle_lift(unittest.TestCase):
         dimshuffle_lift.optimize(g)
         self.assertTrue(str(g) == "[x]")
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(check_stack_trace(g, ops_to_check='all'))
+        self.assertTrue(check_stack_trace(g, ops_to_check='all',
+                                          bug_print='ignore'))
 
     def test_merge2(self):
         x, y, z = inputs()
@@ -137,7 +138,8 @@ class test_dimshuffle_lift(unittest.TestCase):
         dimshuffle_lift.optimize(g)
         self.assertTrue(str(g) == "[x]", str(g))
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(check_stack_trace(g, ops_to_check='all'))
+        self.assertTrue(check_stack_trace(g, ops_to_check='all',
+                                          bug_print='ignore'))
 
     def test_lift(self):
         x, y, z = inputs([False] * 1, [False] * 2, [False] * 3)
@@ -2019,7 +2021,7 @@ class test_local_subtensor_lift(unittest.TestCase):
                      mode=mode_opt)
 
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
+        self.assertTrue(check_stack_trace(f, ops_to_check=tensor.Subtensor))
 
         prog = f.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tensor.DimShuffle)
@@ -2538,11 +2540,11 @@ class test_local_subtensor_merge(unittest.TestCase):
             slice1 = slice(*slice_inputs[:3])
             slice2 = slice(*slice_inputs[3:])
             sub_x = x[slice1][slice2]
-            f = theano.function([x] + input_vars, sub_x,
-                mode=mode_opt.excluding('local_useless_subtensor'))
+            f = theano.function([x] + input_vars, sub_x, mode=mode_opt)
 
             # Check stacktrace was copied over correctly after opt was applied
-            self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
+            self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor,
+                                              bug_print='ignore'))
 
             topo = f.maker.fgraph.toposort()
             # print [t for t in topo if isinstance(t.op, tensor.Subtensor)]
@@ -2946,7 +2948,7 @@ def test_local_IncSubtensor_serialize():
     # Now test that the stack trace is copied over properly,
     # if we return the gradients. We need to use same mode as before.
     f = theano.function([i, j, t], dW, mode=mode)
-    assert check_stack_trace(f, ops_to_check='all')
+    assert check_stack_trace(f, ops_to_check=tensor.AdvancedIncSubtensor)
         
 def test_local_set_to_inc_subtensor():
     v = theano.tensor.fmatrix()
@@ -2978,7 +2980,7 @@ def test_local_set_to_inc_subtensor():
 
     # Finally, test that the stack trace is copied over properly,
     # before before and after optimization.
-    assert check_stack_trace(f1, ops_to_check='all')
+    assert check_stack_trace(f1, ops_to_check=tensor.AdvancedIncSubtensor1)
     assert check_stack_trace(f2, ops_to_check='all')
     
     
@@ -3623,8 +3625,8 @@ class Test_local_useless_inc_subtensor_alloc(unittest.TestCase):
         utt.assert_allclose(r1, r2)
         
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(check_stack_trace(f1, ops_to_check='all'))
-        self.assertTrue(check_stack_trace(f2, ops_to_check='all'))
+        self.assertTrue(check_stack_trace(f1, ops_to_check=tensor.AdvancedIncSubtensor))
+        self.assertTrue(check_stack_trace(f2, ops_to_check=tensor.AdvancedIncSubtensor))
         
 
     def test_advanced_inc_subtensor1(self):
@@ -3657,7 +3659,8 @@ class Test_local_useless_inc_subtensor_alloc(unittest.TestCase):
         utt.assert_allclose(r1, r2)
         
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(check_stack_trace(f1, ops_to_check='all'))
+        self.assertTrue(check_stack_trace(
+                f1, ops_to_check=tensor.AdvancedIncSubtensor1))
         self.assertTrue(check_stack_trace(f2, ops_to_check='all'))
 
     def test_incsubtensor(self):

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -2154,7 +2154,7 @@ class test_local_subtensor_merge(unittest.TestCase):
         #theano.printing.debugprint(f, print_type=True)
 
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(check_stack_trace(f, ops_to_check='last'))
+        self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
 
         topo = f.maker.fgraph.toposort()
         # print [t for t in topo if isinstance(t.op, tensor.Subtensor)]
@@ -2184,7 +2184,7 @@ class test_local_subtensor_merge(unittest.TestCase):
                          mode=mode_opt.excluding('local_subtensor_merge'))
 
             # Check stacktrace was copied over correctly after opt was applied
-            self.assertTrue(check_stack_trace(f, ops_to_check='last'))
+            self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
 
             #theano.printing.debugprint(f, print_type=True)
             topo = f.maker.fgraph.toposort()
@@ -2215,7 +2215,7 @@ class test_local_subtensor_merge(unittest.TestCase):
         #theano.printing.debugprint(f, print_type=True)
 
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(check_stack_trace(f, ops_to_check='last'))
+        self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
 
         topo = f.maker.fgraph.toposort()
         # print [t for t in topo if isinstance(t.op, tensor.Subtensor)]
@@ -2240,7 +2240,7 @@ class test_local_subtensor_merge(unittest.TestCase):
             f = function([x], x[::-1][:idx], mode=mode_opt)
 
             # Check stacktrace was copied over correctly after opt was applied
-            self.assertTrue(check_stack_trace(f, ops_to_check='last'))
+            self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
 
             #theano.printing.debugprint(f, print_type=True)
             topo = f.maker.fgraph.toposort()
@@ -2261,7 +2261,7 @@ class test_local_subtensor_merge(unittest.TestCase):
         f = function([x, y], x[::-1][:y], mode=mode_opt)
 
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(check_stack_trace(f, ops_to_check='last'))
+        self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
 
         #theano.printing.debugprint(f, print_type=True)
 
@@ -2307,7 +2307,7 @@ class test_local_subtensor_merge(unittest.TestCase):
         f = function([x, y, z], x[y:][:z], mode=mode_opt)
 
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(check_stack_trace(f, ops_to_check='last'))
+        self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
 
         #theano.printing.debugprint(f, print_type=True)
 
@@ -2339,7 +2339,7 @@ class test_local_subtensor_merge(unittest.TestCase):
             f = function([x], z, mode=mode_opt)
 
             # Check stacktrace was copied over correctly after opt was applied
-            self.assertTrue(check_stack_trace(f, ops_to_check='last'))
+            self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
 
 
             x_val = self.rng.uniform(size=shape).astype(config.floatX)
@@ -2359,7 +2359,7 @@ class test_local_subtensor_merge(unittest.TestCase):
                      mode=mode_opt)
 
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(check_stack_trace(f, ops_to_check='last'))
+        self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
 
         #theano.printing.debugprint(f, print_type=True)
 
@@ -2447,7 +2447,7 @@ class test_local_subtensor_merge(unittest.TestCase):
         f = function([x, b, e, s, i], x[b:e:s][i], mode=mode_opt)
 
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(check_stack_trace(f, ops_to_check='last'))
+        self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
 
         #theano.printing.debugprint(f, print_type=True)
 
@@ -2538,10 +2538,11 @@ class test_local_subtensor_merge(unittest.TestCase):
             slice1 = slice(*slice_inputs[:3])
             slice2 = slice(*slice_inputs[3:])
             sub_x = x[slice1][slice2]
-            f = theano.function([x] + input_vars, sub_x, mode=mode_opt)
+            f = theano.function([x] + input_vars, sub_x,
+                mode=mode_opt.excluding('local_useless_subtensor'))
 
             # Check stacktrace was copied over correctly after opt was applied
-            self.assertTrue(check_stack_trace(f, ops_to_check='last'))
+            self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
 
             topo = f.maker.fgraph.toposort()
             # print [t for t in topo if isinstance(t.op, tensor.Subtensor)]
@@ -2601,7 +2602,7 @@ class test_local_subtensor_merge(unittest.TestCase):
             f = theano.function([x] + input_vars, sub_x, mode=mode_opt)
 
             # Check stacktrace was copied over correctly after opt was applied
-            self.assertTrue(check_stack_trace(f, ops_to_check='last'))
+            self.assertTrue(check_stack_trace(f, ops_to_check=Subtensor))
 
             topo = f.maker.fgraph.toposort()
             # print [t for t in topo if isinstance(t.op, tensor.Subtensor)]

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -3579,9 +3579,9 @@ class Test_local_useless_alloc(unittest.TestCase):
         # we have to change the following we should not see tensor.Alloc
         # in op_classes and we have to change the assert.
         assert tensor.Alloc in op_classes
+        # self.assertTrue(check_stack_trace(f, ops_to_check=[tensor.Alloc]))
 
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
 
 class Test_local_useless_inc_subtensor_alloc(unittest.TestCase):

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -61,6 +61,7 @@ from theano.tensor.elemwise import DimShuffle
 from theano.tests import unittest_tools as utt
 from theano.compile.mode import optdb
 from theano.compile import Mode
+from theano.gof.opt import check_stack_trace
 from nose.plugins.attrib import attr
 
 mode_opt = theano.config.mode
@@ -111,7 +112,7 @@ class test_dimshuffle_lift(unittest.TestCase):
         dimshuffle_lift.optimize(g)
         self.assertTrue(str(g) == "[x]")
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(g.outputs[0].tag, 'trace'))
+        self.assertTrue(check_stack_trace(g, ops_to_check='all'))
 
     def test_merge2(self):
         x, y, z = inputs()
@@ -123,7 +124,7 @@ class test_dimshuffle_lift(unittest.TestCase):
         dimshuffle_lift.optimize(g)
         self.assertTrue(str(g) == "[DimShuffle{0,1,x,x}(x)]", str(g))
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(g.outputs[0].tag, 'trace'))
+        self.assertTrue(check_stack_trace(g, ops_to_check='all'))
 
     def test_elim3(self):
         x, y, z = inputs()
@@ -136,7 +137,7 @@ class test_dimshuffle_lift(unittest.TestCase):
         dimshuffle_lift.optimize(g)
         self.assertTrue(str(g) == "[x]", str(g))
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(g.outputs[0].tag, 'trace'))
+        self.assertTrue(check_stack_trace(g, ops_to_check='all'))
 
     def test_lift(self):
         x, y, z = inputs([False] * 1, [False] * 2, [False] * 3)
@@ -164,7 +165,7 @@ class test_dimshuffle_lift(unittest.TestCase):
         self.assertTrue(str(g) in (opt_str_g_inplace, opt_str_g_noinplace),
                         str(g))
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(g.outputs[0].tag, 'trace'))
+        self.assertTrue(check_stack_trace(g, ops_to_check='all'))
 
     def test_recursive_lift(self):
         v = T.vector(dtype="float64")
@@ -191,7 +192,7 @@ class test_dimshuffle_lift(unittest.TestCase):
 
         self.assertTrue(str(new_g) == opt_str_g)
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(new_g.outputs[0].tag, 'trace'))
+        self.assertTrue(check_stack_trace(new_g, ops_to_check='all'))
 
     def test_useless_dimshuffle(self):
         x, _, _ = inputs()
@@ -1649,8 +1650,8 @@ def test_local_useless_slice():
 
     # Now test that the stack trace is copied over properly,
     # before before and after optimization.
-    assert hasattr(f_unopt.outputs[0].variable.tag, 'trace')
-    assert hasattr(f_opt.outputs[0].variable.tag, 'trace')
+    assert check_stack_trace(f_unopt, ops_to_check='all')
+    assert check_stack_trace(f_opt, ops_to_check='all')
 
     # test a 4d tensor
     z = tensor.tensor4('z')
@@ -1670,8 +1671,8 @@ def test_local_useless_slice():
 
     # Finally, test that the stack trace is copied over properly,
     # before before and after optimization.
-    assert hasattr(f_opt_check.outputs[0].variable.tag, 'trace')
-    assert hasattr(f_opt_check_apply.outputs[0].variable.tag, 'trace')
+    assert check_stack_trace(f_opt_check, ops_to_check='all')
+    assert check_stack_trace(f_opt_check_apply, ops_to_check='all')
 
 def test_local_useless_inc_subtensor():
     x = tensor.matrix('x')
@@ -1891,7 +1892,7 @@ class test_local_subtensor_make_vector(unittest.TestCase):
         mode = theano.compile.mode.Mode(optimizer=None).including('canonicalize_db').including("local_subtensor_make_vector")
         f = function([x, y, z], v[0], mode=mode)
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(f.outputs[0].variable.tag, 'trace'))
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
         #import ipdb; ipdb.set_trace()
         
         
@@ -1900,21 +1901,17 @@ class test_local_subtensor_make_vector(unittest.TestCase):
         mode = theano.compile.mode.get_mode('FAST_COMPILE').including("local_subtensor_make_vector")
         f = function([x, y, z], v[0], mode=mode)
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(f.outputs[0].variable.tag, 'trace'))
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
         
 
 class test_local_subtensor_lift(unittest.TestCase):
-    def _verify_stack_trace(self, f):
-        for output in f.outputs:
-            # Check stacktrace was copied over correctly after opt was applied
-            self.assertTrue(hasattr(output.variable.tag, 'trace'))
-
     def test0(self):
         # basic test that the Op works
         x = tensor.matrix('x')
         f = function([x], tensor.exp(x)[0], mode=mode_opt)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
         prog = f.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tensor.Subtensor)  # first subtensor
@@ -1928,7 +1925,8 @@ class test_local_subtensor_lift(unittest.TestCase):
         x = tensor.matrix('x')
         f = function([x], [tensor.exp(x)[0], tensor.exp(x)], mode=mode_opt)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
         prog = f.maker.fgraph.toposort()
         assert prog[0].op == tensor.exp
@@ -1944,7 +1942,8 @@ class test_local_subtensor_lift(unittest.TestCase):
         z = tensor.matrix('z')
         f = function([x, y, z], tensor.exp(x + y + z)[0], mode=mode_opt)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
         prog = f.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tensor.DimShuffle)
@@ -1963,7 +1962,8 @@ class test_local_subtensor_lift(unittest.TestCase):
         z = tensor.matrix('z')
         f = function([x, y, z], tensor.exp(x + y + z)[0:2], mode=mode_opt)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
         prog = f.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tensor.DimShuffle)
@@ -1981,7 +1981,8 @@ class test_local_subtensor_lift(unittest.TestCase):
         y = tensor.vector('y')
         f = function([y], tensor.exp(y.dimshuffle(0, 'x'))[0], mode=mode_opt)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
         prog = f.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tensor.DimShuffle)
@@ -1998,7 +1999,8 @@ class test_local_subtensor_lift(unittest.TestCase):
         y = tensor.vector('y')
         f = function([x, y], tensor.exp(x + y)[0], mode=mode_opt)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
         prog = f.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tensor.DimShuffle)
@@ -2016,7 +2018,8 @@ class test_local_subtensor_lift(unittest.TestCase):
         f = function([x, y], [tensor.exp(x + y)[0], tensor.exp(x + y) + x],
                      mode=mode_opt)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
         prog = f.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tensor.DimShuffle)
@@ -2036,7 +2039,8 @@ class test_local_subtensor_lift(unittest.TestCase):
         y = tensor.scalar('y')
         f = function([x, y], tensor.exp(x + y)[0], mode=mode_opt)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
         prog = f.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tensor.Subtensor)
@@ -2057,7 +2061,8 @@ class test_local_subtensor_lift(unittest.TestCase):
         assert newx.broadcastable == (True, False)
 
         f1 = function([x], newx[:2, :5], mode=mode_opt)
-        self._verify_stack_trace(f1)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f1, ops_to_check='all'))
         prog = f1.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tensor.Subtensor)
         assert isinstance(prog[1].op, tensor.Rebroadcast)
@@ -2071,7 +2076,8 @@ class test_local_subtensor_lift(unittest.TestCase):
         assert newy.broadcastable == (True, False, True, False)
 
         f2 = function([y], newy[:, 3, 0, :], mode=mode_opt)
-        self._verify_stack_trace(f2)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f2, ops_to_check='all'))
         prog = f2.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tensor.Subtensor)
         assert isinstance(prog[1].op, tensor.Rebroadcast)
@@ -2079,7 +2085,8 @@ class test_local_subtensor_lift(unittest.TestCase):
 
         # corner case 2: subtensor idx_list is shorter than resulting broadcast pattern
         f3 = function([y], newy[:, 3, 0], mode=mode_opt)
-        self._verify_stack_trace(f3)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f3, ops_to_check='all'))
         prog = f3.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tensor.Subtensor)
         assert isinstance(prog[1].op, tensor.Rebroadcast)
@@ -2094,7 +2101,8 @@ class test_local_subtensor_lift(unittest.TestCase):
 
         out = newz[:, 3, 0]
         f4 = function([z], newz[:, 3, 0], mode=mode_opt)
-        self._verify_stack_trace(f4)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f4, ops_to_check='all'))
         prog = f4.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tensor.Subtensor)
         assert isinstance(prog[1].op, tensor.Rebroadcast)
@@ -2102,11 +2110,6 @@ class test_local_subtensor_lift(unittest.TestCase):
 
 
 class test_local_subtensor_merge(unittest.TestCase):
-    def _verify_stack_trace(self, f):
-        for output in f.outputs:
-            # Check stacktrace was copied over correctly after opt was applied
-            self.assertTrue(hasattr(output.variable.tag, 'trace'))
-
     def setUp(self):
         utt.seed_rng()
         self.x_shapes = [(2, 2), (5, 3), (4, 1), (1, 2),
@@ -2121,7 +2124,8 @@ class test_local_subtensor_merge(unittest.TestCase):
             g = function([x], x[idx::][-1], mode=mode_opt.excluding(
                 'local_subtensor_merge'))
 
-            self._verify_stack_trace(f)
+            # Check stacktrace was copied over correctly after opt was applied
+            self.assertTrue(check_stack_trace(f, ops_to_check='last'))
 
             topo = f.maker.fgraph.toposort()
             assert len([t for t in topo
@@ -2149,7 +2153,8 @@ class test_local_subtensor_merge(unittest.TestCase):
                      mode=mode_opt.excluding('local_subtensor_merge'))
         #theano.printing.debugprint(f, print_type=True)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='last'))
 
         topo = f.maker.fgraph.toposort()
         # print [t for t in topo if isinstance(t.op, tensor.Subtensor)]
@@ -2178,7 +2183,8 @@ class test_local_subtensor_merge(unittest.TestCase):
             g = function([x], x[::-1][idx],
                          mode=mode_opt.excluding('local_subtensor_merge'))
 
-            self._verify_stack_trace(f)
+            # Check stacktrace was copied over correctly after opt was applied
+            self.assertTrue(check_stack_trace(f, ops_to_check='last'))
 
             #theano.printing.debugprint(f, print_type=True)
             topo = f.maker.fgraph.toposort()
@@ -2208,7 +2214,8 @@ class test_local_subtensor_merge(unittest.TestCase):
                      mode=mode_opt.excluding('local_subtensor_merge'))
         #theano.printing.debugprint(f, print_type=True)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='last'))
 
         topo = f.maker.fgraph.toposort()
         # print [t for t in topo if isinstance(t.op, tensor.Subtensor)]
@@ -2232,7 +2239,8 @@ class test_local_subtensor_merge(unittest.TestCase):
         for idx in xrange(-9, 8):
             f = function([x], x[::-1][:idx], mode=mode_opt)
 
-            self._verify_stack_trace(f)
+            # Check stacktrace was copied over correctly after opt was applied
+            self.assertTrue(check_stack_trace(f, ops_to_check='last'))
 
             #theano.printing.debugprint(f, print_type=True)
             topo = f.maker.fgraph.toposort()
@@ -2252,7 +2260,8 @@ class test_local_subtensor_merge(unittest.TestCase):
         y = tensor.iscalar('y')
         f = function([x, y], x[::-1][:y], mode=mode_opt)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='last'))
 
         #theano.printing.debugprint(f, print_type=True)
 
@@ -2275,7 +2284,8 @@ class test_local_subtensor_merge(unittest.TestCase):
             for idx2 in xrange(-7, 7):
                 f = function([x], x[idx1:][:idx2], mode=mode_opt)
 
-                self._verify_stack_trace(f)
+                # Check stacktrace was copied over correctly after opt was applied
+                self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
                 #theano.printing.debugprint(f, print_type=True)
                 topo = f.maker.fgraph.toposort()
@@ -2296,7 +2306,8 @@ class test_local_subtensor_merge(unittest.TestCase):
         z = tensor.iscalar('y')
         f = function([x, y, z], x[y:][:z], mode=mode_opt)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='last'))
 
         #theano.printing.debugprint(f, print_type=True)
 
@@ -2327,7 +2338,8 @@ class test_local_subtensor_merge(unittest.TestCase):
             z = x[slice(*sl1)][slice(*sl2)]
             f = function([x], z, mode=mode_opt)
 
-            self._verify_stack_trace(f)
+            # Check stacktrace was copied over correctly after opt was applied
+            self.assertTrue(check_stack_trace(f, ops_to_check='last'))
 
 
             x_val = self.rng.uniform(size=shape).astype(config.floatX)
@@ -2346,7 +2358,8 @@ class test_local_subtensor_merge(unittest.TestCase):
         f = function([x, b1, e1, s1, b2, e2, s2], x[b1:e1:s1][b2:e2:s2],
                      mode=mode_opt)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='last'))
 
         #theano.printing.debugprint(f, print_type=True)
 
@@ -2433,7 +2446,8 @@ class test_local_subtensor_merge(unittest.TestCase):
         i = tensor.iscalar('i')
         f = function([x, b, e, s, i], x[b:e:s][i], mode=mode_opt)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='last'))
 
         #theano.printing.debugprint(f, print_type=True)
 
@@ -2526,8 +2540,8 @@ class test_local_subtensor_merge(unittest.TestCase):
             sub_x = x[slice1][slice2]
             f = theano.function([x] + input_vars, sub_x, mode=mode_opt)
 
-            self._verify_stack_trace(f)
-
+            # Check stacktrace was copied over correctly after opt was applied
+            self.assertTrue(check_stack_trace(f, ops_to_check='last'))
 
             topo = f.maker.fgraph.toposort()
             # print [t for t in topo if isinstance(t.op, tensor.Subtensor)]
@@ -2586,7 +2600,8 @@ class test_local_subtensor_merge(unittest.TestCase):
             sub_x = x[symbol_slice][i]
             f = theano.function([x] + input_vars, sub_x, mode=mode_opt)
 
-            self._verify_stack_trace(f)
+            # Check stacktrace was copied over correctly after opt was applied
+            self.assertTrue(check_stack_trace(f, ops_to_check='last'))
 
             topo = f.maker.fgraph.toposort()
             # print [t for t in topo if isinstance(t.op, tensor.Subtensor)]
@@ -2718,14 +2733,14 @@ class test_local_adv_sub1_adv_inc_sub1(unittest.TestCase):
         mode = theano.compile.mode.Mode(optimizer=None).including('canonicalize').including("local_adv_sub1_adv_inc_sub1")
         f = theano.function([x, y, idx], o, self.mode)
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(f.outputs[0].variable.tag, 'trace'))
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
         # Compile function using all optimizations in fast_compile mode, 
         # including the 'local_subtensor_make_vector' optimization
         mode = theano.compile.mode.get_mode('FAST_COMPILE').including("local_adv_sub1_adv_inc_sub1")
         f = theano.function([x, y, idx], o, self.mode)
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(f.outputs[0].variable.tag, 'trace'))
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
 
 class Test_alloc_zero(unittest.TestCase):
@@ -2930,7 +2945,7 @@ def test_local_IncSubtensor_serialize():
     # Now test that the stack trace is copied over properly,
     # if we return the gradients. We need to use same mode as before.
     f = theano.function([i, j, t], dW, mode=mode)
-    assert hasattr(f.outputs[0].variable.tag, 'trace')
+    assert check_stack_trace(f, ops_to_check='all')
         
 def test_local_set_to_inc_subtensor():
     v = theano.tensor.fmatrix()
@@ -2962,8 +2977,8 @@ def test_local_set_to_inc_subtensor():
 
     # Finally, test that the stack trace is copied over properly,
     # before before and after optimization.
-    assert hasattr(f1.outputs[0].variable.tag, 'trace')
-    assert hasattr(f2.outputs[0].variable.tag, 'trace')
+    assert check_stack_trace(f1, ops_to_check='all')
+    assert check_stack_trace(f2, ops_to_check='all')
     
     
 def test_local_subtensor_of_dot():
@@ -2998,14 +3013,14 @@ def test_local_subtensor_of_dot():
     f = theano.function([m1, m2, idx], theano.dot(m1, m2)[idx, 1:4, :, idx:], mode=mode)
     assert test_equality(f(d1, d2, 1), numpy.dot(d1, d2)[1, 1:4, :, 1:])
     # if we return the gradients. We need to use same mode as before.
-    assert hasattr(f.outputs[0].variable.tag, 'trace')
+    assert check_stack_trace(f, ops_to_check='last')
 
     f = theano.function([m1, m2, idx], theano.dot(m1, m2)[1:4, :, idx:, idx], mode=mode)
     assert test_equality(f(d1, d2, 1), numpy.dot(d1, d2)[1:4, :, 1:, 1])
 
     # Now test that the stack trace is copied over properly,
     # if we return the gradients. We need to use same mode as before.
-    assert hasattr(f.outputs[0].variable.tag, 'trace')
+    assert check_stack_trace(f, ops_to_check='last')
 
 
 class Test_local_elemwise_alloc(unittest.TestCase):
@@ -3052,11 +3067,6 @@ class Test_local_elemwise_alloc(unittest.TestCase):
                  if elem.op is not None]) == count
         )
 
-    def _verify_stack_trace(self, f):
-        for output in f.outputs:
-            # Check stacktrace was copied over correctly after opt was applied
-            self.assertTrue(hasattr(output.variable.tag, 'trace'))
-
     def test_remove_alloc_wo_dimshuffle(self):
         # No optimization on alloc
         func = function(
@@ -3066,7 +3076,8 @@ class Test_local_elemwise_alloc(unittest.TestCase):
         )
         self._verify_alloc_count(func, 1)
         self._verify_assert_count(func, 0)
-        self._verify_stack_trace(func)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(func, ops_to_check='all'))
 
         # Optimization on alloc with assert
         func = function(
@@ -3509,11 +3520,6 @@ class Test_local_useless_elemwise_comparison(unittest.TestCase):
 
 
 class Test_local_useless_alloc(unittest.TestCase):
-    def _verify_stack_trace(self, f):
-        for output in f.outputs:
-            # Check stacktrace was copied over correctly after opt was applied
-            self.assertTrue(hasattr(output.variable.tag, 'trace'))
-
     def setUp(self):
         self.rng = numpy.random.RandomState(utt.fetch_seed())
 
@@ -3534,7 +3540,8 @@ class Test_local_useless_alloc(unittest.TestCase):
         if isinstance(mode_opt, compile.DebugMode):
             self.assertRaises(ValueError, f)
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
     def test1(self):
         # Test that alloc never gets instantiated during optimization
@@ -3549,7 +3556,8 @@ class Test_local_useless_alloc(unittest.TestCase):
         op_classes = [node.op.__class__ for node in f.maker.fgraph.toposort()]
         assert tensor.Alloc not in op_classes
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
     def test2(self):
         # Test that alloc never gets instantiated during optimization
@@ -3569,16 +3577,12 @@ class Test_local_useless_alloc(unittest.TestCase):
         # in op_classes and we have to change the assert.
         assert tensor.Alloc in op_classes
 
-        self._verify_stack_trace(f)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f, ops_to_check='all'))
 
 
 class Test_local_useless_inc_subtensor_alloc(unittest.TestCase):
     opt_name = 'local_useless_inc_subtensor_alloc'
-
-    def _verify_stack_trace(self, f):
-        for output in f.outputs:
-            # Check stacktrace was copied over correctly after opt was applied
-            self.assertTrue(hasattr(output.variable.tag, 'trace'))
 
     def setUp(self):
         # The optimization requires the shape feature so we need to compile in
@@ -3617,8 +3621,9 @@ class Test_local_useless_inc_subtensor_alloc(unittest.TestCase):
 
         utt.assert_allclose(r1, r2)
         
-        self._verify_stack_trace(f1)
-        self._verify_stack_trace(f2)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f1, ops_to_check='all'))
+        self.assertTrue(check_stack_trace(f2, ops_to_check='all'))
         
 
     def test_advanced_inc_subtensor1(self):
@@ -3650,8 +3655,9 @@ class Test_local_useless_inc_subtensor_alloc(unittest.TestCase):
 
         utt.assert_allclose(r1, r2)
         
-        self._verify_stack_trace(f1)
-        self._verify_stack_trace(f2)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f1, ops_to_check='all'))
+        self.assertTrue(check_stack_trace(f2, ops_to_check='all'))
 
     def test_incsubtensor(self):
         x = tensor.vector('x')
@@ -3679,8 +3685,9 @@ class Test_local_useless_inc_subtensor_alloc(unittest.TestCase):
 
         utt.assert_allclose(r1, r2)
         
-        self._verify_stack_trace(f1)
-        self._verify_stack_trace(f2)
+        # Check stacktrace was copied over correctly after opt was applied
+        self.assertTrue(check_stack_trace(f1, ops_to_check='last'))
+        self.assertTrue(check_stack_trace(f2, ops_to_check='last'))
 
 
 class test_shapeoptimizer(unittest.TestCase):
@@ -4050,7 +4057,7 @@ class T_Tile(unittest.TestCase):
                 f(data)
                 
                 # Check that stacktrace is copied over
-                self.assertTrue(hasattr(f.outputs[0].variable.tag, 'trace'))
+                self.assertTrue(check_stack_trace(f, ops_to_check='all'))
                 self.assertTrue(len(f.outputs[0].variable.tag.trace)>0)
 
 
@@ -4190,7 +4197,7 @@ class T_Rebroadcast(unittest.TestCase):
         e = f.maker.fgraph.toposort()
         assert len([n for n in e if isinstance(n.op, T.Rebroadcast)]) == 0
 
-        assert hasattr(f.outputs[0].variable.tag, 'trace')
+        assert check_stack_trace(f, ops_to_check='all')
 
     def test_rebroadcast_rebroadcast(self):
         mode = theano.compile.get_default_mode().including('canonicalize')
@@ -5818,8 +5825,7 @@ def test_local_join_make_vector():
                 for n in e if isinstance(n.op, Join)])
     assert f.maker.fgraph.outputs[0].dtype == config.floatX
 
-    assert hasattr(f.outputs[0].variable, 'tag')
-    assert hasattr(f.outputs[0].variable.tag, 'trace')
+    assert check_stack_trace(f, ops_to_check='all')
 
 
 def test_local_add_specialize():
@@ -5922,9 +5928,9 @@ def test_local_useless_split():
     assert isinstance(graph_nonopt[0].op, tensor.Split)
 
     # Check that stacktraces have been copied over properly
-    assert hasattr(f_opt.outputs[0].variable.tag, 'trace')
+    assert check_stack_trace(f_opt, ops_to_check='all')
     assert len(f_opt.outputs[0].variable.tag.trace) > 0
-    assert hasattr(f_nonopt.outputs[0].variable.tag, 'trace')
+    assert check_stack_trace(f_nonopt, ops_to_check='all')
     assert len(f_nonopt.outputs[0].variable.tag.trace) > 0
 
 
@@ -5998,7 +6004,7 @@ class Test_lift_transpose_through_dot(unittest.TestCase):
         sg = '[dot(DimShuffle{1,0}(b), DimShuffle{1,0}(a))]'
         assert str(g) == sg, (str(g), sg)
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(g.outputs[0].tag, 'trace'))
+        self.assertTrue(check_stack_trace(g, ops_to_check='all'))
 
     def test_row_matrix(self):
         a = vector('a')
@@ -6010,7 +6016,7 @@ class Test_lift_transpose_through_dot(unittest.TestCase):
         sg = '[dot(DimShuffle{1,0}(b), DimShuffle{0,x}(a))]'
         assert str(g) == sg, (str(g), sg)
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(g.outputs[0].tag, 'trace'))
+        self.assertTrue(check_stack_trace(g, ops_to_check='all'))
 
     def test_matrix_col(self):
         a = vector('a')
@@ -6022,7 +6028,7 @@ class Test_lift_transpose_through_dot(unittest.TestCase):
         sg = '[dot(DimShuffle{x,0}(a), DimShuffle{1,0}(b))]'
         assert str(g) == sg, (str(g), sg)
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(g.outputs[0].tag, 'trace'))
+        self.assertTrue(check_stack_trace(g, ops_to_check='all'))
 
 
 def test_local_upcast_elemwise_constant_inputs():

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -1889,16 +1889,14 @@ class test_local_subtensor_make_vector(unittest.TestCase):
         # which requires us to add the 'canonicalize' phase.
         mode = theano.compile.mode.Mode(optimizer=None).including('canonicalize_db').including("local_subtensor_make_vector")
         f = function([x, y, z], v[0], mode=mode)
-        # The resulting graph only has a DeepCopyOp, for which the
-        # copy_stack_trace is not called. (See issue #4421)
-        # self.assertTrue(check_stack_trace(f, ops_to_check='all'))
-        
+
         # Compile function using all optimizations in fast_compile mode, 
         # including the 'local_subtensor_make_vector' optimization
         mode = theano.compile.mode.get_mode('FAST_COMPILE').including("local_subtensor_make_vector")
         f = function([x, y, z], v[0], mode=mode)
-        # The resulting graph only has a DeepCopyOp, for which the
-        # copy_stack_trace is not called. (See issue #4421)
+
+        # The two cases in this test do not check the case where
+        # local_subtensor_make_vector inserts a Subtensor node (See issue #4421)
         # self.assertTrue(check_stack_trace(f, ops_to_check='all'))
         
 
@@ -3551,8 +3549,8 @@ class Test_local_useless_alloc(unittest.TestCase):
         if isinstance(mode_opt, compile.DebugMode):
             self.assertRaises(ValueError, f)
 
-        # No need to check_stack_trace as the graph only contains
-        # DeepCopyOp which has empty trace
+        # No need to check_stack_trace as the optimization
+        # local_useless_alloc only removes nodes.
 
     def test1(self):
         # Test that alloc never gets instantiated during optimization
@@ -3567,8 +3565,8 @@ class Test_local_useless_alloc(unittest.TestCase):
         op_classes = [node.op.__class__ for node in f.maker.fgraph.toposort()]
         assert tensor.Alloc not in op_classes
 
-        # No need to check_stack_trace as the graph only contains
-        # DeepCopyOp which has empty trace
+        # No need to check_stack_trace as the optimization
+        # local_useless_alloc only removes nodes.
 
     def test2(self):
         # Test that alloc never gets instantiated during optimization


### PR DESCRIPTION
Modified test_opt.py to use check_stack_trace and modified check_stack_trace to loop over outputs for ops_to_check=last and some refactoring

fix #4379 