### PR TITLE
reshape to 1 is replace with dimshuffle

### DIFF
--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -3984,8 +3984,10 @@ register_canonicalize(local_reshape_chain(T.Reshape),
 @gof.local_optimizer([T.Reshape])
 def local_useless_reshape(node):
     """
-    Remove Reshape when both the input and the output have a
-    single dimension.
+    Broadcastable dimensions in reshpae are replaced with dimshuffle.
+    For example:
+        - reshape(x, (1, n)) --> dimshuffle{x,0}(reshape(x, (n,))
+        - reshape(x, (1, m, 1, n, 1, 1)) --> dimshuffle{x,0,x,1,x,x}(reshape(x, (m, n)))
 
     """
     op = node.op

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -47,7 +47,7 @@ from theano.tensor.type import (values_eq_approx_remove_inf,
 from theano.gof.opt import (Optimizer, pre_constant_merge,
                             pre_greedy_local_optimizer)
 from theano.gof import toolbox
-from theano.tensor.basic import get_scalar_constant_value, ShapeError, NotScalarConstantError
+from theano.tensor.basic import Reshape, get_scalar_constant_value, ShapeError, NotScalarConstantError
 from six import StringIO
 
 _logger = logging.getLogger('theano.tensor.opt')
@@ -3987,11 +3987,31 @@ def local_useless_reshape(node):
     single dimension.
 
     """
-    if isinstance(node.op, T.Reshape):
-        if (node.inputs[0].ndim == 1 and node.outputs[0].ndim == 1 and
-                node.inputs[0].broadcastable ==
-                node.outputs[0].broadcastable):
-            return [node.inputs[0]]
+    op = node.op
+    if not isinstance(op, Reshape):
+        return False
+
+    input = node.inputs[0]
+    output = node.outputs[0]
+    output_shape = node.inputs[1]
+
+    if (input.ndim == 1 and output.ndim == 1 and
+            input.broadcastable == output.broadcastable):
+        return [input]
+
+    dimshuffle_new_order = []
+    new_output_shape = []
+    i = 0  # index over the output of the new reshape
+    for dim in output_shape.value:
+        if dim == 1:
+            dimshuffle_new_order.append('x')
+        else:
+            dimshuffle_new_order.append(i)
+            new_output_shape.append(dim)
+            i = i + 1
+    if len(dimshuffle_new_order) > 0:
+        inner = op.__class__(len(new_output_shape))(input, new_output_shape)
+        return [DimShuffle(inner.type.broadcastable, dimshuffle_new_order)(inner)]
 
 
 @register_canonicalize

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -4002,16 +4002,16 @@ def local_useless_reshape(node):
 
     dimshuffle_new_order = []
     new_output_shape = []
-    i = 0  # index over the output of the new reshape
-    import ipdb; ipdb.set_trace()
-    for dim in extract_constant(output_shape, only_process_constants=True):
+    index = 0  # index over the output of the new reshape
+    for i in xrange(output.ndim):
+        dim = extract_constant(output_shape[i], only_process_constants=False)
         if dim == 1:
             dimshuffle_new_order.append('x')
         else:
-            dimshuffle_new_order.append(i)
+            dimshuffle_new_order.append(index)
             new_output_shape.append(dim)
-            i = i + 1
-    if i != output.ndim:
+            index = index + 1
+    if index != output.ndim:
         inner = op.__class__(len(new_output_shape))(input, new_output_shape)
         return [DimShuffle(inner.type.broadcastable, dimshuffle_new_order)(inner)]
 

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -4013,7 +4013,10 @@ def local_useless_reshape(node):
             index = index + 1
     if index != output.ndim:
         inner = op.__class__(len(new_output_shape))(input, new_output_shape)
-        return [DimShuffle(inner.type.broadcastable, dimshuffle_new_order)(inner)]
+        copy_stack_trace(output, inner)
+        new_node = [DimShuffle(inner.type.broadcastable, dimshuffle_new_order)(inner)]
+        copy_stack_trace(output, new_node)
+        return new_node
 
 
 @register_canonicalize

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -47,7 +47,8 @@ from theano.tensor.type import (values_eq_approx_remove_inf,
 from theano.gof.opt import (Optimizer, pre_constant_merge,
                             pre_greedy_local_optimizer)
 from theano.gof import toolbox
-from theano.tensor.basic import Reshape, get_scalar_constant_value, ShapeError, NotScalarConstantError
+from theano.tensor.basic import (Reshape, get_scalar_constant_value, ShapeError,
+                                 extract_constant, NotScalarConstantError)
 from six import StringIO
 
 _logger = logging.getLogger('theano.tensor.opt')
@@ -4002,14 +4003,15 @@ def local_useless_reshape(node):
     dimshuffle_new_order = []
     new_output_shape = []
     i = 0  # index over the output of the new reshape
-    for dim in output_shape.get_scalar_constant_value():
+    import ipdb; ipdb.set_trace()
+    for dim in extract_constant(output_shape, only_process_constants=True):
         if dim == 1:
             dimshuffle_new_order.append('x')
         else:
             dimshuffle_new_order.append(i)
             new_output_shape.append(dim)
             i = i + 1
-    if len(dimshuffle_new_order) > 0:
+    if i != output.ndim:
         inner = op.__class__(len(new_output_shape))(input, new_output_shape)
         return [DimShuffle(inner.type.broadcastable, dimshuffle_new_order)(inner)]
 

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -4002,7 +4002,7 @@ def local_useless_reshape(node):
     dimshuffle_new_order = []
     new_output_shape = []
     i = 0  # index over the output of the new reshape
-    for dim in output_shape.value:
+    for dim in output_shape.get_scalar_constant_value():
         if dim == 1:
             dimshuffle_new_order.append('x')
         else:

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -5195,9 +5195,10 @@ class T_reshape(utt.InferShapeTester, utt.TestOptimizationMixin):
         # test broadcast flag for constant value of 1
         c = reshape(b, (b.shape[0], b.shape[1], 1))
         f = self.function([b], c)
+        g = theano.gof.FunctionGraph([b], [c])
         assert numpy.all(f(numpy.asarray([[0, 1, 2], [3, 4, 5]])) ==
                          numpy.asarray([[[0], [1], [2]], [[3], [4], [5]]]))
-        assert (f.maker.fgraph.toposort()[-2].outputs[0].type.broadcastable ==
+        assert (g.toposort()[-1].outputs[0].type.broadcastable ==
                 (False, False, True))
 
     def test_m1(self):

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -5976,7 +5976,6 @@ class Test_local_useless_reshape(unittest.TestCase):
                                   "TensorConstant{[5 6]}))]")
 
         # Check stacktrace was copied over correctly after opt was applied
-        self.assertTrue(hasattr(g.outputs[0].tag, 'trace'))
         check_stack_trace(g, ops_to_check=(T.DimShuffle, T.Reshape))
 
 

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -5968,16 +5968,15 @@ class Test_local_useless_reshape(unittest.TestCase):
                                    "TensorConstant{[1 5 1 6 1 1]})]"))
 
         reshape_lift.optimize(g)
-        import ipdb; ipdb.set_trace()
         self.assertTrue(str(g) == "[DimShuffle{x,0}"
-                                  "(Reshape{2}(<TensorType(float64, vector)>, "
-                                  "TensorConstant{4})), "
+                                  "(<TensorType(float64, vector)>), "
                                   "DimShuffle{x,0,x,1,x,x}"
-                                  "Reshape{6}(<TensorType(float64, matrix)>, "
-                                  "TensorConstant{[5 6]})]")
+                                  "(Reshape{2}(<TensorType(float64, matrix)>, "
+                                  "TensorConstant{[5 6]}))]")
 
         # Check stacktrace was copied over correctly after opt was applied
         self.assertTrue(hasattr(g.outputs[0].tag, 'trace'))
+
 
 def test_local_reshape_lift():
     x = tensor.tensor4()

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -61,6 +61,7 @@ from theano.tensor.elemwise import DimShuffle
 from theano.tests import unittest_tools as utt
 from theano.compile.mode import optdb
 from theano.compile import Mode
+from theano.gof.opt import check_stack_trace
 from nose.plugins.attrib import attr
 
 mode_opt = theano.config.mode
@@ -5976,6 +5977,7 @@ class Test_local_useless_reshape(unittest.TestCase):
 
         # Check stacktrace was copied over correctly after opt was applied
         self.assertTrue(hasattr(g.outputs[0].tag, 'trace'))
+        check_stack_trace(g, ops_to_check=(T.DimShuffle, T.Reshape))
 
 
 def test_local_reshape_lift():


### PR DESCRIPTION
Regarding issue #4073 .
Hi,
The PR is not complete yet. It seems that during replacing the node with the optimized node, it gets stuck in an infinite loop. It is not exactly clear to me why it is not the case for ```Alloc``` but it here with ```Reshape``` we have this problem.