### PR TITLE
fixes the 'float64' in RNNs

### DIFF
--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -5227,7 +5227,7 @@ def local_opt_alloc(node):
                                if i in node.op.axis]
                     if to_prod:
                         if isinstance(node.op, T.Sum):
-                            val *= T.mul(*to_prod)
+                            val *= T.mul(*to_prod).astype(str(val.dtype))
                         else:
                             val = val ** T.mul(*to_prod)
                     return [T.alloc(T.cast(val, dtype=node.outputs[0].dtype),

--- a/theano/tests/test_raise_on_float64.py
+++ b/theano/tests/test_raise_on_float64.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import, print_function, division
+
+__author__ = "deepworx"
+__contact__ = "deepworx@GitHub"
+
+import unittest
+import theano, numpy
+
+class RaiseOnFloat64(unittest.TestCase):
+    s = theano.tensor.lscalar()
+    a = theano.tensor.alloc(numpy.asarray(5, dtype='float32'), s, s)
+    orig = theano.config.warn_float64
+    theano.config.warn_float64 = "raise"
+    try:
+        f = theano.function([s], a.sum())
+        theano.printing.debugprint(f)
+        f(5)
+    finally:
+        theano.config.warn_float64 = orig


### PR DESCRIPTION
wastes memory and breaks when warn_float64=raise