### PR TITLE
adding variable name in error messages raised by calling a function

### DIFF
--- a/theano/compile/function_module.py
+++ b/theano/compile/function_module.py
@@ -822,10 +822,14 @@ class Function(object):
 
                     except Exception as e:
                         function_name = "theano function"
+                        argument_name = "argument"
                         if self.name:
-                            function_name += ' with name "' + self.name + '" '
-                        e.args = ("Bad input argument to " + function_name +
-                                  " at index %d(0-based)" % i,) + e.args
+                            function_name += ' with name "' + self.name + '"'
+                        if arg.name:
+                            argument_name += ' with name "' + arg.name + '"'
+                        e.args = ("Bad input " + argument_name + " to "
+                                  + function_name + " at index %d (0-based)"
+                                  % i,) + e.args
                         raise
                 s.provided += 1
                 i += 1

--- a/theano/compile/function_module.py
+++ b/theano/compile/function_module.py
@@ -825,7 +825,7 @@ class Function(object):
                         argument_name = "argument"
                         if self.name:
                             function_name += ' with name "' + self.name + '"'
-                        if arg.name:
+                        if hasattr(arg, 'name') and arg.name:
                             argument_name += ' with name "' + arg.name + '"'
                         e.args = ("Bad input " + argument_name + " to " +
                                   function_name + " at index %d (0-based)"

--- a/theano/compile/function_module.py
+++ b/theano/compile/function_module.py
@@ -827,8 +827,8 @@ class Function(object):
                             function_name += ' with name "' + self.name + '"'
                         if arg.name:
                             argument_name += ' with name "' + arg.name + '"'
-                        e.args = ("Bad input " + argument_name + " to "
-                                  + function_name + " at index %d (0-based)"
+                        e.args = ("Bad input " + argument_name + " to " +
+                                  function_name + " at index %d (0-based)"
                                   % i,) + e.args
                         raise
                 s.provided += 1


### PR DESCRIPTION
This patch is intended to resolve #4445.

The added code basically adds argument name to the error message and removes weird trailing space in function name for the same error message.

The example traceback is as follows:

```
Traceback (most recent call last):
  File "script.py", line 28, in <module>
    y = predict(X)  # y = T.dot(X, W) work fine
  File "/usr/local/lib/python2.7/dist-packages/Theano-0.9.0.dev1-py2.7.egg/theano/compile/function_module.py", line 821, in __call__
    allow_downcast=s.allow_downcast)
  File "/usr/local/lib/python2.7/dist-packages/Theano-0.9.0.dev1-py2.7.egg/theano/tensor/type.py", line 87, in filter
    'Expected an array-like object, but found a Variable: '
TypeError: ('Bad input argument with name "X" to theano function with name "script.py:26" at index 0(0-based)', 'Expected an array-like object, but found a Variable: maybe you are trying to call a function on a (possibly shared) variable instead of a numeric array?')
```