### PR TITLE
[nit] Fix typo in tensor/basic.txt: lacks a space

### DIFF
--- a/doc/library/tensor/basic.txt
+++ b/doc/library/tensor/basic.txt
@@ -1414,7 +1414,7 @@ Mathematical
 
 .. function:: abs_(a)
 
-    Returns a variable representingthe absolute of a, ie ``|a|``.
+    Returns a variable representing the absolute of a, ie ``|a|``.
 
     .. note:: Can also be accessed with ``abs(a)``.
 


### PR DESCRIPTION
:v: 