### PR TITLE
Implementation of 2D dilated convolution/correlation.

### DIFF
--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -1393,6 +1393,9 @@ def local_abstractconv_cudnn(node):
     inp1 = node.inputs[0]
     inp2 = node.inputs[1]
 
+    if (node.op.filter_dilation != (1, 1)):
+        return None
+
     if not isinstance(inp1.type, GpuArrayType):
         return None
 

--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -2612,6 +2612,8 @@ def local_abstractconv_cudnn(node):
                                  AbstractConv2d_gradWeights,
                                  AbstractConv2d_gradInputs))):
         return None
+    if (node.op.filter_dilation != (1, 1)):
+        return None
 
     inp1 = node.inputs[0]
     inp2 = node.inputs[1]
@@ -2619,6 +2621,7 @@ def local_abstractconv_cudnn(node):
     if (not isinstance(inp1.type, CudaNdarrayType) or
             not isinstance(inp2.type, CudaNdarrayType)):
         return None
+
     if not dnn_available():
         return None
 

--- a/theano/sandbox/cuda/tests/test_abstractconv.py
+++ b/theano/sandbox/cuda/tests/test_abstractconv.py
@@ -29,25 +29,30 @@ class TestDnnConv2d(test_abstract_conv.BaseTestConv2d):
         self.provide_shape = [False]
         self.shared = gpu_shared
 
-    def tcase(self, i, f, s, b, flip, provide_shape):
+    def tcase(self, i, f, s, b, flip, provide_shape, fd=(1, 1)):
+        if fd != (1, 1):
+            raise SkipTest("No dilation implementation for cuDNN ConvOp.")
         if not dnn_available():
             raise SkipTest(cuda.dnn.dnn_available.msg)
         mode = mode_with_gpu
-        o = self.get_output_shape(i, f, s, b)
+        o = self.get_output_shape(i, f, s, b, fd)
         self.run_fwd(inputs_shape=i, filters_shape=f, subsample=s,
                      verify_grad=True, mode=mode,
                      provide_shape=provide_shape, border_mode=b,
-                     filter_flip=flip, target_op=GpuDnnConv)
+                     filter_flip=flip, target_op=GpuDnnConv,
+                     filter_dilation=fd)
         self.run_gradweight(inputs_shape=i, filters_shape=f,
                             output_shape=o, subsample=s,
                             verify_grad=True, mode=mode,
                             provide_shape=provide_shape, border_mode=b,
-                            filter_flip=flip, target_op=GpuDnnConvGradW)
+                            filter_flip=flip, target_op=GpuDnnConvGradW,
+                            filter_dilation=fd)
         self.run_gradinput(inputs_shape=i, filters_shape=f,
                            output_shape=o, subsample=s,
                            verify_grad=True, mode=mode,
                            provide_shape=provide_shape, border_mode=b,
-                           filter_flip=flip, target_op=GpuDnnConvGradI)
+                           filter_flip=flip, target_op=GpuDnnConvGradI,
+                           filter_dilation=fd)
 
 
 class TestCorrMMConv2d(test_abstract_conv.BaseTestConv2d):
@@ -56,28 +61,30 @@ class TestCorrMMConv2d(test_abstract_conv.BaseTestConv2d):
         self.shared = gpu_shared
         self.mode = mode_with_gpu.excluding('cudnn')
 
-    def tcase(self, i, f, s, b, flip, provide_shape):
+    def tcase(self, i, f, s, b, flip, provide_shape, fd=(1, 1)):
         mode = self.mode
-        o = self.get_output_shape(i, f, s, b)
-        self.run_fwd(inputs_shape=i, filters_shape=f, subsample=s,
-                     verify_grad=True, mode=mode,
+        o = self.get_output_shape(i, f, s, b, fd)
+        self.run_fwd(inputs_shape=i, filters_shape=f,
+                     subsample=s, verify_grad=True, mode=mode,
                      provide_shape=provide_shape, border_mode=b,
-                     filter_flip=flip,
-                     target_op=(GpuCorrMM,
-                                GpuCorrMM_gradWeights,
-                                GpuCorrMM_gradInputs))
+                     filter_flip=flip, target_op=(GpuCorrMM,
+                                                  GpuCorrMM_gradWeights,
+                                                  GpuCorrMM_gradInputs),
+                     filter_dilation=fd)
         self.run_gradweight(inputs_shape=i, filters_shape=f,
                             output_shape=o, subsample=s,
                             verify_grad=True, mode=mode,
                             provide_shape=provide_shape, border_mode=b,
                             filter_flip=flip,
-                            target_op=GpuCorrMM_gradWeights)
+                            target_op=GpuCorrMM_gradWeights,
+                            filter_dilation=fd)
         self.run_gradinput(inputs_shape=i, filters_shape=f,
                            output_shape=o, subsample=s,
                            verify_grad=True, mode=mode,
                            provide_shape=provide_shape, border_mode=b,
                            filter_flip=flip,
-                           target_op=GpuCorrMM_gradInputs)
+                           target_op=GpuCorrMM_gradInputs,
+                           filter_dilation=fd)
 
 
 class TestDnnConvTypes(test_abstract_conv.TestConvTypes):

--- a/theano/tensor/nnet/__init__.py
+++ b/theano/tensor/nnet/__init__.py
@@ -35,7 +35,7 @@ from .abstract_conv import conv2d as abstract_conv2d
 
 def conv2d(input, filters, input_shape=None, filter_shape=None,
            border_mode='valid', subsample=(1, 1), filter_flip=True,
-           image_shape=None, **kwargs):
+           image_shape=None, filter_dilation=(1, 1), **kwargs):
     """
     This function will build the symbolic graph for convolving a mini-batch of a
     stack of 2D inputs with a set of 2D filters. The implementation is modelled
@@ -95,6 +95,10 @@ def conv2d(input, filters, input_shape=None, filter_shape=None,
     image_shape: None, tuple/list of len 4 of int or Constant variable
         Deprecated alias for input_shape.
 
+    filter_dilation: tuple of len 2
+        Factor by which to subsample (stride) the input.
+        Also called dilation elsewhere.
+
     kwargs: Any other keyword arguments are accepted for backwards
             compatibility, but will be ignored.
 
@@ -140,4 +144,5 @@ def conv2d(input, filters, input_shape=None, filter_shape=None,
                              " be provided at the same time.")
 
     return abstract_conv2d(input, filters, input_shape, filter_shape,
-                           border_mode, subsample, filter_flip)
+                           border_mode, subsample, filter_flip,
+                           filter_dilation)


### PR DESCRIPTION
Comments:
- For some reason when tensor.nnet.conv2d is called then convop is implemented with the debug slow version in abstract_conv.py. Modified already opt.py (both cpu and gpu versions) and dnn.py (both gpuarray and cuda). The idea is that whenever tensor.nnet.conv2d is called we need to check wether there is dilation and if there is the call conv_gemm implementation. 
- Following the previous point, the TestDnnConv2d in test_sandbox/cuda/tests/abstractconv.py fails. The reason is the use of cuDNN implementation of dilated architectures in tests (should we skip them or adapt with the abstract iface?)
