### PR TITLE
Reduce C code generated when using GpuDnnConvDesc

### DIFF
--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -4,8 +4,12 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject *subsample,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {PAD_0, PAD_1, PAD_2};
-  int strides[3] = {SUB_0, SUB_1, SUB_2};
+  int strides[3] = {0,0,0};
   int upscale[3] = {1, 1, 1};
+
+strides[0] = *(npy_int64 *)PyArray_DATA(subsample);
+strides[1] = *(npy_int64 *)(PyArray_DATA(subsample) + 1);
+strides[2] = *(npy_int64 *)(PyArray_DATA(subsample) + 2);
 
 #if BORDER_MODE == 0
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) - 1;

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -7,9 +7,9 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject *subsample,
   int strides[3] = {0,0,0};
   int upscale[3] = {1, 1, 1};
 
-strides[0] = *(npy_int64 *)PyArray_DATA(subsample);
-strides[1] = *(npy_int64 *)(PyArray_DATA(subsample) + 1);
-strides[2] = *(npy_int64 *)(PyArray_DATA(subsample) + 2);
+strides[0] = *(npy_int64 *)PyArray_GETPTR1(subsample, 0);
+strides[1] = *(npy_int64 *)PyArray_GETPTR1(subsample, 1);
+strides[2] = *(npy_int64 *)PyArray_GETPTR1(subsample, 2);
 
 #if BORDER_MODE == 0
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) - 1;

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -14,20 +14,18 @@ strides[2] = *(npy_int64 *)PyArray_GETPTR1(subsample, 2);
 #if BORDER_MODE == 0
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) - 1;
   pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) - 1;
-#if NB_DIMS > 2
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) - 1;
 #endif
 #elif BORDER_MODE == 2
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) / 2;
   pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) / 2;
-#if NB_DIMS > 2
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) / 2;
 #endif
 #endif
 
-  if (PyArray_DIM(filt_shp, 0) - 2 != NB_DIMS) {
+  if (PyArray_DIM(filt_shp, 0) - 2 != 3) {
     PyErr_Format(PyExc_ValueError, "Filter shape has too many dimensions: "
-                 "expected %d, got %lld.", NB_DIMS,
+                 "expected 3, got %lld.", 
                  (long long)PyArray_DIM(filt_shp, 0));
     return -1;
   }
@@ -39,7 +37,7 @@ strides[2] = *(npy_int64 *)PyArray_GETPTR1(subsample, 2);
     return -1;
   }
 
-  err = cudnnSetConvolutionNdDescriptor(*desc, NB_DIMS, pad, strides,
+  err = cudnnSetConvolutionNdDescriptor(*desc, 3, pad, strides,
                                         upscale, CONV_MODE, PRECISION);
   return 0;
 }

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -1,6 +1,7 @@
 #section support_code_apply
 
-int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject *subsample,
+int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject *subsample, PyArrayObject *padding,
+                              PyObject *bmode,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {PAD_0, PAD_1, PAD_2};
@@ -11,12 +12,12 @@ strides[0] = *(npy_int64 *)PyArray_GETPTR1(subsample, 0);
 strides[1] = *(npy_int64 *)PyArray_GETPTR1(subsample, 1);
 strides[2] = *(npy_int64 *)PyArray_GETPTR1(subsample, 2);
 
-#if BORDER_MODE == 0
+#if PyInt_asLong(bmode) == 0L
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) - 1;
   pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) - 1;
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) - 1;
 #endif
-#elif BORDER_MODE == 2
+#elif PyInt_asLong(bmode) == 2L
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) / 2;
   pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) / 2;
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) / 2;

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -1,13 +1,14 @@
 #section support_code_apply
 
 int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject *subsample, PyArrayObject *padding,
-                              PyObject *bmode, PyObject *conv_flag,
+                              PyObject *bmode, PyObject *conv_flag, PyObject *precision_flag,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {PAD_0, PAD_1, PAD_2};
   int strides[3] = {0,0,0};
   int upscale[3] = {1, 1, 1};
-  char * conv_mode;
+  char *precision_flag
+  char *conv_mode;
 
 strides[0] = *(npy_int64 *)PyArray_GETPTR1(subsample, 0);
 strides[1] = *(npy_int64 *)PyArray_GETPTR1(subsample, 1);
@@ -26,16 +27,27 @@ else if (PyInt_asLong(bmode) == 2L)
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) / 2;
 }
 
-if (PyInt_asLong(conv_flag) == 1)
+if (PyInt_asLong(conv_flag) == 1L)
 {
   conv_mode = "CUDNN_CONVOLUTION";
 }
-else if (PyInt_asLong(conv_flag) == 2)
+else if (PyInt_asLong(conv_flag) == 2L)
 {
   conv_mode = "CUDNN_CROSS_CORRELATION";
 }
 
-
+if (PyInt_asLong(precision_flag) == 1L)
+{
+  precision_flag = "CUDNN_DATA_HALF" ;
+}
+else if (PyInt_asLong(precision_flag) == 2L)
+{
+  precision_flag = "CUDNN_DATA_FLOAT";
+}
+else if (PyInt_asLong(precision_flag) == 3L)
+{
+  precision_flag = "CUDNN_DATA_DOUBLE";
+}
 
   if (PyArray_DIM(filt_shp, 0) - 2 != 3) {
     PyErr_Format(PyExc_ValueError, "Filter shape has too many dimensions: "
@@ -52,6 +64,6 @@ else if (PyInt_asLong(conv_flag) == 2)
   }
 
   err = cudnnSetConvolutionNdDescriptor(*desc, 3, pad, strides,
-                                        upscale, conv_mode, PRECISION);
+                                        upscale, conv_mode, precision_flag);
   return 0;
 }

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -4,10 +4,10 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject *subsample,
                               PyObject *bmode, PyObject *conv_flag, PyObject *precision_flag,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
-  int pad[3] = {PAD_0, PAD_1, PAD_2};
+  int pad[3] = {0,0,0};
   int strides[3] = {0,0,0};
   int upscale[3] = {1, 1, 1};
-  char *precision_flag
+  char *precision_flag;
   char *conv_mode;
 
 strides[0] = *(npy_int64 *)PyArray_GETPTR1(subsample, 0);

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -1,28 +1,41 @@
 #section support_code_apply
 
 int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject *subsample, PyArrayObject *padding,
-                              PyObject *bmode,
+                              PyObject *bmode, PyObject *conv_flag,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {PAD_0, PAD_1, PAD_2};
   int strides[3] = {0,0,0};
   int upscale[3] = {1, 1, 1};
+  char * conv_mode;
 
 strides[0] = *(npy_int64 *)PyArray_GETPTR1(subsample, 0);
 strides[1] = *(npy_int64 *)PyArray_GETPTR1(subsample, 1);
 strides[2] = *(npy_int64 *)PyArray_GETPTR1(subsample, 2);
 
-#if PyInt_asLong(bmode) == 0L
+if (PyInt_asLong(bmode) == 0L)
+{
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) - 1;
   pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) - 1;
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) - 1;
-#endif
-#elif PyInt_asLong(bmode) == 2L
+}
+else if (PyInt_asLong(bmode) == 2L)
+{
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) / 2;
   pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) / 2;
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) / 2;
-#endif
-#endif
+}
+
+if (PyInt_asLong(conv_flag) == 1)
+{
+  conv_mode = "CUDNN_CONVOLUTION";
+}
+else if (PyInt_asLong(conv_flag) == 2)
+{
+  conv_mode = "CUDNN_CROSS_CORRELATION";
+}
+
+
 
   if (PyArray_DIM(filt_shp, 0) - 2 != 3) {
     PyErr_Format(PyExc_ValueError, "Filter shape has too many dimensions: "
@@ -39,6 +52,6 @@ strides[2] = *(npy_int64 *)PyArray_GETPTR1(subsample, 2);
   }
 
   err = cudnnSetConvolutionNdDescriptor(*desc, 3, pad, strides,
-                                        upscale, CONV_MODE, PRECISION);
+                                        upscale, conv_mode, PRECISION);
   return 0;
 }

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -1,6 +1,6 @@
 #section support_code_apply
 
-int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp,
+int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject *subsample,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {PAD_0, PAD_1, PAD_2};

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -292,7 +292,7 @@ class GpuDnnConvDesc(COp):
         assert precision in ['float16', 'float32', 'float64']
         self.precision = precision
 
-    def make_node(self, kern_shape, subsample=(1, 1,0)):
+    def make_node(self, kern_shape, subsample=(1, 1, 0)):
         if kern_shape.type.ndim != 1 or kern_shape.type.dtype != 'int64':
             raise TypeError('kern must be 1D shape tensor')
         if isinstance(border_mode, integer_types):
@@ -322,7 +322,7 @@ class GpuDnnConvDesc(COp):
         out.tag.values_eq_approx = tensor.type.values_eq_approx_always_true
         return node
 
-    #TODO: Need to document this, not in Extending using COp
+    # TODO: Need to document this, not in Extending using COp
     def get_op_params(self):
         pad0 = '0'
         pad1 = '0'

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -292,6 +292,9 @@ class GpuDnnConvDesc(COp):
         assert precision in ['float16', 'float32', 'float64']
         self.precision = precision
 
+        # Checking is done in make_node
+        self.border_mode = border_mode 
+
     def make_node(self, kern_shape, subsample=(1, 1, 0)):
         if kern_shape.type.ndim != 1 or kern_shape.type.dtype != 'int64':
             raise TypeError('kern must be 1D shape tensor')

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -355,8 +355,7 @@ class GpuDnnConvDesc(COp):
             assert self.precision == 'float64'
             precision = 'CUDNN_DATA_DOUBLE'
 
-        return [('NB_DIMS', str(len(self.subsample))),
-                ('BORDER_MODE', bmode),
+        return [('BORDER_MODE', bmode),
                 ('PAD_0', pad0), ('PAD_1', pad1), ('PAD_2', pad2),
                 ('CONV_MODE', conv_flag),
                 ('PRECISION', precision)]

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -282,11 +282,10 @@ class GpuDnnConvDesc(COp):
     def do_constant_folding(self, node):
         return False
 
-    def __init__(self,
-                 precision="float32"):
+    def __init__(self):
         COp.__init__(self, ["conv_desc.c"], "APPLY_SPECIFIC(conv_desc)")
 
-    def make_node(self, border_mode, kern_shape, subsample=(1, 1, 0), conv_mode='conv'):
+    def make_node(self, border_mode, kern_shape, precision="float32", subsample=(1, 1, 0), conv_mode='conv'):
         if kern_shape.type.ndim != 1 or kern_shape.type.dtype != 'int64':
             raise TypeError('kern must be 1D shape tensor')
         if isinstance(border_mode, integer_types):

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -306,7 +306,7 @@ class GpuDnnConvDesc(COp):
                 'invalid border_mode {}, which must be either '
                 '"valid", "full", "half", an integer or a pair of'
                 ' integers'.format(border_mode))
-        self.border_mode = border_modeS
+        self.border_mode = border_mode
         assert len(subsample) in (2, 3)
         self.subsample = subsample
         if len(subsample) == 2:

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -311,7 +311,24 @@ class GpuDnnConvDesc(COp):
         self.subsample = subsample
         if len(subsample) == 2:
             subsample += (0,)
-        node = Apply(self, [kern_shape, subsample],
+        padding = [0, 0, 0]
+        bmode = 1
+        if isinstance(self.border_mode, tuple):
+            padding[0] = self.border_mode[0]
+            padding[1] = self.border_mode[1]
+            if len(self.border_mode) > 2:
+                padding[2] = self.border_mode[2]
+            bmode = 1
+        elif self.border_mode == "valid":
+            bmode = 1
+        elif self.border_mode == "half":
+            bmode = 2
+        elif self.border_mode == "full":
+            bmode = 0
+        else:
+            raise ValueError("Invalid value for border_mode")
+
+        node = Apply(self, [kern_shape, subsample, padding, bmode],
                      [CDataType("cudnnConvolutionDescriptor_t",
                                 freefunc="cudnnDestroyConvolutionDescriptor")()])
         # DebugMode cannot compare the values of CDataType variables, so by
@@ -324,23 +341,6 @@ class GpuDnnConvDesc(COp):
 
     # TODO: Need to document this, not in Extending using COp
     def get_op_params(self):
-        pad0 = '0'
-        pad1 = '0'
-        pad2 = '0'
-        if isinstance(self.border_mode, tuple):
-            pad0 = str(self.border_mode[0])
-            pad1 = str(self.border_mode[1])
-            if len(self.border_mode) > 2:
-                pad2 = str(self.border_mode[2])
-            bmode = '1'
-        elif self.border_mode == "valid":
-            bmode = '1'
-        elif self.border_mode == "half":
-            bmode = '2'
-        elif self.border_mode == "full":
-            bmode = '0'
-        else:
-            raise ValueError("Invalid value for border_mode")
 
         if self.conv_mode == 'conv':
             conv_flag = 'CUDNN_CONVOLUTION'
@@ -355,13 +355,13 @@ class GpuDnnConvDesc(COp):
             assert self.precision == 'float64'
             precision = 'CUDNN_DATA_DOUBLE'
 
-        return [('BORDER_MODE', bmode),
-                ('PAD_0', pad0), ('PAD_1', pad1), ('PAD_2', pad2),
+        return [
                 ('CONV_MODE', conv_flag),
                 ('PRECISION', precision)]
 
     def c_code_cache_version(self):
         return (super(GpuDnnConvDesc, self).c_code_cache_version(), version())
+
 
 # scalar constants
 _zero = constant(numpy.asarray(0.0, dtype='float64'))

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -349,10 +349,6 @@ class GpuDnnConvDesc(COp):
         out.tag.values_eq_approx = tensor.type.values_eq_approx_always_true
         return node
 
-    # TODO: Need to document this, not in Extending using COp
-    def get_op_params(self):
-        return []
-
     def c_code_cache_version(self):
         return (super(GpuDnnConvDesc, self).c_code_cache_version(), version())
 

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -293,7 +293,7 @@ class GpuDnnConvDesc(COp):
         self.precision = precision
 
         # Checking is done in make_node
-        self.border_mode = border_mode 
+        self.border_mode = border_mode
 
     def make_node(self, kern_shape, subsample=(1, 1, 0)):
         if kern_shape.type.ndim != 1 or kern_shape.type.dtype != 'int64':

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -292,7 +292,6 @@ class GpuDnnConvDesc(COp):
         assert precision in ['float16', 'float32', 'float64']
         self.precision = precision
 
-
     def make_node(self, border_mode, kern_shape, subsample=(1, 1, 0)):
         if kern_shape.type.ndim != 1 or kern_shape.type.dtype != 'int64':
             raise TypeError('kern must be 1D shape tensor')
@@ -306,8 +305,8 @@ class GpuDnnConvDesc(COp):
             raise ValueError(
                 'invalid border_mode {}, which must be either '
                 '"valid", "full", "half", an integer or a pair of'
-                ' integers'.format(self.border_mode))
-        # self.border_mode = border_modeS
+                ' integers'.format(border_mode))
+        self.border_mode = border_modeS
         assert len(subsample) in (2, 3)
         self.subsample = subsample
         if len(subsample) == 2:

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -356,7 +356,7 @@ class GpuDnnConvDesc(COp):
             precision = 'CUDNN_DATA_DOUBLE'
 
         return [
-                ('CONV_MODE', conv_flag),
+                
                 ('PRECISION', precision)]
 
     def c_code_cache_version(self):

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -282,7 +282,7 @@ class GpuDnnConvDesc(COp):
     def do_constant_folding(self, node):
         return False
 
-    def __init__(self, border_mode, conv_mode='conv',
+    def __init__(self, conv_mode='conv',
                  precision="float32"):
         COp.__init__(self, ["conv_desc.c"], "APPLY_SPECIFIC(conv_desc)")
 
@@ -292,19 +292,17 @@ class GpuDnnConvDesc(COp):
         assert precision in ['float16', 'float32', 'float64']
         self.precision = precision
 
-        # Checking is done in make_node
-        self.border_mode = border_mode
 
-    def make_node(self, kern_shape, subsample=(1, 1, 0)):
+    def make_node(self, border_mode, kern_shape, subsample=(1, 1, 0)):
         if kern_shape.type.ndim != 1 or kern_shape.type.dtype != 'int64':
             raise TypeError('kern must be 1D shape tensor')
-        if isinstance(self.border_mode, integer_types):
-            self.border_mode = (self.border_mode,) * len(subsample)
-        if isinstance(self.border_mode, tuple):
-            assert len(self.border_mode) == len(subsample)
-            self.border_mode = tuple(map(int, self.border_mode))
-        if not ((isinstance(self.border_mode, tuple) and min(self.border_mode) >= 0) or
-                self.border_mode in ('valid', 'full', 'half')):
+        if isinstance(border_mode, integer_types):
+            border_mode = (border_mode,) * len(subsample)
+        if isinstance(border_mode, tuple):
+            assert len(border_mode) == len(subsample)
+            border_mode = tuple(map(int, border_mode))
+        if not ((isinstance(border_mode, tuple) and min(border_mode) >= 0) or
+                border_mode in ('valid', 'full', 'half')):
             raise ValueError(
                 'invalid border_mode {}, which must be either '
                 '"valid", "full", "half", an integer or a pair of'

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -298,18 +298,18 @@ class GpuDnnConvDesc(COp):
     def make_node(self, kern_shape, subsample=(1, 1, 0)):
         if kern_shape.type.ndim != 1 or kern_shape.type.dtype != 'int64':
             raise TypeError('kern must be 1D shape tensor')
-        if isinstance(border_mode, integer_types):
-            border_mode = (border_mode,) * len(subsample)
-        if isinstance(border_mode, tuple):
-            assert len(border_mode) == len(subsample)
-            border_mode = tuple(map(int, border_mode))
-        if not ((isinstance(border_mode, tuple) and min(border_mode) >= 0) or
-                border_mode in ('valid', 'full', 'half')):
+        if isinstance(self.border_mode, integer_types):
+            self.border_mode = (self.border_mode,) * len(subsample)
+        if isinstance(self.border_mode, tuple):
+            assert len(self.border_mode) == len(subsample)
+            self.border_mode = tuple(map(int, self.border_mode))
+        if not ((isinstance(self.border_mode, tuple) and min(self.border_mode) >= 0) or
+                self.border_mode in ('valid', 'full', 'half')):
             raise ValueError(
                 'invalid border_mode {}, which must be either '
                 '"valid", "full", "half", an integer or a pair of'
-                ' integers'.format(border_mode))
-        self.border_mode = border_mode
+                ' integers'.format(self.border_mode))
+        # self.border_mode = border_modeS
         assert len(subsample) in (2, 3)
         self.subsample = subsample
         if len(subsample) == 2:

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -286,7 +286,6 @@ class GpuDnnConvDesc(COp):
                  precision="float32"):
         COp.__init__(self, ["conv_desc.c"], "APPLY_SPECIFIC(conv_desc)")
 
-
         assert precision in ['float16', 'float32', 'float64']
         self.precision = precision
 
@@ -328,9 +327,9 @@ class GpuDnnConvDesc(COp):
         assert conv_mode in ('conv', 'cross')
         self.conv_mode = conv_mode
         if self.conv_mode == 'conv':
-            conv_flag = 1 #'CUDNN_CONVOLUTION'
-        else:
-            conv_flag = 2 #'CUDNN_CROSS_CORRELATION'
+            conv_flag = 1  # 'CUDNN_CONVOLUTION'
+        elif self.conv_mode == 'cross':
+            conv_flag = 2  # 'CUDNN_CROSS_CORRELATION'
         node = Apply(self, [kern_shape, subsample, padding, bmode, conv_flag],
                      [CDataType("cudnnConvolutionDescriptor_t",
                                 freefunc="cudnnDestroyConvolutionDescriptor")()])
@@ -344,9 +343,6 @@ class GpuDnnConvDesc(COp):
 
     # TODO: Need to document this, not in Extending using COp
     def get_op_params(self):
-
-
-
         if self.precision == 'float16':
             precision = 'CUDNN_DATA_HALF'
         elif self.precision == 'float32':
@@ -355,9 +351,7 @@ class GpuDnnConvDesc(COp):
             assert self.precision == 'float64'
             precision = 'CUDNN_DATA_DOUBLE'
 
-        return [
-                
-                ('PRECISION', precision)]
+        return [('PRECISION', precision)]
 
     def c_code_cache_version(self):
         return (super(GpuDnnConvDesc, self).c_code_cache_version(), version())


### PR DESCRIPTION
Modified GpuDnnConvDesc so that multiple versions of the C code are not created. It now creates just one piece of code which takes the subsample as a parameter instead of hard coding.

Need to check if the numpy C API has been used correctly. @nouiz @abergeron @lamblin could you please help with the review?

Additionally, the next PRs would make the other hard coded parameters in get_op_params as parameters.