### PR TITLE
Updated Numpy copyright dates

### DIFF
--- a/doc/LICENSE.txt
+++ b/doc/LICENSE.txt
@@ -6,7 +6,7 @@ LICENSE
 Copyright (c) 2008--2016, Theano Development Team
 All rights reserved.
 
-Contains code from NumPy, Copyright (c) 2005-2011, NumPy Developers.
+Contains code from NumPy, Copyright (c) 2005-2016, NumPy Developers.
 All rights reserved.
 
 Contain CnMeM under the same license with this copyright:


### PR DESCRIPTION
Numpy has changed copyright dates to 2005-2016. [Numpy License](https://github.com/numpy/numpy/blob/master/LICENSE.txt)