### PR TITLE
gpuarray tests should pass when floatX=float32 and add this to the daily buildbot

### DIFF
--- a/theano/gpuarray/tests/test_basic_ops.py
+++ b/theano/gpuarray/tests/test_basic_ops.py
@@ -89,9 +89,10 @@ def makeTester(name, op, gpu_op, cases, checks=None, mode_gpu=mode_with_gpu,
                 raise SkipTest(skip)
 
             for testname, inputs in iteritems(cases):
-                for _ in xrange(len(inputs)):
+                for _ in range(len(inputs)):
                     if type(inputs[_]) is float:
-                        inputs[_] = numpy.asarray(inputs[_], dtype=theano.config.floatX)
+                        inputs[_] = numpy.asarray(inputs[_],
+                                                  dtype=theano.config.floatX)
                 self.run_case(testname, inputs)
 
         def run_case(self, testname, inputs):

--- a/theano/gpuarray/tests/test_basic_ops.py
+++ b/theano/gpuarray/tests/test_basic_ops.py
@@ -89,6 +89,9 @@ def makeTester(name, op, gpu_op, cases, checks=None, mode_gpu=mode_with_gpu,
                 raise SkipTest(skip)
 
             for testname, inputs in iteritems(cases):
+                for _ in xrange(len(inputs)):
+                    if type(inputs[_]) is float:
+                        inputs[_] = numpy.asarray(inputs[_], dtype=theano.config.floatX)
                 self.run_case(testname, inputs)
 
         def run_case(self, testname, inputs):


### PR DESCRIPTION
fix gh-4555