### PR TITLE
Decode bytes to string before split

### DIFF
--- a/theano/misc/elemwise_openmp_speedup.py
+++ b/theano/misc/elemwise_openmp_speedup.py
@@ -23,7 +23,7 @@ def runScript(N):
     if err:
         print(err)
         sys.exit()
-    return list(map(float, out.split(" ")))
+    return list(map(float, out.decode().split(" ")))
 
 if __name__ == '__main__':
     options, arguments = parser.parse_args(sys.argv)

--- a/theano/misc/elemwise_openmp_speedup.py
+++ b/theano/misc/elemwise_openmp_speedup.py
@@ -3,8 +3,12 @@ import os
 import subprocess
 import sys
 from optparse import OptionParser
+from locale import getpreferredencoding
 
 import theano
+from theano.compat import decode_with
+
+console_encoding = getpreferredencoding()
 
 parser = OptionParser(usage='%prog <options>\n Compute time for'
                       ' fast and slow elemwise operations')
@@ -15,15 +19,15 @@ parser.add_option('-N', '--N', action='store', dest='N',
 
 def runScript(N):
     script = 'elemwise_time_test.py'
-    dir = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.dirname(os.path.abspath(__file__))
     proc = subprocess.Popen(['python', script, '--script', '-N', str(N)],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                            cwd=dir)
+                            cwd=path)
     (out, err) = proc.communicate()
     if err:
         print(err)
         sys.exit()
-    return list(map(float, out.decode().split(" ")))
+    return list(map(float, decode_with(out, console_encoding).split(" ")))
 
 if __name__ == '__main__':
     options, arguments = parser.parse_args(sys.argv)


### PR DESCRIPTION
The current elemwise_openmp_speedup.py will output the following error when used with Python 3.5.1:
```
Traceback (most recent call last):
  File "lib/python3.5/site-packages/theano/misc/elemwise_openmp_speedup.py", line 35, in <module>
    (cheapTime, costlyTime) = runScript(N=options.N)
  File "lib/python3.5/site-packages/theano/misc/elemwise_openmp_speedup.py", line 26, in runScript
    return list(map(float, out.split(" ")))
TypeError: a bytes-like object is required, not 'str'
```

Quick testing shows this to be the expected exception when calling split() on a bytes object. Calling decode() on the bytes object fixes this for Python 3, and seems to still work fine in my Python 2.7.11 install.