### PR TITLE
Fix a test failure in GpuCumsum class

### DIFF
--- a/theano/gpuarray/extra_ops.py
+++ b/theano/gpuarray/extra_ops.py
@@ -12,7 +12,7 @@ from .basic_ops import (as_gpuarray_variable, GpuKernelBase, Kernel, GpuReshape)
 from .opt import register_opt, op_lifter, register_opt2
 
 
-class GpuCumsum(GpuKernelBase, Op):
+class GpuCumsum(GpuKernelBase, CumsumOp):
     """
     Parameters
     ----------


### PR DESCRIPTION
If I run the unit test for the GpuCumsum class (using the CUDA backend) I get an assertion failure:

```
$ THEANO_FLAGS=mode=FAST_RUN,device=cuda0,floatX=float32 bin/theano-nose -s theano/gpuarray/tests/test_extra_ops.py
Mapped name None to device cuda0: Tesla K40c
.........F
======================================================================
FAIL: test_infer_shape (theano.gpuarray.tests.test_extra_ops.TestGpuCumsum)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/hzhang12/projects/Theano/theano/tensor/tests/test_extra_ops.py", line 157, in test_infer_shape
    self.op_class)
  File "/home/hzhang12/projects/Theano/theano/tests/unittest_tools.py", line 249, in _compile_and_check
    assert any(isinstance(t.op, cls) for t in topo_out)
AssertionError

----------------------------------------------------------------------
Ran 10 tests in 30.616s

FAILED (failures=1)
```

It seems in function InferShapeTester._compile_and_check(), it is checking if the operator class is derived from CumsumOp. Currently the GpuCumsum class is derived from class Op, not CumsumOp, so it fails. I am not sure if it is intentional. To make InferShapeTester happy, I changed the base class of GpuCumsum from Op to CumsumOp, and we can pass all the tests now.

If this is not the right approach, maybe we need to fix InferShapeTester._compile_and_check()? Or maybe it is a known issue?

I also noticed that in earlier versions of extra_ops.py, GpuCumsum was inherited from CumsumOp. But it is removed by [commit d87cf8b4](https://github.com/Theano/Theano/commit/d87cf8b458b626da14e548443424c722f0e89c61). @kelvinxu I am not sure why. 
