### PR TITLE
Reduce C code generated when using GpuDnnConvDesc

### DIFF
--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -1,7 +1,7 @@
 #section support_code_apply
 
-int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyObject *conv_mode,
-                              PyObject *precision,
+int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* border_mode,
+                              PyArrayObject* subsample, PyObject *conv_mode, PyObject *precision,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {PAD_0, PAD_1, PAD_2};

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -1,6 +1,7 @@
 #section support_code_apply
 
 int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyObject *precision,
+                              PyObject *conv_mode,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {PAD_0, PAD_1, PAD_2};
@@ -8,6 +9,9 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyObject *precision,
   int upscale[3] = {1, 1, 1};
   long precision_code = PyInt_asLong(precision);
   char* PRECISION = NULL;
+  long conv_mode_code = PyInt_asLong(conv_mode);
+  char* CONV_MODE = NULL;
+
 if (precision_code == 16L)
 {
   PRECISION = "CUDNN_DATA_HALF" ;
@@ -19,6 +23,15 @@ else if (precision_code == 32L)
 else if (precision_code == 64L)
 {
   PRECISION = "CUDNN_DATA_DOUBLE";
+}
+
+if (conv_mode_code == 0L)
+{
+  CONV_MODE = "CUDNN_CONVOLUTION";
+}
+else if (conv_mode_code == 1L)
+{
+  CONV_MODE = "CUDNN_CROSS_CORRELATION";
 }
 
 #if BORDER_MODE == 0

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -3,9 +3,9 @@
 int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, 
                               PyArrayObject *padding,
                               PyArrayObject *subsample,
-                              PyArrayObject *conv_mode,
-                              PyArrayObject *precision,
-                              PyArrayObject *bmode,
+                              PyObject *conv_mode,
+                              PyObject *precision,
+                              PyObject *bmode,
                               PyArrayObject *nb_dims,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -17,7 +17,7 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
   long conv_mode_code = PyInt_AsLong(conv_mode);
   char* CONV_MODE = NULL;
   long BORDER_MODE = PyInt_AsLong(bmode);
-  long NB_DIMS = (int)PyInt_AsLong(nb_dims);
+  int NB_DIMS = (int)PyInt_AsLong(nb_dims);
 
 if (precision_code == 16L)
 {

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -6,6 +6,20 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyObject *precision,
   int pad[3] = {PAD_0, PAD_1, PAD_2};
   int strides[3] = {SUB_0, SUB_1, SUB_2};
   int upscale[3] = {1, 1, 1};
+  long precision_code = PyInt_asLong(precision);
+  char* PRECISION = NULL;
+if (precision_code == 16L)
+{
+  PRECISION = "CUDNN_DATA_HALF" ;
+}
+else if (precision_code == 32L)
+{
+  PRECISION = "CUDNN_DATA_FLOAT";
+}
+else if (precision_code == 64L)
+{
+  PRECISION = "CUDNN_DATA_DOUBLE";
+}
 
 #if BORDER_MODE == 0
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) - 1;

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -3,9 +3,9 @@
 int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, 
                               PyArrayObject *padding,
                               PyArrayObject *subsample,
-                              PyObject *conv_mode,
-                              PyObject *precision,
-                              PyObject *bmode,
+                              PyArrayObject *conv_mode,
+                              PyArrayObject *precision,
+                              PyArrayObject *bmode,
                               PyArrayObject *nb_dims,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -1,8 +1,12 @@
 #section support_code_apply
 
-int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
-                              PyArrayObject* subsample, PyObject* conv_mode, PyObject* precision,
-                              PyObject* bmode, PyObject* nb_dims,
+int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, 
+                              PyArrayObject* padding,
+                              PyArrayObject* subsample, 
+                              PyObject* conv_mode, 
+                              PyObject* precision,
+                              PyObject* bmode, 
+                              PyObject* nb_dims,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {*(npy_int64 *)PyArray_GETPTR1(padding, 0),
@@ -17,7 +21,7 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
   long conv_mode_code = PyInt_AsLong(conv_mode);
   cudnnConvolutionMode_t CONV_MODE;
   long BORDER_MODE = PyInt_AsLong(bmode);
-  int NB_DIMS = (int)PyInt_AsLong(nb_dims);
+  long NB_DIMS = PyInt_AsLong(nb_dims);
 
 if (precision_code == 16L)
 {
@@ -45,21 +49,21 @@ if (BORDER_MODE == 0L)
 {
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) - 1;
   pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) - 1;
-if (NB_DIMS > 2)
+if (NB_DIMS > 2L)
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) - 1;
 }
 else if (BORDER_MODE == 2L)
 {
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) / 2;
   pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) / 2;
-if (NB_DIMS > 2)
+if (NB_DIMS > 2L)
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) / 2;
 }
 
 
   if (PyArray_DIM(filt_shp, 0) - 2 != NB_DIMS) {
     PyErr_Format(PyExc_ValueError, "Filter shape has too many dimensions: "
-                 "expected %d, got %lld.", NB_DIMS,
+                 "expected %ld, got %lld.", NB_DIMS,
                  (long long)PyArray_DIM(filt_shp, 0));
     return -1;
   }

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -9,19 +9,19 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp,
                               PyArrayObject *nb_dims,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
-  int pad[3] = {*(npy_int64 *)PyArray_GETPTR1(padding, 0),
-                *(npy_int64 *)PyArray_GETPTR1(padding, 1),
-                *(npy_int64 *)PyArray_GETPTR1(padding, 2)};
-  int strides[3] = {*(npy_int64 *)PyArray_GETPTR1(subsample, 0),
-                    *(npy_int64 *)PyArray_GETPTR1(subsample, 1),
-                    *(npy_int64 *)PyArray_GETPTR1(subsample, 2)};
+  int pad[3] = {*(npy_int8 *)PyArray_GETPTR1(padding, 0),
+                *(npy_int8 *)PyArray_GETPTR1(padding, 1),
+                *(npy_int8 *)PyArray_GETPTR1(padding, 2)};
+  int strides[3] = {*(npy_int8 *)PyArray_GETPTR1(subsample, 0),
+                    *(npy_int8 *)PyArray_GETPTR1(subsample, 1),
+                    *(npy_int8 *)PyArray_GETPTR1(subsample, 2)};
   int upscale[3] = {1, 1, 1};
-  int precision_code = *(npy_int64 *)PyArray_GETPTR1(precision, 0);
+  int precision_code = *(npy_int8 *)PyArray_GETPTR1(precision, 0);
   cudnnDataType_t PRECISION;
-  int conv_mode_code = *(npy_int64 *)PyArray_GETPTR1(conv_mode, 0);
+  int conv_mode_code = *(npy_int8 *)PyArray_GETPTR1(conv_mode, 0);
   cudnnConvolutionMode_t CONV_MODE;
-  int BORDER_MODE = *(npy_int64 *)PyArray_GETPTR1(bmode, 0);
-  int NB_DIMS = *(npy_int64 *)PyArray_GETPTR1(nb_dims, 0);
+  int BORDER_MODE = *(npy_int8 *)PyArray_GETPTR1(bmode, 0);
+  int NB_DIMS = *(npy_int8 *)PyArray_GETPTR1(nb_dims, 0);
 
 if (precision_code == 16)
 {
@@ -47,17 +47,17 @@ else if (conv_mode_code == 1)
 
 if (BORDER_MODE == 0)
 {
-  pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) - 1;
-  pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) - 1;
+  pad[0] = *(npy_int8 *)PyArray_GETPTR1(filt_shp, 2) - 1;
+  pad[1] = *(npy_int8 *)PyArray_GETPTR1(filt_shp, 3) - 1;
 if (NB_DIMS > 2)
-  pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) - 1;
+  pad[2] = *(npy_int8 *)PyArray_GETPTR1(filt_shp, 4) - 1;
 }
 else if (BORDER_MODE == 2)
 {
-  pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) / 2;
-  pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) / 2;
+  pad[0] = *(npy_int8 *)PyArray_GETPTR1(filt_shp, 2) / 2;
+  pad[1] = *(npy_int8 *)PyArray_GETPTR1(filt_shp, 3) / 2;
 if (NB_DIMS > 2)
-  pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) / 2;
+  pad[2] = *(npy_int8 *)PyArray_GETPTR1(filt_shp, 4) / 2;
 }
 
 

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -2,7 +2,7 @@
 
 int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
                               PyArrayObject* subsample, PyObject *conv_mode, PyObject *precision,
-                              PyObject* bmode,
+                              PyObject* bmode, PyObject* nb_dims,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {*(npy_int64 *)PyArray_GETPTR1(padding, 0),
@@ -15,6 +15,7 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
   long conv_mode_code = PyInt_asLong(conv_mode);
   char* CONV_MODE = NULL;
   long BORDER_MODE = PyInt_asLong(bmode);
+  long NB_DIMS = PyInt_asLong(nb_dims);
 
 if (precision_code == 16L)
 {
@@ -42,17 +43,15 @@ if (BORDER_MODE == 0L)
 {
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) - 1;
   pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) - 1;
-#if NB_DIMS > 2
+if (NB_DIMS > 2)
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) - 1;
-#endif
 }
 else if (BORDER_MODE == 2L)
 {
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) / 2;
   pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) / 2;
-#if NB_DIMS > 2
+if (NB_DIMS > 2)
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) / 2;
-#endif
 }
 
 

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -5,7 +5,7 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp,
                               PyArrayObject* subsample, 
                               PyObject* conv_mode, 
                               PyObject* precision,
-                              PyObject* bmode, 
+                              PyArrayObject* bmode,
                               PyObject* nb_dims,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
@@ -20,7 +20,7 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp,
   cudnnDataType_t PRECISION;
   long conv_mode_code = PyInt_AsLong(conv_mode);
   cudnnConvolutionMode_t CONV_MODE;
-  long BORDER_MODE = PyInt_AsLong(bmode);
+  long BORDER_MODE = *(npy_int64 *)PyArray_GETPTR1(bmode, 0);
   long NB_DIMS = PyInt_AsLong(nb_dims);
 
 if (precision_code == 16L)

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -16,47 +16,47 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp,
                     *(npy_int64 *)PyArray_GETPTR1(subsample, 1),
                     *(npy_int64 *)PyArray_GETPTR1(subsample, 2)};
   int upscale[3] = {1, 1, 1};
-  long precision_code = *(npy_int64 *)PyArray_GETPTR1(precision, 0);
+  int precision_code = *(npy_int64 *)PyArray_GETPTR1(precision, 0);
   cudnnDataType_t PRECISION;
-  long conv_mode_code = *(npy_int64 *)PyArray_GETPTR1(conv_mode, 0);
+  int conv_mode_code = *(npy_int64 *)PyArray_GETPTR1(conv_mode, 0);
   cudnnConvolutionMode_t CONV_MODE;
-  long BORDER_MODE = *(npy_int64 *)PyArray_GETPTR1(bmode, 0);
-  long NB_DIMS = *(npy_int64 *)PyArray_GETPTR1(nb_dims, 0);
+  int BORDER_MODE = *(npy_int64 *)PyArray_GETPTR1(bmode, 0);
+  int NB_DIMS = *(npy_int64 *)PyArray_GETPTR1(nb_dims, 0);
 
-if (precision_code == 16L)
+if (precision_code == 16)
 {
   PRECISION = CUDNN_DATA_HALF;
 }
-else if (precision_code == 32L)
+else if (precision_code == 32)
 {
   PRECISION = CUDNN_DATA_FLOAT;
 }
-else if (precision_code == 64L)
+else if (precision_code == 64)
 {
   PRECISION = CUDNN_DATA_DOUBLE;
 }
 
-if (conv_mode_code == 0L)
+if (conv_mode_code == 0)
 {
   CONV_MODE = CUDNN_CONVOLUTION;
 }
-else if (conv_mode_code == 1L)
+else if (conv_mode_code == 1)
 {
   CONV_MODE = CUDNN_CROSS_CORRELATION;
 }
 
-if (BORDER_MODE == 0L)
+if (BORDER_MODE == 0)
 {
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) - 1;
   pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) - 1;
-if (NB_DIMS > 2L)
+if (NB_DIMS > 2)
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) - 1;
 }
-else if (BORDER_MODE == 2L)
+else if (BORDER_MODE == 2)
 {
   pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) / 2;
   pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) / 2;
-if (NB_DIMS > 2L)
+if (NB_DIMS > 2)
   pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) / 2;
 }
 

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -8,7 +8,9 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
   int pad[3] = {*(npy_int64 *)PyArray_GETPTR1(padding, 0),
                 *(npy_int64 *)PyArray_GETPTR1(padding, 1),
                 *(npy_int64 *)PyArray_GETPTR1(padding, 2)};
-  int strides[3] = {SUB_0, SUB_1, SUB_2};
+  int strides[3] = {*(npy_int64 *)PyArray_GETPTR1(subsample, 0),
+                    *(npy_int64 *)PyArray_GETPTR1(subsample, 1),
+                    *(npy_int64 *)PyArray_GETPTR1(subsample, 2)};
   int upscale[3] = {1, 1, 1};
   long precision_code = PyInt_asLong(precision);
   char* PRECISION = NULL;

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -1,7 +1,7 @@
 #section support_code_apply
 
-int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyObject *precision,
-                              PyObject *conv_mode,
+int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyObject *conv_mode,
+                              PyObject *precision,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {PAD_0, PAD_1, PAD_2};

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -1,6 +1,6 @@
 #section support_code_apply
 
-int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp,
+int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyObject *precision,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {PAD_0, PAD_1, PAD_2};

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -1,12 +1,12 @@
 #section support_code_apply
 
 int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, 
-                              PyArrayObject* padding,
-                              PyArrayObject* subsample, 
-                              PyObject* conv_mode, 
-                              PyObject* precision,
-                              PyArrayObject* bmode,
-                              PyArrayObject* nb_dims,
+                              PyArrayObject *padding,
+                              PyArrayObject *subsample,
+                              PyArrayObject *conv_mode,
+                              PyArrayObject *precision,
+                              PyArrayObject *bmode,
+                              PyArrayObject *nb_dims,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {*(npy_int64 *)PyArray_GETPTR1(padding, 0),
@@ -16,9 +16,9 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp,
                     *(npy_int64 *)PyArray_GETPTR1(subsample, 1),
                     *(npy_int64 *)PyArray_GETPTR1(subsample, 2)};
   int upscale[3] = {1, 1, 1};
-  long precision_code = PyInt_AsLong(precision);
+  long precision_code = *(npy_int64 *)PyArray_GETPTR1(precision, 0);
   cudnnDataType_t PRECISION;
-  long conv_mode_code = PyInt_AsLong(conv_mode);
+  long conv_mode_code = *(npy_int64 *)PyArray_GETPTR1(conv_mode, 0);
   cudnnConvolutionMode_t CONV_MODE;
   long BORDER_MODE = *(npy_int64 *)PyArray_GETPTR1(bmode, 0);
   long NB_DIMS = *(npy_int64 *)PyArray_GETPTR1(nb_dims, 0);

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -9,12 +9,12 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp,
                               PyArrayObject *nb_dims,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
-  int pad[3] = {*(npy_int8 *)PyArray_GETPTR1(padding, 0),
-                *(npy_int8 *)PyArray_GETPTR1(padding, 1),
-                *(npy_int8 *)PyArray_GETPTR1(padding, 2)};
-  int strides[3] = {*(npy_int8 *)PyArray_GETPTR1(subsample, 0),
-                    *(npy_int8 *)PyArray_GETPTR1(subsample, 1),
-                    *(npy_int8 *)PyArray_GETPTR1(subsample, 2)};
+  int pad[3] = {*(npy_int64 *)PyArray_GETPTR1(padding, 0),
+                *(npy_int64 *)PyArray_GETPTR1(padding, 1),
+                *(npy_int64 *)PyArray_GETPTR1(padding, 2)};
+  int strides[3] = {*(npy_int64 *)PyArray_GETPTR1(subsample, 0),
+                    *(npy_int64 *)PyArray_GETPTR1(subsample, 1),
+                    *(npy_int64 *)PyArray_GETPTR1(subsample, 2)};
   int upscale[3] = {1, 1, 1};
   int precision_code = *(npy_int8 *)PyArray_GETPTR1(precision, 0);
   cudnnDataType_t PRECISION;

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -47,17 +47,17 @@ else if (conv_mode_code == 1)
 
 if (BORDER_MODE == 0)
 {
-  pad[0] = *(npy_int8 *)PyArray_GETPTR1(filt_shp, 2) - 1;
-  pad[1] = *(npy_int8 *)PyArray_GETPTR1(filt_shp, 3) - 1;
+  pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) - 1;
+  pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) - 1;
 if (NB_DIMS > 2)
-  pad[2] = *(npy_int8 *)PyArray_GETPTR1(filt_shp, 4) - 1;
+  pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) - 1;
 }
 else if (BORDER_MODE == 2)
 {
-  pad[0] = *(npy_int8 *)PyArray_GETPTR1(filt_shp, 2) / 2;
-  pad[1] = *(npy_int8 *)PyArray_GETPTR1(filt_shp, 3) / 2;
+  pad[0] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 2) / 2;
+  pad[1] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 3) / 2;
 if (NB_DIMS > 2)
-  pad[2] = *(npy_int8 *)PyArray_GETPTR1(filt_shp, 4) / 2;
+  pad[2] = *(npy_int64 *)PyArray_GETPTR1(filt_shp, 4) / 2;
 }
 
 

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -13,7 +13,7 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
                     *(npy_int64 *)PyArray_GETPTR1(subsample, 2)};
   int upscale[3] = {1, 1, 1};
   long precision_code = PyInt_AsLong(precision);
-  char* PRECISION = NULL;
+  cudnnDataType_t PRECISION;
   long conv_mode_code = PyInt_AsLong(conv_mode);
   cudnnConvolutionMode_t CONV_MODE;
   long BORDER_MODE = PyInt_AsLong(bmode);
@@ -21,15 +21,15 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
 
 if (precision_code == 16L)
 {
-  PRECISION = "CUDNN_DATA_HALF";
+  PRECISION = CUDNN_DATA_HALF;
 }
 else if (precision_code == 32L)
 {
-  PRECISION = "CUDNN_DATA_FLOAT";
+  PRECISION = CUDNN_DATA_FLOAT;
 }
 else if (precision_code == 64L)
 {
-  PRECISION = "CUDNN_DATA_DOUBLE";
+  PRECISION = CUDNN_DATA_DOUBLE;
 }
 
 if (conv_mode_code == 0L)

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -6,7 +6,7 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp,
                               PyObject* conv_mode, 
                               PyObject* precision,
                               PyArrayObject* bmode,
-                              PyObject* nb_dims,
+                              PyArrayObject* nb_dims,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
   int pad[3] = {*(npy_int64 *)PyArray_GETPTR1(padding, 0),
@@ -21,7 +21,7 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp,
   long conv_mode_code = PyInt_AsLong(conv_mode);
   cudnnConvolutionMode_t CONV_MODE;
   long BORDER_MODE = *(npy_int64 *)PyArray_GETPTR1(bmode, 0);
-  long NB_DIMS = PyInt_AsLong(nb_dims);
+  long NB_DIMS = *(npy_int64 *)PyArray_GETPTR1(nb_dims, 0);
 
 if (precision_code == 16L)
 {

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -63,7 +63,7 @@ if (NB_DIMS > 2)
 
   if (PyArray_DIM(filt_shp, 0) - 2 != NB_DIMS) {
     PyErr_Format(PyExc_ValueError, "Filter shape has too many dimensions: "
-                 "expected %ld, got %lld.", NB_DIMS,
+                 "expected %d, got %lld.", NB_DIMS,
                  (long long)PyArray_DIM(filt_shp, 0));
     return -1;
   }

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -15,7 +15,7 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
   long precision_code = PyInt_AsLong(precision);
   char* PRECISION = NULL;
   long conv_mode_code = PyInt_AsLong(conv_mode);
-  char* CONV_MODE = NULL;
+  cudnnConvolutionMode_t CONV_MODE;
   long BORDER_MODE = PyInt_AsLong(bmode);
   int NB_DIMS = (int)PyInt_AsLong(nb_dims);
 
@@ -34,11 +34,11 @@ else if (precision_code == 64L)
 
 if (conv_mode_code == 0L)
 {
-  CONV_MODE = "CUDNN_CONVOLUTION";
+  CONV_MODE = CUDNN_CONVOLUTION;
 }
 else if (conv_mode_code == 1L)
 {
-  CONV_MODE = "CUDNN_CROSS_CORRELATION";
+  CONV_MODE = CUDNN_CROSS_CORRELATION;
 }
 
 if (BORDER_MODE == 0L)

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -1,7 +1,7 @@
 #section support_code_apply
 
 int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
-                              PyArrayObject* subsample, PyObject *conv_mode, PyObject *precision,
+                              PyArrayObject* subsample, PyObject* conv_mode, PyObject* precision,
                               PyObject* bmode, PyObject* nb_dims,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
@@ -12,12 +12,12 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
                     *(npy_int64 *)PyArray_GETPTR1(subsample, 1),
                     *(npy_int64 *)PyArray_GETPTR1(subsample, 2)};
   int upscale[3] = {1, 1, 1};
-  long precision_code = PyInt_asLong(precision);
+  long precision_code = PyInt_AsLong(precision);
   char* PRECISION = NULL;
-  long conv_mode_code = PyInt_asLong(conv_mode);
+  long conv_mode_code = PyInt_AsLong(conv_mode);
   char* CONV_MODE = NULL;
-  long BORDER_MODE = PyInt_asLong(bmode);
-  long NB_DIMS = (int)PyInt_asLong(nb_dims);
+  long BORDER_MODE = PyInt_AsLong(bmode);
+  long NB_DIMS = (int)PyInt_AsLong(nb_dims);
 
 if (precision_code == 16L)
 {

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -14,7 +14,7 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyObject *precision,
 
 if (precision_code == 16L)
 {
-  PRECISION = "CUDNN_DATA_HALF" ;
+  PRECISION = "CUDNN_DATA_HALF";
 }
 else if (precision_code == 32L)
 {

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -17,7 +17,7 @@ int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
   long conv_mode_code = PyInt_asLong(conv_mode);
   char* CONV_MODE = NULL;
   long BORDER_MODE = PyInt_asLong(bmode);
-  long NB_DIMS = PyInt_asLong(nb_dims);
+  long NB_DIMS = (int)PyInt_asLong(nb_dims);
 
 if (precision_code == 16L)
 {

--- a/theano/gpuarray/conv_desc.c
+++ b/theano/gpuarray/conv_desc.c
@@ -1,11 +1,13 @@
 #section support_code_apply
 
-int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* border_mode,
+int APPLY_SPECIFIC(conv_desc)(PyArrayObject *filt_shp, PyArrayObject* padding,
                               PyArrayObject* subsample, PyObject *conv_mode, PyObject *precision,
                               PyObject* bmode,
                               cudnnConvolutionDescriptor_t *desc) {
   cudnnStatus_t err;
-  int pad[3] = {PAD_0, PAD_1, PAD_2};
+  int pad[3] = {*(npy_int64 *)PyArray_GETPTR1(padding, 0),
+                *(npy_int64 *)PyArray_GETPTR1(padding, 1),
+                *(npy_int64 *)PyArray_GETPTR1(padding, 2)};
   int strides[3] = {SUB_0, SUB_1, SUB_2};
   int upscale[3] = {1, 1, 1};
   long precision_code = PyInt_asLong(precision);

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -413,9 +413,9 @@ class GpuDnnConvDesc(COp):
             subsample += (0,)
         padding = as_tensor_variable(padding)
         subsample = as_tensor_variable(list(subsample))
-        conv_mode = as_tensor_variable(conv_mode)
-        precision = as_tensor_variable(precision)
-        bmode = as_tensor_variable(bmode)
+        conv_mode = int(conv_mode)
+        precision = int(precision)
+        bmode = int(bmode)
         node = Apply(self, [kern_shape, padding, subsample, conv_mode, precision, bmode, nb_dims],
                      [CDataType("cudnnConvolutionDescriptor_t",
                                 freefunc="cudnnDestroyConvolutionDescriptor")()])

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -390,6 +390,10 @@ class GpuDnnConvDesc(COp):
             elif precision == 'float64':
                 precision = 64
 
+        border_mode = as_tensor_variable(border_mode)
+        subsample = as_tensor_variable(subsample)
+        conv_mode = as_tensor_variable(conv_mode)
+        precision = as_tensor_variable(precision)
         node = Apply(self, [kern_shape, border_mode, subsample, conv_mode, precision],
                      [CDataType("cudnnConvolutionDescriptor_t",
                                 freefunc="cudnnDestroyConvolutionDescriptor")()])

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -383,7 +383,12 @@ class GpuDnnConvDesc(COp):
         if precision not in ['float16', 'float32', 'float64']:
         	raise TypeError('precision must be one of float16, float32, float64')
         else:
-        	precision = int(precision[5:]) # float32 is now 32
+            if precision == 'float16':
+                precision = 16
+            elif precision == 'float32':
+                precision = 32
+            elif precision == 'float64':
+                precision = 64
 
         node = Apply(self, [kern_shape, border_mode, subsample, conv_mode, precision],
                      [CDataType("cudnnConvolutionDescriptor_t",

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -408,9 +408,9 @@ class GpuDnnConvDesc(COp):
                 padding[2] = border_mode[2]
         else:
             padding = [0, 0, 0]
+        nb_dims = as_tensor_variable(len(subsample))
         if len(subsample) == 2:
             subsample += (0,)
-        nb_dims = as_tensor_variable(len(subsample))
         padding = as_tensor_variable(padding)
         subsample = as_tensor_variable(list(subsample))
         conv_mode = as_tensor_variable(conv_mode)

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -372,8 +372,8 @@ class GpuDnnConvDesc(COp):
                 'invalid border_mode {}, which must be either '
                 '"valid", "full", "half", an integer or a pair of'
                 ' integers'.format(border_mode))
-        assert len(subsample) in (2, 3)
         self.border_mode = border_mode
+        assert len(subsample) in (2, 3)
         self.subsample = subsample
         assert conv_mode in ('conv', 'cross')
         self.conv_mode = conv_mode
@@ -396,8 +396,10 @@ class GpuDnnConvDesc(COp):
             bmode = 1
         elif border_mode == 'half':
             bmode = 2
-        else:
+        elif border_mode == 'full':
             bmode = 0
+        else:
+            raise ValueError("Invalid value for border_mode")
         padding = [0, 0, 0]
         if isinstance(border_mode, tuple):
             padding[0] = border_mode[0]

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -337,7 +337,7 @@ class GpuDnnConvDesc(COp):
 
     """
 
-    __props__ = ('border_mode', 'subsample', 'conv_mode', 'precision')
+    __props__ = ()
 
     def c_headers(self):
         return ['cudnn.h', 'cudnn_helper.h']

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -408,7 +408,8 @@ class GpuDnnConvDesc(COp):
         conv_mode = as_tensor_variable(conv_mode)
         precision = as_tensor_variable(precision)
         bmode = as_tensor_variable(bmode)
-        node = Apply(self, [kern_shape, padding, subsample, conv_mode, precision, bmode],
+        nb_dims = as_tensor_variable(len(subsample))
+        node = Apply(self, [kern_shape, padding, subsample, conv_mode, precision, bmode, nb_dims],
                      [CDataType("cudnnConvolutionDescriptor_t",
                                 freefunc="cudnnDestroyConvolutionDescriptor")()])
         # DebugMode cannot compare the values of CDataType variables, so by
@@ -427,8 +428,7 @@ class GpuDnnConvDesc(COp):
         else:
             sub2 = '0'
 
-        return [('NB_DIMS', str(len(self.subsample))),
-                ('SUB_0', sub0), ('SUB_1', sub1), ('SUB_2', sub2)]
+        return [('SUB_0', sub0), ('SUB_1', sub1), ('SUB_2', sub2)]
 
     def c_code_cache_version(self): #TODO: need to update at the end
         return (super(GpuDnnConvDesc, self).c_code_cache_version(), version())

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -987,7 +987,7 @@ def dnn_conv(img, kerns, border_mode='valid', subsample=(1, 1),
     img = gpu_contiguous(img)
     kerns = gpu_contiguous(kerns)
     desc = gpu_dnn_conv_desc()(kerns.shape, border_mode=border_mode, subsample=subsample,
-                            conv_mode=conv_mode, precision=precision)
+                               conv_mode=conv_mode, precision=precision)
     desc_op = desc.owner.op
     # We can use Shape_i and bypass the infer_shape here as this is on
     # the input of node and it will always be present.
@@ -1166,7 +1166,7 @@ def dnn_gradinput(kerns, topgrad, img_shp, border_mode='valid',
     topgrad = gpu_contiguous(topgrad)
     img_shp = as_tensor_variable(img_shp)
     desc = gpu_dnn_conv_desc()(kerns.shape, border_mode=border_mode, subsample=subsample,
-                            conv_mode=conv_mode)
+                               conv_mode=conv_mode)
     out = gpu_alloc_empty(ctx_name, kerns.dtype)(*img_shp)
     return gpu_dnn_conv_gradI()(kerns, topgrad, out, desc)
 

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -434,7 +434,7 @@ class GpuDnnConvDesc(COp):
 def gpu_dnn_conv_desc():
     if 0 not in gpu_dnn_conv_desc.cache:
         gpu_dnn_conv_desc.cache[0] = GpuDnnConvDesc()
-    print gpu_dnn_conv_desc.cache[0]
+    print (gpu_dnn_conv_desc.cache[0])
     return gpu_dnn_conv_desc.cache[0]
 
 gpu_dnn_conv_desc.cache = {}

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -986,7 +986,7 @@ def dnn_conv(img, kerns, border_mode='valid', subsample=(1, 1),
     # if the img contains negative strides
     img = gpu_contiguous(img)
     kerns = gpu_contiguous(kerns)
-    desc = GpuDnnConvDesc()(kerns.shape, border_mode=border_mode, subsample=subsample,
+    desc = gpu_dnn_conv_desc()(kerns.shape, border_mode=border_mode, subsample=subsample,
                             conv_mode=conv_mode, precision=precision)
     desc_op = desc.owner.op
     # We can use Shape_i and bypass the infer_shape here as this is on
@@ -1132,7 +1132,7 @@ def dnn_gradweight(img, topgrad, kerns_shp, border_mode='valid',
     img = gpu_contiguous(img)
     topgrad = gpu_contiguous(topgrad)
     kerns_shp = as_tensor_variable(kerns_shp)
-    desc = GpuDnnConvDesc()(kerns_shp, border_mode=border_mode, subsample=subsample, conv_mode=conv_mode)
+    desc = gpu_dnn_conv_desc()(kerns_shp, border_mode=border_mode, subsample=subsample, conv_mode=conv_mode)
     out = gpu_alloc_empty(ctx_name, dtype=img.dtype)(*kerns_shp)
     return gpu_dnn_conv_gradW()(img, topgrad, out, desc)
 
@@ -1165,7 +1165,7 @@ def dnn_gradinput(kerns, topgrad, img_shp, border_mode='valid',
     kerns = gpu_contiguous(kerns)
     topgrad = gpu_contiguous(topgrad)
     img_shp = as_tensor_variable(img_shp)
-    desc = GpuDnnConvDesc()(kerns.shape, border_mode=border_mode, subsample=subsample,
+    desc = gpu_dnn_conv_desc()(kerns.shape, border_mode=border_mode, subsample=subsample,
                             conv_mode=conv_mode)
     out = gpu_alloc_empty(ctx_name, kerns.dtype)(*img_shp)
     return gpu_dnn_conv_gradI()(kerns, topgrad, out, desc)

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -413,9 +413,9 @@ class GpuDnnConvDesc(COp):
             subsample += (0,)
         padding = as_tensor_variable(padding)
         subsample = as_tensor_variable(list(subsample))
-        conv_mode = int(conv_mode)
-        precision = int(precision)
-        bmode = int(bmode)
+        conv_mode = as_tensor_variable(conv_mode)
+        precision = as_tensor_variable(precision)
+        bmode = as_tensor_variable(bmode)
         node = Apply(self, [kern_shape, padding, subsample, conv_mode, precision, bmode, nb_dims],
                      [CDataType("cudnnConvolutionDescriptor_t",
                                 freefunc="cudnnDestroyConvolutionDescriptor")()])

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -376,12 +376,12 @@ class GpuDnnConvDesc(COp):
 
         assert conv_mode in ('conv', 'cross')
         if conv_mode == 'conv':
-            conv_mode = 0 # CUDNN_CONVOLUTION
+            conv_mode = 0  # CUDNN_CONVOLUTION
         else:
-            conv_mode = 1 # CUDNN_CROSS_CORRELATION
-        
+            conv_mode = 1  # CUDNN_CROSS_CORRELATION
+
         if precision not in ['float16', 'float32', 'float64']:
-        	raise TypeError('precision must be one of float16, float32, float64')
+            raise TypeError('precision must be one of float16, float32, float64')
         else:
             if precision == 'float16':
                 precision = 16
@@ -389,20 +389,20 @@ class GpuDnnConvDesc(COp):
                 precision = 32
             elif precision == 'float64':
                 precision = 64
-        if isinstance(border_mode,tuple) or border_mode == 'valid':
+        if isinstance(border_mode, tuple) or border_mode == 'valid':
             bmode = 1
         elif border_mode == 'half':
             bmode = 2
         else:
             bmode = 0
-        padding = [0,0,0]
+        padding = [0, 0, 0]
         if isinstance(border_mode, tuple):
             padding[0] = border_mode[0]
             padding[1] = border_mode[1]
             if len(border_mode) > 2:
                 padding[2] = border_mode[2]
         else:
-            padding = [0,0,0]
+            padding = [0, 0, 0]
         if len(subsample) == 2:
             subsample.append(0)
         padding = as_tensor_variable(padding)
@@ -422,7 +422,7 @@ class GpuDnnConvDesc(COp):
         out.tag.values_eq_approx = tensor.type.values_eq_approx_always_true
         return node
 
-    def c_code_cache_version(self): #TODO: need to update at the end
+    def c_code_cache_version(self):  # TODO: need to update at the end
         return (super(GpuDnnConvDesc, self).c_code_cache_version(), version())
 
 

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -430,7 +430,7 @@ def gpu_dnn_conv_desc(border_mode, subsample=(1, 1), conv_mode='conv',
                       precision="float32"):
     key = (border_mode, subsample, conv_mode, precision)
     if key not in gpu_dnn_conv_desc.cache:
-        gpu_dnn_conv_desc.cache[key] = GpuDnnConvDesc(border_mode,
+        gpu_dnn_conv_desc.cache[key] = GpuDnnConvDesc()(border_mode,
                                                       subsample,
                                                       conv_mode,
                                                       precision)
@@ -958,8 +958,8 @@ def dnn_conv(img, kerns, border_mode='valid', subsample=(1, 1),
                    shape_i(img, 3, fgraph) - shape_i(kerns, 3, fgraph) + 1)
         out_shp = assert_conv_shape(out_shp)
         out = gpu_alloc_empty(ctx_name, dtype=img.dtype)(*out_shp)
-        desc = GpuDnnConvDesc(border_mode='valid', subsample=(1, 1),
-                              conv_mode='cross', precision=precision)(out.shape)
+        desc = GpuDnnConvDesc()(out.shape, border_mode='valid', subsample=(1, 1),
+                              conv_mode='cross', precision=precision)
         conv = gpu_dnn_conv_gradW()(img, kerns, out, desc)
         return as_gpuarray_variable(conv.dimshuffle(1, 0, 2, 3), ctx_name)
 
@@ -977,8 +977,8 @@ def dnn_conv(img, kerns, border_mode='valid', subsample=(1, 1),
                    shape_i(img, 3, fgraph) + shape_i(kerns, 3, fgraph) - 1)
         out_shp = assert_conv_shape(out_shp)
         out = gpu_alloc_empty(ctx_name, dtype=img.dtype)(*out_shp)
-        desc = GpuDnnConvDesc(border_mode='valid', subsample=(1, 1),
-                              conv_mode=conv_mode, precision=precision)(kerns.shape)
+        desc = GpuDnnConvDesc()(kerns.shape, border_mode='valid', subsample=(1, 1),
+                              conv_mode=conv_mode, precision=precision)
         return gpu_dnn_conv_gradI()(kerns, img, out, desc)
 
     # Standard case: We use GpuDnnConv with suitable padding.

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -427,7 +427,7 @@ class GpuDnnConvDesc(COp):
         out.tag.values_eq_approx = tensor.type.values_eq_approx_always_true
         return node
 
-    def c_code_cache_version(self):  # TODO: need to update at the end
+    def c_code_cache_version(self):
         return (super(GpuDnnConvDesc, self).c_code_cache_version(), version())
 
 # scalar constants

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -354,7 +354,7 @@ class GpuDnnConvDesc(COp):
     def do_constant_folding(self, node):
         return False
 
-    def __init__(self, border_mode, subsample=(1, 1), conv_mode='conv'):
+    def __init__(self, border_mode, subsample=(1, 1)):
         COp.__init__(self, ["conv_desc.c"], "APPLY_SPECIFIC(conv_desc)")
 
         if isinstance(border_mode, integer_types):
@@ -371,10 +371,9 @@ class GpuDnnConvDesc(COp):
         self.border_mode = border_mode
         assert len(subsample) in (2, 3)
         self.subsample = subsample
-        assert conv_mode in ('conv', 'cross')
-        self.conv_mode = conv_mode
 
-    def make_node(self, kern_shape,precision="float32"):
+
+    def make_node(self, kern_shape,precision="float32",conv_mode='conv'):
         if kern_shape.type.ndim != 1 or kern_shape.type.dtype != 'int64':
             raise TypeError('kern must be 1D shape tensor')
 
@@ -382,7 +381,9 @@ class GpuDnnConvDesc(COp):
         	raise TypeError('precision must be one of float16, float32, float64')
         else:
         	precision = int(precision[5:]) # float32 is now 32
-        node = Apply(self, [kern_shape, precision],
+        assert conv_mode in ('conv', 'cross')
+        self.conv_mode = conv_mode
+        node = Apply(self, [kern_shape, precision, conv_mode],
                      [CDataType("cudnnConvolutionDescriptor_t",
                                 freefunc="cudnnDestroyConvolutionDescriptor")()])
         # DebugMode cannot compare the values of CDataType variables, so by

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -405,12 +405,12 @@ class GpuDnnConvDesc(COp):
             padding = [0, 0, 0]
         if len(subsample) == 2:
             subsample.append(0)
+        nb_dims = as_tensor_variable(len(subsample))
         padding = as_tensor_variable(padding)
         subsample = as_tensor_variable(subsample)
         conv_mode = as_tensor_variable(conv_mode)
         precision = as_tensor_variable(precision)
         bmode = as_tensor_variable(bmode)
-        nb_dims = as_tensor_variable(len(subsample))
         node = Apply(self, [kern_shape, padding, subsample, conv_mode, precision, bmode, nb_dims],
                      [CDataType("cudnnConvolutionDescriptor_t",
                                 freefunc="cudnnDestroyConvolutionDescriptor")()])

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -434,6 +434,7 @@ class GpuDnnConvDesc(COp):
 def gpu_dnn_conv_desc():
     if 0 not in gpu_dnn_conv_desc.cache:
         gpu_dnn_conv_desc.cache[0] = GpuDnnConvDesc()
+    print gpu_dnn_conv_desc.cache[0]
     return gpu_dnn_conv_desc.cache[0]
 
 gpu_dnn_conv_desc.cache = {}

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -389,12 +389,18 @@ class GpuDnnConvDesc(COp):
                 precision = 32
             elif precision == 'float64':
                 precision = 64
-
+        if isinstance(border_mode,tuple) or border_mode == 'valid':
+            bmode = 1
+        elif border_mode == 'half':
+            bmode = 2
+        else:
+            bmode = 0
         border_mode = as_tensor_variable(border_mode)
         subsample = as_tensor_variable(subsample)
         conv_mode = as_tensor_variable(conv_mode)
         precision = as_tensor_variable(precision)
-        node = Apply(self, [kern_shape, border_mode, subsample, conv_mode, precision],
+        bmode = as_tensor_variable(bmode)
+        node = Apply(self, [kern_shape, border_mode, subsample, conv_mode, precision, bmode],
                      [CDataType("cudnnConvolutionDescriptor_t",
                                 freefunc="cudnnDestroyConvolutionDescriptor")()])
         # DebugMode cannot compare the values of CDataType variables, so by
@@ -432,7 +438,6 @@ class GpuDnnConvDesc(COp):
             sub2 = '0'
 
         return [('NB_DIMS', str(len(self.subsample))),
-                ('BORDER_MODE', bmode),
                 ('PAD_0', pad0), ('PAD_1', pad1), ('PAD_2', pad2),
                 ('SUB_0', sub0), ('SUB_1', sub1), ('SUB_2', sub2)]
 

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -359,7 +359,7 @@ class GpuDnnConvDesc(COp):
 
     def make_node(self, kern_shape, border_mode, subsample=(1, 1), conv_mode='conv', precision="float32"):
         if kern_shape.type.ndim != 1 or kern_shape.type.dtype != 'int64':
-            raise TypeError('kern must be 1D shape tensor')
+            raise TypeError('kern must be 1D shape tensor with int64 dtype')
 
         if isinstance(border_mode, integer_types):
             border_mode = (border_mode,) * len(subsample)

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -434,7 +434,6 @@ class GpuDnnConvDesc(COp):
 def gpu_dnn_conv_desc():
     if 0 not in gpu_dnn_conv_desc.cache:
         gpu_dnn_conv_desc.cache[0] = GpuDnnConvDesc()
-    print (gpu_dnn_conv_desc.cache[0])
     return gpu_dnn_conv_desc.cache[0]
 
 gpu_dnn_conv_desc.cache = {}

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -433,7 +433,7 @@ class GpuDnnConvDesc(COp):
 
 def gpu_dnn_conv_desc():
     if 0 not in gpu_dnn_conv_desc.cache:
-        gpu_dnn_conv_desc[0] = GpuDnnConvDesc()
+        gpu_dnn_conv_desc.cache[0] = GpuDnnConvDesc()
     return gpu_dnn_conv_desc.cache[0]
 
 gpu_dnn_conv_desc.cache = {}

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -407,7 +407,7 @@ class GpuDnnConvDesc(COp):
             subsample += (0,)
         nb_dims = as_tensor_variable(len(subsample))
         padding = as_tensor_variable(padding)
-        subsample = as_tensor_variable(subsample)
+        subsample = as_tensor_variable(list(subsample))
         conv_mode = as_tensor_variable(conv_mode)
         precision = as_tensor_variable(precision)
         bmode = as_tensor_variable(bmode)

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -337,7 +337,7 @@ class GpuDnnConvDesc(COp):
 
     """
 
-    __props__ = ()
+    __props__ = ('border_mode', 'subsample', 'conv_mode', 'precision')
 
     def c_headers(self):
         return ['cudnn.h', 'cudnn_helper.h']

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -383,9 +383,9 @@ class GpuDnnConvDesc(COp):
         	precision = int(precision[5:]) # float32 is now 32
         assert conv_mode in ('conv', 'cross')
         if conv_mode == 'conv':
-            conv_mode = 0
+            conv_mode = 0 # CUDNN_CONVOLUTION
         else:
-            conv_mode = 1
+            conv_mode = 1 # CUDNN_CROSS_CORRELATION
 
         node = Apply(self, [kern_shape, precision, conv_mode],
                      [CDataType("cudnnConvolutionDescriptor_t",

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -373,8 +373,10 @@ class GpuDnnConvDesc(COp):
                 '"valid", "full", "half", an integer or a pair of'
                 ' integers'.format(border_mode))
         assert len(subsample) in (2, 3)
-
+        self.border_mode = border_mode
+        self.subsample = subsample
         assert conv_mode in ('conv', 'cross')
+        self.conv_mode = conv_mode
         if conv_mode == 'conv':
             conv_mode = 0  # CUDNN_CONVOLUTION
         else:
@@ -383,6 +385,7 @@ class GpuDnnConvDesc(COp):
         if precision not in ['float16', 'float32', 'float64']:
             raise TypeError('precision must be one of float16, float32, float64')
         else:
+            self.precision = precision
             if precision == 'float16':
                 precision = 16
             elif precision == 'float32':

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -382,7 +382,11 @@ class GpuDnnConvDesc(COp):
         else:
         	precision = int(precision[5:]) # float32 is now 32
         assert conv_mode in ('conv', 'cross')
-        self.conv_mode = conv_mode
+        if conv_mode == 'conv':
+            conv_mode = 0
+        else:
+            conv_mode = 1
+
         node = Apply(self, [kern_shape, precision, conv_mode],
                      [CDataType("cudnnConvolutionDescriptor_t",
                                 freefunc="cudnnDestroyConvolutionDescriptor")()])
@@ -413,11 +417,6 @@ class GpuDnnConvDesc(COp):
         else:
             raise ValueError("Invalid value for border_mode")
 
-        if self.conv_mode == 'conv':
-            conv_flag = 'CUDNN_CONVOLUTION'
-        else:
-            conv_flag = 'CUDNN_CROSS_CORRELATION'
-
         sub0 = str(self.subsample[0])
         sub1 = str(self.subsample[1])
         if len(self.subsample) > 2:
@@ -428,10 +427,9 @@ class GpuDnnConvDesc(COp):
         return [('NB_DIMS', str(len(self.subsample))),
                 ('BORDER_MODE', bmode),
                 ('PAD_0', pad0), ('PAD_1', pad1), ('PAD_2', pad2),
-                ('CONV_MODE', conv_flag),
                 ('SUB_0', sub0), ('SUB_1', sub1), ('SUB_2', sub2)]
 
-    def c_code_cache_version(self):
+    def c_code_cache_version(self): #TODO: need to update at the end
         return (super(GpuDnnConvDesc, self).c_code_cache_version(), version())
 
 

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -430,6 +430,14 @@ class GpuDnnConvDesc(COp):
     def c_code_cache_version(self):
         return (super(GpuDnnConvDesc, self).c_code_cache_version(), version())
 
+
+def gpu_dnn_conv_desc():
+    if 0 not in gpu_dnn_conv_desc.cache:
+        gpu_dnn_conv_desc[0] = GpuDnnConvDesc()
+    return gpu_dnn_conv_desc.cache[0]
+
+gpu_dnn_conv_desc.cache = {}
+
 # scalar constants
 _zero = constant(numpy.asarray(0.0, dtype='float64'))
 _one = constant(numpy.asarray(1.0, dtype='float64'))

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -400,9 +400,11 @@ class GpuDnnConvDesc(COp):
             padding[0] = border_mode[0]
             padding[1] = border_mode[1]
             if len(border_mode) > 2:
-            padding[2] = border_mode[2]
+                padding[2] = border_mode[2]
         else:
             padding = [0,0,0]
+        if len(subsample) == 2:
+            subsample.append(0)
         padding = as_tensor_variable(padding)
         subsample = as_tensor_variable(subsample)
         conv_mode = as_tensor_variable(conv_mode)
@@ -419,16 +421,6 @@ class GpuDnnConvDesc(COp):
         out = node.outputs[0]
         out.tag.values_eq_approx = tensor.type.values_eq_approx_always_true
         return node
-
-    def get_op_params(self):
-        sub0 = str(self.subsample[0])
-        sub1 = str(self.subsample[1])
-        if len(self.subsample) > 2:
-            sub2 = str(self.subsample[2])
-        else:
-            sub2 = '0'
-
-        return [('SUB_0', sub0), ('SUB_1', sub1), ('SUB_2', sub2)]
 
     def c_code_cache_version(self): #TODO: need to update at the end
         return (super(GpuDnnConvDesc, self).c_code_cache_version(), version())

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -425,19 +425,6 @@ class GpuDnnConvDesc(COp):
     def c_code_cache_version(self):  # TODO: need to update at the end
         return (super(GpuDnnConvDesc, self).c_code_cache_version(), version())
 
-
-def gpu_dnn_conv_desc(border_mode, subsample=(1, 1), conv_mode='conv',
-                      precision="float32"):
-    key = (border_mode, subsample, conv_mode, precision)
-    if key not in gpu_dnn_conv_desc.cache:
-        gpu_dnn_conv_desc.cache[key] = GpuDnnConvDesc()(border_mode,
-                                                      subsample,
-                                                      conv_mode,
-                                                      precision)
-    return gpu_dnn_conv_desc.cache[key]
-gpu_dnn_conv_desc.cache = {}
-
-
 # scalar constants
 _zero = constant(numpy.asarray(0.0, dtype='float64'))
 _one = constant(numpy.asarray(1.0, dtype='float64'))
@@ -986,8 +973,8 @@ def dnn_conv(img, kerns, border_mode='valid', subsample=(1, 1),
     # if the img contains negative strides
     img = gpu_contiguous(img)
     kerns = gpu_contiguous(kerns)
-    desc = gpu_dnn_conv_desc(border_mode=border_mode, subsample=subsample,
-                             conv_mode=conv_mode, precision=precision)(kerns.shape)
+    desc = GpuDnnConvDesc()(kerns.shape, border_mode=border_mode, subsample=subsample,
+                             conv_mode=conv_mode, precision=precision)
     desc_op = desc.owner.op
     # We can use Shape_i and bypass the infer_shape here as this is on
     # the input of node and it will always be present.
@@ -1132,8 +1119,7 @@ def dnn_gradweight(img, topgrad, kerns_shp, border_mode='valid',
     img = gpu_contiguous(img)
     topgrad = gpu_contiguous(topgrad)
     kerns_shp = as_tensor_variable(kerns_shp)
-    desc = gpu_dnn_conv_desc(border_mode=border_mode, subsample=subsample,
-                             conv_mode=conv_mode)(kerns_shp)
+    desc = GpuDnnConvDesc()(kerns_shp, border_mode=border_mode, subsample=subsample, conv_mode=conv_mode)
     out = gpu_alloc_empty(ctx_name, dtype=img.dtype)(*kerns_shp)
     return gpu_dnn_conv_gradW()(img, topgrad, out, desc)
 
@@ -1166,8 +1152,8 @@ def dnn_gradinput(kerns, topgrad, img_shp, border_mode='valid',
     kerns = gpu_contiguous(kerns)
     topgrad = gpu_contiguous(topgrad)
     img_shp = as_tensor_variable(img_shp)
-    desc = gpu_dnn_conv_desc(border_mode=border_mode, subsample=subsample,
-                             conv_mode=conv_mode)(kerns.shape)
+    desc = GpuDnnConvDesc()(kerns.shape, border_mode=border_mode, subsample=subsample,
+                             conv_mode=conv_mode)
     out = gpu_alloc_empty(ctx_name, kerns.dtype)(*img_shp)
     return gpu_dnn_conv_gradI()(kerns, topgrad, out, desc)
 

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -404,7 +404,7 @@ class GpuDnnConvDesc(COp):
         else:
             padding = [0, 0, 0]
         if len(subsample) == 2:
-            subsample.append(0)
+            subsample += (0,)
         nb_dims = as_tensor_variable(len(subsample))
         padding = as_tensor_variable(padding)
         subsample = as_tensor_variable(subsample)

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -946,7 +946,7 @@ def dnn_conv(img, kerns, border_mode='valid', subsample=(1, 1),
         out_shp = assert_conv_shape(out_shp)
         out = gpu_alloc_empty(ctx_name, dtype=img.dtype)(*out_shp)
         desc = GpuDnnConvDesc()(out.shape, border_mode='valid', subsample=(1, 1),
-                              conv_mode='cross', precision=precision)
+                                conv_mode='cross', precision=precision)
         conv = gpu_dnn_conv_gradW()(img, kerns, out, desc)
         return as_gpuarray_variable(conv.dimshuffle(1, 0, 2, 3), ctx_name)
 
@@ -965,7 +965,7 @@ def dnn_conv(img, kerns, border_mode='valid', subsample=(1, 1),
         out_shp = assert_conv_shape(out_shp)
         out = gpu_alloc_empty(ctx_name, dtype=img.dtype)(*out_shp)
         desc = GpuDnnConvDesc()(kerns.shape, border_mode='valid', subsample=(1, 1),
-                              conv_mode=conv_mode, precision=precision)
+                                conv_mode=conv_mode, precision=precision)
         return gpu_dnn_conv_gradI()(kerns, img, out, desc)
 
     # Standard case: We use GpuDnnConv with suitable padding.
@@ -974,7 +974,7 @@ def dnn_conv(img, kerns, border_mode='valid', subsample=(1, 1),
     img = gpu_contiguous(img)
     kerns = gpu_contiguous(kerns)
     desc = GpuDnnConvDesc()(kerns.shape, border_mode=border_mode, subsample=subsample,
-                             conv_mode=conv_mode, precision=precision)
+                            conv_mode=conv_mode, precision=precision)
     desc_op = desc.owner.op
     # We can use Shape_i and bypass the infer_shape here as this is on
     # the input of node and it will always be present.
@@ -1153,7 +1153,7 @@ def dnn_gradinput(kerns, topgrad, img_shp, border_mode='valid',
     topgrad = gpu_contiguous(topgrad)
     img_shp = as_tensor_variable(img_shp)
     desc = GpuDnnConvDesc()(kerns.shape, border_mode=border_mode, subsample=subsample,
-                             conv_mode=conv_mode)
+                            conv_mode=conv_mode)
     out = gpu_alloc_empty(ctx_name, kerns.dtype)(*img_shp)
     return gpu_dnn_conv_gradI()(kerns, topgrad, out, desc)
 

--- a/theano/gpuarray/tests/test_dnn.py
+++ b/theano/gpuarray/tests/test_dnn.py
@@ -39,10 +39,8 @@ def test_dnn_conv_desc_merge():
         raise SkipTest(dnn.dnn_available.msg)
     kern_shp = T.as_tensor_variable(
         numpy.asarray([3, 1, 2, 2]).astype('int64'))
-    desc1 = dnn.GpuDnnConvDesc(border_mode='valid', subsample=(2, 2),
-                               conv_mode='conv')(kern_shp)
-    desc2 = dnn.GpuDnnConvDesc(border_mode='full', subsample=(1, 1),
-                               conv_mode='cross')(kern_shp)
+    desc1 = dnn.GpuDnnConvDesc()(kern_shp, border_mode='valid', subsample=(2, 2), conv_mode='conv')
+    desc2 = dnn.GpuDnnConvDesc()(kern_shp, border_mode='full', subsample=(1, 1), conv_mode='cross')
     # CDataType is not DeepCopyable so this will crash if we don't use
     # borrow=True
     f = theano.function([], [theano.Out(desc1, borrow=True),
@@ -63,7 +61,8 @@ def test_dnn_conv_merge():
     img = T.tensor4('img')
     kern = T.tensor4('kern')
     out = T.tensor4('out')
-    desc = dnn.GpuDnnConvDesc(border_mode='valid')(kern.shape)
+    desc = dnn.GpuDnnConvDesc()(kern.shape, border_mode='valid')
+
 
     # Test forward op
     o1 = dnn.dnn_conv(img, kern)
@@ -101,10 +100,8 @@ def test_dnn_conv_inplace():
     img = T.tensor4('img')
     kern = T.tensor4('kern')
     out = T.tensor4('out')
-    desc1 = dnn.GpuDnnConvDesc(border_mode='valid', conv_mode='conv')(
-        kern.shape)
-    desc2 = dnn.GpuDnnConvDesc(
-        border_mode='valid', conv_mode='cross')(kern.shape)
+    desc1 = dnn.GpuDnnConvDesc()(kern.shape, border_mode='valid', conv_mode='conv')
+    desc2 = dnn.GpuDnnConvDesc()(kern.shape, border_mode='valid', conv_mode='cross')
 
     # Test forward op
     o1 = dnn.dnn_conv(img, kern, conv_mode='conv')
@@ -582,12 +579,11 @@ class TestDnnInferShapes(utt.InferShapeTester):
                                              border_mode=border_mode,
                                              subsample=subsample),
                 dtype=theano.config.floatX)
-            desc = dnn.GpuDnnConvDesc(
+            desc = dnn.GpuDnnConvDesc()(
+                kerns.shape,
                 border_mode=border_mode,
                 subsample=subsample,
-                conv_mode=conv_mode,
-                precision=set_precision(theano.config.floatX)
-            )(kerns.shape)
+                conv_mode=conv_mode)
             conv = dnn.GpuDnnConv(algo=algo)(img, kerns, out, desc)
             self._compile_and_check(
                 [img, kerns, out],
@@ -644,12 +640,12 @@ class TestDnnInferShapes(utt.InferShapeTester):
 
         kerns_vals = numpy.zeros(kerns_shape, dtype=theano.config.floatX)
         kerns_shape = theano.shared(numpy.asarray(kerns_shape))
-        desc = dnn.GpuDnnConvDesc(
+        desc = dnn.GpuDnnConvDesc()(
+            out.shape,
             border_mode=border_mode,
             subsample=subsample,
-            conv_mode=conv_mode,
-            precision=set_precision(theano.config.floatX)
-        )(kerns_shape)
+            conv_mode=conv_mode
+        )
         conv_grad_w = dnn.GpuDnnConvGradW()(
             img,
             topgrad,
@@ -700,12 +696,12 @@ class TestDnnInferShapes(utt.InferShapeTester):
                 out_vals.shape[3] + kern_vals.shape[3] - 1
             )
             img_vals = numpy.zeros(shape, dtype=theano.config.floatX)
-            desc = dnn.GpuDnnConvDesc(
+            desc = dnn.GpuDnnConvDesc()(
+                kerns.shape,
                 border_mode=params[0],
                 subsample=params[1],
-                conv_mode=params[2],
-                precision=set_precision(theano.config.floatX)
-            )(kerns.shape)
+                conv_mode=params[2]
+            )
             conv_grad_i = dnn.GpuDnnConvGradI()(
                 kerns,
                 out,
@@ -945,19 +941,19 @@ def test_dnn_conv_grad():
                                    iw - kw + 1)).astype(theano.config.floatX)
 
     def dconv(img, kern, out):
-        desc = dnn.GpuDnnConvDesc(border_mode='valid', subsample=(1, 1),
-                                  conv_mode='conv', precision=set_precision(theano.config.floatX))(kern.shape)
+        desc = dnn.GpuDnnConvDesc()(kern.shape, border_mode='valid', subsample=(1, 1),
+                                  conv_mode='conv', precision=set_precision(theano.config.floatX))
         return dnn.GpuDnnConv()(img, kern, out, desc, alpha=0.5, beta=0.75)
 
     def dconvi(img, kern, out):
-        desc = dnn.GpuDnnConvDesc(border_mode='valid', subsample=(1, 1),
-                                  conv_mode='conv', precision=set_precision(theano.config.floatX))(kern.shape)
+        desc = dnn.GpuDnnConvDesc()(kern.shape, border_mode='valid', subsample=(1, 1),
+                                  conv_mode='conv', precision=set_precision(theano.config.floatX))
         return dnn.GpuDnnConvGradI()(kern, out, img, desc, alpha=-1.0,
                                      beta=0.0)
 
     def dconvw(img, kern, out):
-        desc = dnn.GpuDnnConvDesc(border_mode='valid', subsample=(1, 1),
-                                  conv_mode='conv', precision=set_precision(theano.config.floatX))(kern.shape)
+        desc = dnn.GpuDnnConvDesc()(kern.shape, border_mode='valid', subsample=(1, 1),
+                                  conv_mode='conv', precision=set_precision(theano.config.floatX))
         return dnn.GpuDnnConvGradW()(img, out, kern, desc, alpha=0.75,
                                      beta=-1.0)
 


### PR DESCRIPTION
This is a continuation of PR #4638. I've made the commits a bit more clean.
TODO: to what number should I increment the c_cache_version to?

nosetests theano/gpuarray/test_dnn.py fails with the following output.
 (a part of it)

```
======================================================================
ERROR: theano.gpuarray.tests.test_dnn.test_dnn_conv_grad
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/gokul/Theano/theano/gpuarray/tests/test_dnn.py", line 763, in test_dnn_conv_grad
    utt.verify_grad(dconv, [img_val, kern_val, out_val])
  File "/home/gokul/Theano/theano/tests/unittest_tools.py", line 91, in verify_grad
    T.verify_grad(op, pt, n_tests, rng, *args, **kwargs)
  File "/home/gokul/Theano/theano/gradient.py", line 1654, in verify_grad
    o_fn = function(tensor_pt, o_output, name='gradient.py fwd')
  File "/home/gokul/Theano/theano/gradient.py", line 1635, in function
    on_unused_input='ignore', name=name)
  File "/home/gokul/Theano/theano/compile/function.py", line 322, in function
    output_keys=output_keys)
  File "/home/gokul/Theano/theano/compile/pfunc.py", line 480, in pfunc
    output_keys=output_keys)
  File "/home/gokul/Theano/theano/compile/function_module.py", line 1784, in orig_function
    defaults)
  File "/home/gokul/Theano/theano/compile/function_module.py", line 1648, in create
    input_storage=input_storage_lists, storage_map=storage_map)
  File "/home/gokul/Theano/theano/gof/link.py", line 699, in make_thunk
    storage_map=storage_map)[:3]
  File "/home/gokul/Theano/theano/gof/vm.py", line 1042, in make_all
    no_recycling))
  File "/home/gokul/Theano/theano/gof/op.py", line 975, in make_thunk
    no_recycling)
  File "/home/gokul/Theano/theano/gof/op.py", line 875, in make_c_thunk
    output_storage=node_output_storage)
  File "/home/gokul/Theano/theano/gof/cc.py", line 1189, in make_thunk
    keep_lock=keep_lock)
  File "/home/gokul/Theano/theano/gof/cc.py", line 1130, in __compile__
    keep_lock=keep_lock)
  File "/home/gokul/Theano/theano/gof/cc.py", line 1585, in cthunk_factory
    key=key, lnk=self, keep_lock=keep_lock)
  File "/home/gokul/Theano/theano/gof/cmodule.py", line 1145, in module_from_key
    module = lnk.compile_cmodule(location)
  File "/home/gokul/Theano/theano/gof/cc.py", line 1491, in compile_cmodule
    preargs=preargs)
  File "/home/gokul/Theano/theano/gof/cmodule.py", line 2299, in compile_str
    (status, compile_stderr.replace('\n', '. ')))
Exception: ('The following error happened while compiling the node', GpuDnnConvDesc(MakeVector{dtype='int64'}.0, TensorConstant{(3,) of 0}, TensorConstant{[1 1 0]}, TensorConstant{0}, TensorConstant{32}, TensorConstant{1}, TensorConstant{3}), '\n', 'Compilation failed (return status=1): /home/gokul/.theano/compiledir_Linux-3.19--generic-x86_64-with-Ubuntu-14.04-trusty-x86_64-2.7.6-64/tmpb60Wnv/mod.cpp: In member function \xe2\x80\x98int {anonymous}::__struct_compiled_op_ec8795bee5233416784c277810d57ff0::run()\xe2\x80\x99:. /home/gokul/.theano/compiledir_Linux-3.19--generic-x86_64-with-Ubuntu-14.04-trusty-x86_64-2.7.6-64/tmpb60Wnv/mod.cpp:893:83: error: cannot convert \xe2\x80\x98PyArrayObject* {aka tagPyArrayObject*}\xe2\x80\x99 to \xe2\x80\x98PyObject* {aka _object*}\xe2\x80\x99 for argument \xe2\x80\x984\xe2\x80\x99 to \xe2\x80\x98int conv_desc_node_ec8795bee5233416784c277810d57ff0_0(PyArrayObject*, PyArrayObject*, PyArrayObject*, PyObject*, PyObject*, PyObject*, PyObject*, cudnnConvolutionStruct**)\xe2\x80\x99.                    if (APPLY_SPECIFIC(conv_desc)(V3, V5, V7, V9, V11, V13, V15, &V1) != 0) {.                                                                                    ^. ', '[GpuDnnConvDesc(<TensorType(int64, vector)>, TensorConstant{(3,) of 0}, TensorConstant{[1 1 0]}, TensorConstant{0}, TensorConstant{32}, TensorConstant{1}, TensorConstant{3})]')
-------------------- >> begin captured stdout << ---------------------
===============================
===============================
/home/gokul/.theano/compiledir_Linux-3.19--generic-x86_64-with-Ubuntu-14.04-trusty-x86_64-2.7.6-64/tmpb60Wnv/mod.cpp: In member function \u2018int {anonymous}::__struct_compiled_op_ec8795bee5233416784c277810d57ff0::run()\u2019:
/home/gokul/.theano/compiledir_Linux-3.19--generic-x86_64-with-Ubuntu-14.04-trusty-x86_64-2.7.6-64/tmpb60Wnv/mod.cpp:893:83: error: cannot convert \u2018PyArrayObject* {aka tagPyArrayObject*}\u2019 to \u2018PyObject* {aka _object*}\u2019 for argument \u20184\u2019 to \u2018int conv_desc_node_ec8795bee5233416784c277810d57ff0_0(PyArrayObject*, PyArrayObject*, PyArrayObject*, PyObject*, PyObject*, PyObject*, PyObject*, cudnnConvolutionStruct**)\u2019
                   if (APPLY_SPECIFIC(conv_desc)(V3, V5, V7, V9, V11, V13, V15, &V1) != 0) {
                                                                                   ^


--------------------- >> end captured stdout << ----------------------
```
