### PR TITLE
Use shift modulo axis size to handle large shifts in theano.tensor.roll

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4047,6 +4047,11 @@ def roll(x, shift, axis=None):
         else:
             axis = 0
 
+    # Shift may be larger than the size of the axis. If so, since the
+    # roll operation is cyclic, we can take the shift modulo the size
+    # of the axis
+    shift = shift % x.shape[axis]
+
     # A slice of all elements in a dimension ':'
     allslice = slice(None)
     # List of slices describing the front half [:, :, shift:, :]

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -3736,6 +3736,22 @@ class T_Join_and_Split(unittest.TestCase):
 
             assert (out == want).all()
 
+            # Test rolling on axis 0 with a positive shift that is
+            # larger than axis size
+            want = numpy.roll(a.get_value(borrow=True), 4, 0)
+            b = roll(a, get_shift(4), 0)
+            out = theano.function([], b)()
+
+            assert (out == want).all()
+
+            # Test rolling on axis 0 with a negative shift that is
+            # larger than axis size
+            want = numpy.roll(a.get_value(borrow=True), -4, 0)
+            b = roll(a, get_shift(-4), 0)
+            out = theano.function([], b)()
+
+            assert (out == want).all()
+
     def test_stack_vector(self):
         a = self.shared(numpy.array([1, 2, 3], dtype=self.floatX))
         b = as_tensor_variable(numpy.array([7, 8, 9], dtype=self.floatX))


### PR DESCRIPTION
This pull request addresses issue #4662 by taking the desired shift modulo the axis size. It also adds tests to verify the correct behavior.