### PR TITLE
Confusion matrix 

### DIFF
--- a/theano/tensor/nnet/__init__.py
+++ b/theano/tensor/nnet/__init__.py
@@ -17,7 +17,8 @@ from .nnet import (
     graph_merge_softmax_with_crossentropy_softmax, h_softmax,
     logsoftmax, logsoftmax_op, prepend_0_to_each_row, prepend_1_to_each_row,
     prepend_scalar_to_each_row, relu, softmax, softmax_grad, softmax_graph,
-    softmax_op, softmax_simplifier, softmax_with_bias, elu)
+    softmax_op, softmax_simplifier, softmax_with_bias, elu,
+    confusion_matrix)
 from . import opt
 from .conv import ConvOp
 from .Conv3D import *

--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -20,7 +20,6 @@ from six.moves import xrange
 import theano
 from theano import gof
 from theano import scalar
-from theano.tensor import basic as tensor, subtensor, opt
 from theano.tensor import extra_ops
 from theano.gof.opt import copy_stack_trace
 from theano.tensor import basic as tensor, subtensor, opt, elemwise

--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -2445,7 +2445,6 @@ def confusion_matrix(actual, pred):
     [array([[0, 0, 1],
             [2, 1, 0],
             [0, 0, 1]]), array([ 0.,  1.,  2.])]
-
     """
     if actual.type.ndim != 1:
         raise ValueError('actual must be 1-d tensor variable')

--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -2429,7 +2429,7 @@ def confusion_matrix(actual, pred):
        Actual  |
                |
 
-    order : Order of entries in terms of original data
+    order : 1-d array of order of entries in rows and columns
 
     Examples
     --------
@@ -2446,12 +2446,10 @@ def confusion_matrix(actual, pred):
             [2, 1, 0],
             [0, 0, 1]]), array([ 0.,  1.,  2.])]
     """
-    if actual.type.ndim != 1:
+    if actual.ndim != 1:
         raise ValueError('actual must be 1-d tensor variable')
-    if pred.type.ndim != 1:
+    if pred.ndim != 1:
         raise ValueError('pred must be 1-d tensor variable')
-    if actual.shape[0] != pred.shape[0]:
-        raise ValueError('actual and pred must have the same length')
 
     order = extra_ops.Unique(False, False, False)(tensor.concatenate([actual, pred]))
 
@@ -2462,5 +2460,4 @@ def confusion_matrix(actual, pred):
     oneHotP = tensor.eq(colP, order).astype('int64')
 
     conf_mat = tensor.dot(oneHotA.T, oneHotP)
-
     return [conf_mat, order]

--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -2439,12 +2439,12 @@ def confusion_matrix(actual, pred):
     >>> x = theano.tensor.vector()
     >>> y = theano.tensor.vector()
     >>> f = theano.function([x, y], confusion_matrix(x, y))
-    >>> a = [0, 1, 2, 1, 0]
-    >>> b = [0, 0, 2, 1, 2]
-    >>> print(f(a, b))
-    [array([[0, 0, 1],
-            [2, 1, 0],
-            [0, 0, 1]]), array([ 0.,  1.,  2.])]
+    >>> y_true = [2, 0, 2, 2, 0, 1]
+    >>> y_pred = [0, 0, 2, 2, 0, 2]
+    >>> print(f(y_true, y_pred))
+    [array([[2, 0, 0],
+       [0, 0, 1],
+       [1, 0, 2]]), array([ 0.,  1.,  2.])]
     """
     if actual.ndim != 1:
         raise ValueError('actual must be 1-d tensor variable')


### PR DESCRIPTION
Fixes issue #3637. This is simply a rebase of #4100 plus updated example to match sklearn.confusion_matrix very closely. API signature is the same as sklearn.confusion_matrix:

`def confusion_matrix(actual, pred)`