### PR TITLE
Full 3D convolution for conv3d2d

### DIFF
--- a/theano/tensor/nnet/tests/test_conv3d2d.py
+++ b/theano/tensor/nnet/tests/test_conv3d2d.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 import time
 
 from nose.plugins.skip import SkipTest
+from nose_parameterized import parameterized
 import numpy
 try:
     from scipy import ndimage
@@ -53,7 +54,17 @@ def test_get_diagonal_subtensor_view(wrap=lambda a: a):
         assert numpy.all(xvi == get_diagonal_subtensor_view(xi, 0, 1))
 
 
-def pyconv3d(signals, filters):
+def pyconv3d(signals, filters, border_mode='valid'):
+    if border_mode == 'full':
+        # zero-pad signals for full convolution
+        Ns, Ts, C, Hs, Ws = signals.shape
+        Nf, Tf, C, Hf, Wf = filters.shape
+        signals_padded = numpy.zeros((Ns, Ts + 2 * (Tf - 1), C,
+                                      Hs + 2 * (Hf - 1), Ws + 2 * (Wf - 1)), 'float32')
+        signals_padded[:, (Tf - 1):(Ts + Tf - 1), :, (Hf - 1):(Hs + Hf - 1),
+                       (Wf - 1):(Ws + Wf - 1)] = signals
+        signals = signals_padded
+
     Ns, Ts, C, Hs, Ws = signals.shape
     Nf, Tf, C, Hf, Wf = filters.shape
 
@@ -80,7 +91,8 @@ def check_diagonal_subtensor_view_traces(fn):
         fn, ops_to_check=(DiagonalSubtensor, IncDiagonalSubtensor))
 
 
-def test_conv3d(mode=mode_without_gpu, shared=theano.tensor._shared):
+@parameterized.expand(('valid', 'full'), utt.custom_name_func)
+def test_conv3d(border_mode, mode=mode_without_gpu, shared=theano.tensor._shared):
     if ndimage is None:
         raise SkipTest("conv3d2d tests need SciPy")
 
@@ -91,7 +103,7 @@ def test_conv3d(mode=mode_without_gpu, shared=theano.tensor._shared):
     filters = numpy.arange(Nf * Tf * C * Hf * Wf).reshape(Nf, Tf, C, Hf, Wf).astype('float32')
 
     t0 = time.time()
-    pyres = pyconv3d(signals, filters)
+    pyres = pyconv3d(signals, filters, border_mode)
     print(time.time() - t0)
 
     s_signals = shared(signals)
@@ -100,7 +112,8 @@ def test_conv3d(mode=mode_without_gpu, shared=theano.tensor._shared):
 
     out = conv3d(s_signals, s_filters,
                  signals_shape=signals.shape,
-                 filters_shape=filters.shape)
+                 filters_shape=filters.shape,
+                 border_mode=border_mode)
 
     newconv3d = theano.function([], [],
                                 updates={s_output: out},
@@ -128,7 +141,8 @@ def test_conv3d(mode=mode_without_gpu, shared=theano.tensor._shared):
 
     signals = numpy.random.rand(Ns, Ts, C, Hs, Ws).astype('float32')
     filters = numpy.random.rand(Nf, Tf, C, Hf, Wf).astype('float32')
-    utt.verify_grad(conv3d, [signals, filters], eps=1e-1, mode=mode)
+    utt.verify_grad(lambda s, f: conv3d(s, f, border_mode=border_mode),
+                    [signals, filters], eps=1e-1, mode=mode)
 
     # Additional Test that covers the case of patched implementation for filter with Tf=1
     Ns, Ts, C, Hs, Ws = 3, 10, 3, 32, 32
@@ -138,7 +152,7 @@ def test_conv3d(mode=mode_without_gpu, shared=theano.tensor._shared):
     filters = numpy.arange(Nf * Tf * C * Hf * Wf).reshape(Nf, Tf, C, Hf, Wf).astype('float32')
 
     t0 = time.time()
-    pyres = pyconv3d(signals, filters)
+    pyres = pyconv3d(signals, filters, border_mode)
     print(time.time() - t0)
 
     s_signals = shared(signals)
@@ -147,7 +161,8 @@ def test_conv3d(mode=mode_without_gpu, shared=theano.tensor._shared):
 
     out = conv3d(s_signals, s_filters,
                  signals_shape=signals.shape,
-                 filters_shape=filters.shape)
+                 filters_shape=filters.shape,
+                 border_mode=border_mode)
 
     newconv3d = theano.function([], [],
                                 updates={s_output: out},
@@ -173,4 +188,5 @@ def test_conv3d(mode=mode_without_gpu, shared=theano.tensor._shared):
 
     signals = numpy.random.rand(Ns, Ts, C, Hs, Ws).astype('float32')
     filters = numpy.random.rand(Nf, Tf, C, Hf, Wf).astype('float32')
-    utt.verify_grad(conv3d, [signals, filters], eps=1e-1, mode=mode)
+    utt.verify_grad(lambda s, f: conv3d(s, f, border_mode=border_mode),
+                    [signals, filters], eps=1e-1, mode=mode)


### PR DESCRIPTION
This patch adds support for `border_mode='full'` to the 3D convolution in `tensor.nnet.conv3d2d`.

`tensor.nnet.conv2d` already provides full convolution for the H and W dimensions, so the code only has to be changed to support full convolution in the time dimension. I've implemented this by padding the stacked 2D output with zeros using `set_subtensor`. Summing over the output of `DiagonalSubtensor` then provides the result of a full convolution. This approach, unfortunately, requires an additional, temporary array for `set_subtensor`.