### PR TITLE
Use randint() instead of random_integers() in the tests.

### DIFF
--- a/theano/sparse/tests/test_basic.py
+++ b/theano/sparse/tests/test_basic.py
@@ -82,7 +82,7 @@ def random_lil(shape, dtype, nnz):
     huge = 2 ** 30
     for k in range(nnz):
         # set non-zeros in random locations (row x, col y)
-        idx = numpy.random.random_integers(huge, size=2) % shape
+        idx = numpy.random.randint(1, huge+1, size=2) % shape
         value = numpy.random.rand()
         # if dtype *int*, value will always be zeros!
         if "int" in dtype:
@@ -484,7 +484,7 @@ class TestConstructSparseFromList(unittest.TestCase):
 
         # Test the sparse grad
         valm = numpy.random.rand(5, 4).astype(config.floatX)
-        valv = numpy.random.random_integers(0, 4, 10)
+        valv = numpy.random.randint(0, 5, 10)
         m = theano.tensor.matrix()
         shared_v = theano.shared(valv)
 
@@ -2492,7 +2492,7 @@ class AddSSDataTester(utt.InferShapeTester):
             variable = getattr(theano.sparse, format + '_matrix')
 
             rand = numpy.array(
-                numpy.random.random_integers(3, size=(3, 4)) - 1,
+                numpy.random.randint(1, 4, size=(3, 4)) - 1,
                 dtype=theano.config.floatX)
             constant = as_sparse_format(rand, format)
 
@@ -3064,11 +3064,11 @@ class SamplingDotTester(utt.InferShapeTester):
     x = [tensor.matrix() for t in range(2)]
     x.append(sparse.csr_matrix())
     # unsquare shape
-    a = [numpy.array(numpy.random.random_integers(5, size=(4, 3)) - 1,
+    a = [numpy.array(numpy.random.randint(1, 6, size=(4, 3)) - 1,
                      dtype=theano.config.floatX),
-         numpy.array(numpy.random.random_integers(5, size=(5, 3)) - 1,
+         numpy.array(numpy.random.randint(1, 6, size=(5, 3)) - 1,
                      dtype=theano.config.floatX),
-         numpy.array(numpy.random.random_integers(2, size=(4, 5)) - 1,
+         numpy.array(numpy.random.randint(1, 3, size=(4, 5)) - 1,
                      dtype=theano.config.floatX)
          ]
     a[2] = sp.csr_matrix(a[2])

--- a/theano/sparse/tests/test_sp2.py
+++ b/theano/sparse/tests/test_sp2.py
@@ -30,7 +30,7 @@ class PoissonTester(utt.InferShapeTester):
     for format in sparse.sparse_formats:
         variable = getattr(theano.sparse, format + '_matrix')
 
-        rand = numpy.array(numpy.random.random_integers(3, size=(3, 4)) - 1,
+        rand = numpy.array(numpy.random.randint(1, 4, size=(3, 4)) - 1,
                            dtype=theano.config.floatX)
 
         x[format] = variable()

--- a/theano/tensor/raw_random.py
+++ b/theano/tensor/raw_random.py
@@ -551,6 +551,8 @@ def random_integers_helper(random_state, low, high, size):
     This is a generalization of numpy.random.random_integers to the case where
     low and high are tensors.
 
+    Since random_integers is deprecated it calls randint() instead.
+
     """
     # Figure out the output shape
     if size is not None:
@@ -587,7 +589,7 @@ def random_integers_helper(random_state, low, high, size):
                                                    high.shape)
     # Iterate over these indices, drawing one sample at a time from numpy
     for oi, li, hi in zip(*broadcast_ind):
-        out[oi] = random_state.random_integers(low=low[li], high=high[hi])
+        out[oi] = random_state.randint(low=low[li], high=high[hi]+1)
 
     return out
 

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -561,7 +561,7 @@ def rand_nonzero(shape, eps=3e-4):
 
 
 def randint(*shape):
-    return numpy.random.random_integers(-5, 5, shape)
+    return numpy.random.randint(-5, 6, shape)
 
 def randuint(*shape):
     return numpy.array(numpy.random.randint(5, size=shape), dtype=numpy.uint32)
@@ -577,7 +577,7 @@ def randcomplex_nonzero(shape, eps=1e-4):
 
 
 def randint_nonzero(*shape):
-    r = numpy.random.random_integers(-5, 4, shape)
+    r = numpy.random.randint(-5, 5, shape)
     return r + (r == 0) * 5
 
 
@@ -587,7 +587,7 @@ def rand_ranged(min, max, shape):
 
 
 def randint_ranged(min, max, shape):
-    return numpy.random.random_integers(min, max, shape)
+    return numpy.random.randint(min, max+1, shape)
 
 
 def randc128_ranged(min, max, shape):
@@ -7535,17 +7535,17 @@ class TestInferShape(utt.InferShapeTester):
                                 [adtens4_bro_val], Rebroadcast)
 
         # Alloc
-        randint = numpy.random.random_integers
+        randint = numpy.random.randint
         adscal = dscalar()
         aiscal = lscalar()
         biscal = lscalar()
         ciscal = lscalar()
         discal = lscalar()
         adscal_val = rand()
-        aiscal_val = randint(3, 5, size=())
-        biscal_val = randint(3, 5, size=())
-        ciscal_val = randint(3, 5, size=())
-        discal_val = randint(3, 5, size=())
+        aiscal_val = randint(3, 6, size=())
+        biscal_val = randint(3, 6, size=())
+        ciscal_val = randint(3, 6, size=())
+        discal_val = randint(3, 6, size=())
         self._compile_and_check([adscal, aiscal, biscal, ciscal, discal],
                 [Alloc()(adscal, aiscal, biscal, ciscal, discal)],
                 [adscal_val, aiscal_val, biscal_val,
@@ -8000,8 +8000,7 @@ class T_Choose(utt.InferShapeTester):
         a = tensor.vector(dtype='int32')
         b = tensor.matrix(dtype='float32')
 
-        A = numpy.asarray(numpy.random.random_integers(0, 3, 4),
-                          dtype='int32')
+        A = numpy.random.randint(0, 4, 4, dtype='int32')
         B = numpy.asarray(numpy.random.rand(4, 4), dtype='float32')
 
         for m in self.modes:
@@ -8048,8 +8047,7 @@ class T_Choose(utt.InferShapeTester):
         b = tensor.tensor3(dtype='float32')
         c = tensor.tensor3(dtype='float32')
 
-        A = numpy.asarray(numpy.random.random_integers(0, 1, (2, 1, 1)),
-                          dtype='int32')
+        A = numpy.random.randint(0, 2, (2, 1, 1), dtype='int32')
         B = numpy.asarray(numpy.random.rand(1, 6, 1), dtype='float32')
         C = numpy.asarray(numpy.random.rand(1, 1, 5), dtype='float32')
 

--- a/theano/tensor/tests/test_extra_ops.py
+++ b/theano/tensor/tests/test_extra_ops.py
@@ -245,7 +245,7 @@ class TestBinCountOp(utt.InferShapeTester):
                       'uint8', 'uint16', 'uint32', 'uint64'):
             x = T.vector('x', dtype=dtype)
 
-            a = np.random.random_integers(50, size=(25)).astype(dtype)
+            a = np.random.randint(1, 51, size=(25)).astype(dtype)
             weights = np.random.random((25,)).astype(config.floatX)
 
             f1 = theano.function([x], bincount(x))
@@ -281,7 +281,7 @@ class TestBinCountOp(utt.InferShapeTester):
                 self.assertRaises(TypeError, BinCountOp(), x)
 
             else:
-                a = np.random.random_integers(50, size=(25)).astype(dtype)
+                a = np.random.randint(1, 51, size=(25)).astype(dtype)
                 weights = np.random.random((25,)).astype(config.floatX)
 
                 f1 = theano.function([x], BinCountOp()(x, weights=None))
@@ -316,29 +316,29 @@ class TestBinCountOp(utt.InferShapeTester):
             else:
                 self._compile_and_check([x],
                                         [BinCountOp()(x, None)],
-                                        [np.random.random_integers(
-                                            50, size=(25,)).astype(dtype)],
+                                        [np.random.randint(
+                                             1, 51, size=(25,)).astype(dtype)],
                                         self.op_class)
 
                 weights = np.random.random((25,)).astype(config.floatX)
                 self._compile_and_check([x],
                                         [BinCountOp()(x, weights=weights)],
-                                        [np.random.random_integers(
-                                            50, size=(25,)).astype(dtype)],
+                                        [np.random.randint(
+                                            1, 51, size=(25,)).astype(dtype)],
                                         self.op_class)
 
                 if not numpy_16:
                     continue
                 self._compile_and_check([x],
                                         [BinCountOp(minlength=60)(x, weights=weights)],
-                                        [np.random.random_integers(
-                                            50, size=(25,)).astype(dtype)],
+                                        [np.random.randint(
+                                            1, 51, size=(25,)).astype(dtype)],
                                         self.op_class)
 
                 self._compile_and_check([x],
                                         [BinCountOp(minlength=5)(x, weights=weights)],
-                                        [np.random.random_integers(
-                                            50, size=(25,)).astype(dtype)],
+                                        [np.random.randint(
+                                            1, 51, size=(25,)).astype(dtype)],
                                         self.op_class)
 
 
@@ -525,11 +525,11 @@ class TestRepeatOp(utt.InferShapeTester):
 
                         r_var = T.vector(dtype=dtype)
                         if axis is None:
-                            r = np.random.random_integers(
-                                5, size=a.size).astype(dtype)
+                            r = np.random.randint(
+                                1, 6, size=a.size).astype(dtype)
                         else:
-                            r = np.random.random_integers(
-                                5, size=(10,)).astype(dtype)
+                            r = np.random.randint(
+                                1, 6, size=(10,)).astype(dtype)
 
                         if dtype in self.numpy_unsupported_dtypes and r_var.ndim == 1:
                             self.assertRaises(TypeError,
@@ -541,8 +541,8 @@ class TestRepeatOp(utt.InferShapeTester):
                                                f(a, r))
 
                         # check when r is a list of single integer, e.g. [3].
-                        r = np.random.random_integers(
-                            10, size=()).astype(dtype) + 2
+                        r = np.random.randint(
+                            1, 11, size=()).astype(dtype) + 2
                         f = theano.function([x],
                                             repeat(x, [r], axis=axis))
                         assert np.allclose(np.repeat(a, r, axis=axis),
@@ -553,7 +553,7 @@ class TestRepeatOp(utt.InferShapeTester):
                         # check when r is  theano tensortype that broadcastable is (True,)
                         r_var = theano.tensor.TensorType(broadcastable=(True,),
                                                          dtype=dtype)()
-                        r = np.random.random_integers(5, size=(1,)).astype(dtype)
+                        r = np.random.randint(1, 6, size=(1,)).astype(dtype)
                         f = theano.function([x, r_var],
                                             repeat(x, r_var, axis=axis))
                         assert np.allclose(np.repeat(a, r[0], axis=axis),
@@ -583,14 +583,14 @@ class TestRepeatOp(utt.InferShapeTester):
 
                         r_var = T.vector(dtype=dtype)
                         if axis is None:
-                            r = np.random.random_integers(
-                                5, size=a.size).astype(dtype)
+                            r = np.random.randint(
+                                1, 6, size=a.size).astype(dtype)
                         elif a.size > 0:
-                            r = np.random.random_integers(
-                                5, size=a.shape[axis]).astype(dtype)
+                            r = np.random.randint(
+                                1, 6, size=a.shape[axis]).astype(dtype)
                         else:
-                            r = np.random.random_integers(
-                                5, size=(10,)).astype(dtype)
+                            r = np.random.randint(
+                                1, 6, size=(10,)).astype(dtype)
 
                         self._compile_and_check(
                             [x, r_var],
@@ -625,7 +625,7 @@ class TestBartlett(utt.InferShapeTester):
     def test_perform(self):
         x = tensor.lscalar()
         f = function([x], self.op(x))
-        M = numpy.random.random_integers(3, 50, size=())
+        M = numpy.random.randint(3, 51, size=())
         assert numpy.allclose(f(M), numpy.bartlett(M))
         assert numpy.allclose(f(0), numpy.bartlett(0))
         assert numpy.allclose(f(-1), numpy.bartlett(-1))
@@ -635,7 +635,7 @@ class TestBartlett(utt.InferShapeTester):
     def test_infer_shape(self):
         x = tensor.lscalar()
         self._compile_and_check([x], [self.op(x)],
-                                [numpy.random.random_integers(3, 50, size=())],
+                                [numpy.random.randint(3, 51, size=())],
                                 self.op_class)
         self._compile_and_check([x], [self.op(x)], [0], self.op_class)
         self._compile_and_check([x], [self.op(x)], [1], self.op_class)

--- a/theano/tensor/tests/test_raw_random.py
+++ b/theano/tensor/tests/test_raw_random.py
@@ -378,8 +378,10 @@ class T_random_function(utt.InferShapeTester):
         self.assertTrue(numpy.allclose(val1, numpy_val1))
 
     def test_random_integers(self):
-        """Test that raw_random.random_integers generates the same
-        results as numpy."""
+        # Test that raw_random.random_integers generates the same
+        # results as numpy.  We use randint() for comparison since
+        # random_integers() is deprecated.
+
         # Check over two calls to see if the random state is correctly updated.
         rng_R = random_state_type()
         # Use non-default parameters, and larger dimensions because of
@@ -395,8 +397,8 @@ class T_random_function(utt.InferShapeTester):
         numpy_rng = numpy.random.RandomState(utt.fetch_seed())
         val0 = f()
         val1 = f()
-        numpy_val0 = numpy_rng.random_integers(-3, 16, size=(11, 8))
-        numpy_val1 = numpy_rng.random_integers(-3, 16, size=(11, 8))
+        numpy_val0 = numpy_rng.randint(-3, 17, size=(11, 8))
+        numpy_val1 = numpy_rng.randint(-3, 17, size=(11, 8))
         self.assertTrue(numpy.allclose(val0, numpy_val0))
         self.assertTrue(numpy.allclose(val1, numpy_val1))
 
@@ -845,13 +847,13 @@ class T_random_function(utt.InferShapeTester):
 
         # Arguments of size (3,)
         rng0, val0 = f(rng, low_val, high_val)
-        numpy_val0 = numpy.asarray([numpy_rng.random_integers(low=lv, high=hv)
+        numpy_val0 = numpy.asarray([numpy_rng.randint(low=lv, high=hv+1)
             for lv, hv in zip(low_val, high_val)])
         assert numpy.all(val0 == numpy_val0)
 
         # arguments of size (2,)
         rng1, val1 = f(rng0, low_val[:-1], high_val[:-1])
-        numpy_val1 = numpy.asarray([numpy_rng.random_integers(low=lv, high=hv)
+        numpy_val1 = numpy.asarray([numpy_rng.randint(low=lv, high=hv+1)
             for lv, hv in zip(low_val[:-1], high_val[:-1])])
         assert numpy.all(val1 == numpy_val1)
 
@@ -860,7 +862,7 @@ class T_random_function(utt.InferShapeTester):
                 random_integers(rng_R, low=low, high=high, size=(3,)),
                 accept_inplace=True)
         rng2, val2 = g(rng1, low_val, high_val)
-        numpy_val2 = numpy.asarray([numpy_rng.random_integers(low=lv, high=hv)
+        numpy_val2 = numpy.asarray([numpy_rng.randint(low=lv, high=hv+1)
             for lv, hv in zip(low_val, high_val)])
         assert numpy.all(val2 == numpy_val2)
         self.assertRaises(ValueError, g, rng2, low_val[:-1], high_val[:-1])

--- a/theano/tensor/tests/test_shared_randomstreams.py
+++ b/theano/tensor/tests/test_shared_randomstreams.py
@@ -170,7 +170,10 @@ class T_SharedRandomStreams(unittest.TestCase):
         assert numpy.allclose(fn_val1, numpy_val1)
 
     def test_random_integers(self):
-        """Test that RandomStreams.random_integers generates the same results as numpy"""
+        # Test that RandomStreams.random_integers generates the same
+        # results as numpy.  We use randint() for numpy since
+        # random_integers() is deprecated.
+
         # Check over two calls to see if the random state is correctly updated.
         random = RandomStreams(utt.fetch_seed())
         fn = function([], random.random_integers((20, 20), -5, 5))
@@ -179,8 +182,8 @@ class T_SharedRandomStreams(unittest.TestCase):
 
         rng_seed = numpy.random.RandomState(utt.fetch_seed()).randint(2**30)
         rng = numpy.random.RandomState(int(rng_seed))  # int() is for 32bit
-        numpy_val0 = rng.random_integers(-5, 5, size=(20, 20))
-        numpy_val1 = rng.random_integers(-5, 5, size=(20, 20))
+        numpy_val0 = rng.randint(-5, 6, size=(20, 20))
+        numpy_val1 = rng.randint(-5, 6, size=(20, 20))
 
         assert numpy.all(fn_val0 == numpy_val0)
         assert numpy.all(fn_val1 == numpy_val1)
@@ -610,21 +613,21 @@ class T_SharedRandomStreams(unittest.TestCase):
 
         # Arguments of size (3,)
         val0 = f(low_val, high_val)
-        numpy_val0 = numpy.asarray([numpy_rng.random_integers(low=lv, high=hv)
+        numpy_val0 = numpy.asarray([numpy_rng.randint(low=lv, high=hv+1)
             for lv, hv in zip(low_val, high_val)])
         assert numpy.all(val0 == numpy_val0)
 
         # arguments of size (2,)
         val1 = f(low_val[:-1], high_val[:-1])
-        numpy_val1 = numpy.asarray([numpy_rng.random_integers(low=lv, high=hv)
+        numpy_val1 = numpy.asarray([numpy_rng.randint(low=lv, high=hv+1)
             for lv, hv in zip(low_val[:-1], high_val[:-1])])
         assert numpy.all(val1 == numpy_val1)
 
         # Specifying the size explicitly
-        g = function([low, high], random.random_integers(low=low, high=high, size=(3,)))
+        g = function([low, high], random.randint(low=low, high=high+1, size=(3,)))
         val2 = g(low_val, high_val)
         numpy_rng = numpy.random.RandomState(int(seed_gen.randint(2**30)))
-        numpy_val2 = numpy.asarray([numpy_rng.random_integers(low=lv, high=hv)
+        numpy_val2 = numpy.asarray([numpy_rng.randint(low=lv, high=hv+1)
             for lv, hv in zip(low_val, high_val)])
         assert numpy.all(val2 == numpy_val2)
         self.assertRaises(ValueError, g, low_val[:-1], high_val[:-1])

--- a/theano/typed_list/tests/test_basic.py
+++ b/theano/typed_list/tests/test_basic.py
@@ -34,7 +34,7 @@ def random_lil(shape, dtype, nnz):
     huge = 2 ** 30
     for k in range(nnz):
         # set non-zeros in random locations (row x, col y)
-        idx = numpy.random.random_integers(huge, size=2) % shape
+        idx = numpy.random.randint(1, huge+1, size=2) % shape
         value = numpy.random.rand()
         # if dtype *int*, value will always be zeros!
         if "int" in dtype:


### PR DESCRIPTION
This should be a comprehensive for the warnings in numpy 1.11.