### PR TITLE
Fix abstractconv_grad dilation and enable border_mode tests

### DIFF
--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -966,14 +966,15 @@ class AbstractConv2d_gradWeights(BaseAbstractConv2d):
                 '"valid", "full", "half", an integer or a pair of'
                 ' integers'.format(mode))
 
+        dil_shape = ((shape[0] - 1) * self.filter_dilation[0] + 1,
+                     (shape[1] - 1) * self.filter_dilation[1] + 1)
+
         if mode == "full":
-            mode = (shape[0] - 1, shape[1] - 1)
+            mode = (dil_shape[0] - 1, dil_shape[1] - 1)
         elif mode == "half":
-            mode = (shape[0] // 2, shape[1] // 2)
+            mode = (dil_shape[0] // 2, dil_shape[1] // 2)
         if isinstance(mode, tuple):
             pad_h, pad_w = map(int, mode)
-            pad_h = (pad_h - 1) * self.filter_dilation[0] + 1
-            pad_w = (pad_w - 1) * self.filter_dilation[1] + 1
 
             mode = "valid"
             new_img = numpy.zeros((img.shape[0], img.shape[1],
@@ -983,8 +984,6 @@ class AbstractConv2d_gradWeights(BaseAbstractConv2d):
             img = new_img
 
         if self.subsample[0] > 1 or self.subsample[1] > 1:
-            dil_shape = ((shape[0] - 1) * self.filter_dilation[0] + 1,
-                         (shape[1] - 1) * self.filter_dilation[1] + 1)
             new_shape = (topgrad.shape[0], topgrad.shape[1],
                          img.shape[2] - dil_shape[0] + 1,
                          img.shape[3] - dil_shape[1] + 1)
@@ -1114,9 +1113,9 @@ class AbstractConv2d_gradInputs(BaseAbstractConv2d):
                        (kern.shape[3] - 1) * self.filter_dilation[1] + 1)
         pad_h, pad_w = 0, 0
         if mode == "full":
-            pad_h, pad_w = (dil_kernshp[0] - 1, dil_kernshp[0] - 1)
+            pad_h, pad_w = (dil_kernshp[0] - 1, dil_kernshp[1] - 1)
         elif mode == "half":
-            pad_h, pad_w = (dil_kernshp[1] // 2, dil_kernshp[1] // 2)
+            pad_h, pad_w = (dil_kernshp[0] // 2, dil_kernshp[1] // 2)
         elif isinstance(mode, tuple):
             pad_h, pad_w = map(int, self.border_mode)
         if self.subsample[0] > 1 or self.subsample[1] > 1:

--- a/theano/tensor/nnet/tests/test_abstract_conv.py
+++ b/theano/tensor/nnet/tests/test_abstract_conv.py
@@ -89,7 +89,7 @@ class BaseTestConv2d:
                               (1, 1, 2, 3), (4, 1, 1, 3), (4, 5, 3, 2)]
         cls.subsamples = [(1, 1), (2, 2), (2, 4)]
         cls.filters_dilations = [(1, 1), (1, 2), (2, 1)]
-        cls.border_modes = ["valid", "full", (0, 0), (1, 1), (5, 5), (5, 2)]
+        cls.border_modes = ["valid", "half", "full", (0, 0), (1, 1), (5, 5), (5, 2)]
         cls.filter_flip = [True, False]
         cls.provide_shape = [True, False]
         cls.shared = staticmethod(theano.compile.shared)
@@ -100,6 +100,9 @@ class BaseTestConv2d:
                        (filters_shape[3] - 1) * filter_dilation[1] + 1)
         if border_mode == "valid":
             border_mode = (0, 0)
+        if border_mode == "half":
+            border_mode = (dil_filters[0] // 2,
+                           dil_filters[1] // 2)
         if border_mode == "full":
             border_mode = (dil_filters[0] - 1,
                            dil_filters[1] - 1)
@@ -292,7 +295,7 @@ class BaseTestConv2d:
             for fd in self.filters_dilations:
                 for s in self.subsamples:
                     for b in self.border_modes:
-                        yield (self.tcase, i, f, s, db, dflip,
+                        yield (self.tcase, i, f, s, b, dflip,
                                dprovide_shape, fd)
             for flip in self.filter_flip:
                 yield (self.tcase, i, f, ds, db, flip, dprovide_shape)


### PR DESCRIPTION
I think there are a few bugs in commit bbc749ab516 (e.g., lines [1116-L1119 of abstract_conv.py](https://github.com/ballasn/Theano/blob/bbc749ab516a1242d5eb359d1d34cf5fbd031167/theano/tensor/nnet/abstract_conv.py#L1116-L1119), see also #4846), which would give problems with non-symmetric filter dilations for border_modes full or half and with custom padding (which should not be multiplied with the dilation factor).

These errors would have been visible only in the debug mode, if the test had worked. It seems that the test only used the default `border_mode = 'valid'`, but the errors occur with `full` and `half`. This commit should fix that.

Finally, this commit adds `border_mode = "half"` to the tests.