### PR TITLE
Modified Developer Start Guide VIM instructions

### DIFF
--- a/doc/dev_start_guide.txt
+++ b/doc/dev_start_guide.txt
@@ -154,6 +154,8 @@ To setup VIM:
         Plugin 'scrooloose/syntastic'
         Plugin 'jimf/vim-pep8-text-width'
 
+        call vundle#end()
+
         " Syntastic settings
         " You can run checkers explicitly by calling :SyntasticCheck <checker
         let g:syntastic_python_checkers = ['flake8'] "use one of the following checkers:


### PR DESCRIPTION
Plugins will not load without calling `vundle#end()`