### PR TITLE
Add a wrapper function for kernels to simplify calling.

### DIFF
--- a/doc/extending/extending_theano_gpu.txt
+++ b/doc/extending/extending_theano_gpu.txt
@@ -163,7 +163,7 @@ would be::
 
     ls = 1;
     gs = 256;
-    err = k_call(1, &ls, &gs, 0, input->ga.data, dims[0], dims[1]);
+    err = k_call(1, &gs, &ls, 0, input->ga.data, dims[0], dims[1]);
 
     // ...
 

--- a/doc/extending/extending_theano_gpu.txt
+++ b/doc/extending/extending_theano_gpu.txt
@@ -152,30 +152,24 @@ go this way, then you can look up the C API for kernels in
 libgpuarray.
 
 In any case you will need to call your compiled kernel with some data,
-in most cases in your :meth:`c_code` method.  This is done using the
-`GpuKernel_call()
-<http://deeplearning.net/software/libgpuarray/c_api.html#GpuKernel_call>`_
-function in your C code.  An example calling the above kernel would
-be::
+in most cases in your :meth:`c_code` method.  This is done by using
+the provided wrapper function. An example calling the above kernel
+would be::
 
     size_t ls, gs;
     size_t dims[2];
-    void *args[3];
 
     // ...
 
-    args[0] = input->ga.data;
-    args[1] = &dims[0];
-    args[2] = &dims[1];
     ls = 1;
     gs = 256;
-    err = GpuKernel_call(&k_k, 1, &ls, &gs, 0, args);
+    err = k_call(1, &ls, &gs, 0, input->ga.data, dims[0], dims[1]);
 
     // ...
 
-The name of the kernel object depends on the name you passed to
+The name of the wrapper function depends on the name you passed to
 ``Kernel()`` when you declared it (or the name in your `#kernel`
-statement).  It defaults to `'k_' + name`.
+statement).  It defaults to `name + '_call'`.
 
 For other operations in the C code you should refer to the
 `libgpuarray documentation

--- a/theano/gpuarray/basic_ops.py
+++ b/theano/gpuarray/basic_ops.py
@@ -262,11 +262,13 @@ class Kernel(object):
 def get_ctype(dtype):
     if dtype is gpuarray.GpuArray:
         return "gpudata *"
-    if dtype == gpuarray.SIZE:
+    elif dtype == gpuarray.SIZE:
         return "size_t"
-    if dtype == gpuarray.SSIZE:
+    elif dtype == gpuarray.SSIZE:
         return "ssize_t"
     else:
+        if not isinstance(dtype, numpy.dtype):
+            dtype = numpy.dtype(dtype)
         return dtype.name + '_t'
 
 

--- a/theano/gpuarray/basic_ops.py
+++ b/theano/gpuarray/basic_ops.py
@@ -329,7 +329,7 @@ class GpuKernelBase(object):
         setargs = '\n  '.join(setargs)
 
         return """
-int {fname}(unsigned int nd, size_t *ldim, size_t *gdim, size_t shared,
+int {fname}(unsigned int nd, size_t *gdim, size_t *ldim, size_t shared,
                   {args}) {{
   {setargs}
 
@@ -419,7 +419,7 @@ int {fname}(unsigned int nd, size_t *ldim, size_t *gdim, size_t shared,
             The node that we need the cache version for.
 
         """
-        return (5, self.get_params(node).bin_id)
+        return (6, self.get_params(node).bin_id)
 
 
 def forward_string_meth(name):
@@ -1393,7 +1393,7 @@ KERNEL void eye(GLOBAL_MEM %(ctype)s *a, ga_size n, ga_size m) {
 
         ls = 1;
         gs = 256;
-        err = eye_call(1, &ls, &gs, 0, %(z)s->ga.data, dims[0], dims[1]);
+        err = eye_call(1, &gs, &ls, 0, %(z)s->ga.data, dims[0], dims[1]);
         if (err != GA_NO_ERROR) {
             PyErr_Format(PyExc_RuntimeError,
                          "gpuarray error: kEye: %%s. n%%lu, m=%%lu.",

--- a/theano/gpuarray/tests/tstgpueye.c
+++ b/theano/gpuarray/tests/tstgpueye.c
@@ -37,7 +37,7 @@ int APPLY_SPECIFIC(tstgpueye)(PyArrayObject *n, PyArrayObject *m,
   ls = 1;
   gs = 256;
   /* The eye_call name comes from the kernel declaration above. */
-  err = eye_call(1, &ls, &gs, 0, (*z)->ga.data, dims[0], dims[1]);
+  err = eye_call(1, &gs, &ls, 0, (*z)->ga.data, dims[0], dims[1]);
   if (err != GA_NO_ERROR) {
     PyErr_Format(PyExc_RuntimeError,
                  "gpuarray error: kEye: %s. n%lu, m=%lu.",

--- a/theano/gpuarray/tests/tstgpueye.c
+++ b/theano/gpuarray/tests/tstgpueye.c
@@ -34,13 +34,10 @@ int APPLY_SPECIFIC(tstgpueye)(PyArrayObject *n, PyArrayObject *m,
   if (*z == NULL)
     return -1;
 
-  args[0] = (*z)->ga.data;
-  args[1] = &dims[0];
-  args[2] = &dims[1];
   ls = 1;
   gs = 256;
-  /* The k_eye name comes from the kernel declaration above. */
-  err = GpuKernel_call(&k_eye, 1, &ls, &gs, 0, args);
+  /* The eye_call name comes from the kernel declaration above. */
+  err = eye_call(1, &ls, &gs, 0, (*z)->ga.data, dims[0], dims[1]);
   if (err != GA_NO_ERROR) {
     PyErr_Format(PyExc_RuntimeError,
                  "gpuarray error: kEye: %s. n%lu, m=%lu.",


### PR DESCRIPTION
This comes with tests and docs changes.  This also updates GpuEye to use it so that we have a real-world example.

I did this in preparation of the CorrMM port but this is a worthwhile improvement regardless.