### PR TITLE
Fix d3viz multi-level/inheritance tags

### DIFF
--- a/theano/d3viz/formatting.py
+++ b/theano/d3viz/formatting.py
@@ -292,7 +292,10 @@ def var_tag(var):
     """Parse tag attribute of variable node."""
     tag = var.tag
     if hasattr(tag, 'trace') and len(tag.trace) and len(tag.trace[0]) == 4:
-        path, line, _, src = tag.trace[0]
+        if isinstance(tag.trace[0][0], (tuple, list)):
+            path, line, _, src = tag.trace[0][-1]
+        else:
+            path, line, _, src = tag.trace[0]
         path = os.path.basename(path)
         path = path.replace('<', '')
         path = path.replace('>', '')


### PR DESCRIPTION
I tried to visualize a Theano computation graph build with Keras by accessing it through `model.train_function.function`. I am not exactly sure what happens, but instead of a single trace tuple a list of tuples gets returned (each one containing a path, line, module, src). This results in the following exception.

```
Traceback (most recent call last):
  File "./train.py", line 203, in <module>
    d3v.d3viz(model.train_function.function, 'd3v_model.html')
  File "/usr/local/lib/python2.7/dist-packages/theano/d3viz/d3viz.py", line 79, in d3viz
    graph = formatter(fct)
  File "/usr/local/lib/python2.7/dist-packages/theano/d3viz/formatting.py", line 199, in __call__
    vparams['tag'] = var_tag(var)
  File "/usr/local/lib/python2.7/dist-packages/theano/d3viz/formatting.py", line 311, in var_tag
    path = os.path.basename(path)
  File "/usr/lib/python2.7/posixpath.py", line 114, in basename
    i = p.rfind('/') + 1
AttributeError: 'tuple' object has no attribute 'rfind'
```

```python
(Pdb) print tag.trace
[[('./train.py', 16, '<module>', 'from keras.utils.visualize_util import plot'),
  ('/usr/local/lib/python2.7/dist-packages/keras/__init__.py', 2, '<module>', 'from . import backend'),
  ('/usr/local/lib/python2.7/dist-packages/keras/backend/__init__.py', 61, '<module>', 'from .theano_backend import *'),
  ('/usr/local/lib/python2.7/dist-packages/keras/backend/theano_backend.py', 18, '<module>', "_LEARNING_PHASE = T.scalar(dtype='uint8', name='keras_learning_phase')  # 0 = test, 1 = train")
]]
```

As a solution I am proposing this PR to use the last trace tuple for constructing the d3viz tag.