### PR TITLE
Improve the example for strict=True in the scan() doc.

### DIFF
--- a/doc/library/scan.txt
+++ b/doc/library/scan.txt
@@ -400,7 +400,6 @@ Using the original Gibbs sampling example, with ``strict=True`` added to the
         return trng.binomial(size=vsample.shape, n=1, p=vmean,
                              dtype=theano.config.floatX)
 
-
     # The new scan, adding strict=True to the original call.
     # Produces an error, because W, bvis and bhid are used by OneStep, but not
     # passed explicitly.

--- a/doc/library/scan.txt
+++ b/doc/library/scan.txt
@@ -390,7 +390,7 @@ ensured by the user. Otherwise, it will result in an error.
 Using the original Gibbs sampling example, with ``strict=True`` added to the
 ``scan()`` call:
 
-.. testcode:: scan_strict
+.. code-block:: python
 
     # Same OneStep as in original example.
     def OneStep(vsample) :

--- a/doc/library/scan.txt
+++ b/doc/library/scan.txt
@@ -383,23 +383,34 @@ Using shared variables - the strict flag
 As we just saw, passing the shared variables to scan may result in a simpler
 computational graph, which speeds up the optimization and the execution. A
 good way to remember to pass every shared variable used during scan is to use
-the ``strict`` flag. When set to true, scan assumes that all the necessary
-shared variables in ``fn`` are passed as a part of ``non_sequences``. This has
-to be ensured by the user. Otherwise, it will result in an error.
+the ``strict`` flag. When set to true, scan checks that all the necessary shared
+variables in ``fn`` are passed as explicit arguments to ``fn``. This has to be
+ensured by the user. Otherwise, it will result in an error.
 
-Using the previous Gibbs sampling example:
+Using the original Gibbs sampling example, with ``strict=True`` added to the
+``scan()`` call:
 
-.. testcode:: scan1
+.. testcode:: scan_strict
 
-    # The new scan, using strict=True
-    values, updates = theano.scan(fn=OneStep,
+    # Same OneStep as in original example.
+    def OneStep(vsample) :
+        hmean = T.nnet.sigmoid(theano.dot(vsample, W) + bhid)
+        hsample = trng.binomial(size=hmean.shape, n=1, p=hmean)
+        vmean = T.nnet.sigmoid(theano.dot(hsample, W.T) + bvis)
+        return trng.binomial(size=vsample.shape, n=1, p=vmean,
+                             dtype=theano.config.floatX)
+
+
+    # The new scan, adding strict=True to the original call.
+    # Produces an error, because W, bvis and bhid are used by OneStep, but not
+    # passed explicitly.
+    values, updates = theano.scan(OneStep,
                                   outputs_info=sample,
-                                  non_sequences=[W, bvis, bhid],
                                   n_steps=10,
                                   strict=True)
 
-If you omit to pass ``W``, ``bvis`` or ``bhid`` as a ``non_sequence``, it will
-result in an error.
+The above will result in an error, indicating that ``OneStep`` relies on
+variables that are not passed as its explicit arguments.
 
 
 Multiple outputs, several taps values - Recurrent Neural Network with Scan


### PR DESCRIPTION
Change the example illustrating the effect of strict=True in the scan() doc to actually trigger the proper error. Existing example triggers a different one (non_sequences not aligned with the arguments of OneStep) if one simply omits some of the [W, bvis, bhid] from non_sequences.
