### PR TITLE
Remove nose-parameterized dependency from theano.sparse

### DIFF
--- a/theano/sparse/basic.py
+++ b/theano/sparse/basic.py
@@ -22,7 +22,6 @@ import theano
 from theano import gof, tensor, scalar, config
 from theano.gradient import DisconnectedType
 from theano.sparse.utils import hash_from_sparse
-import theano.tests.unittest_tools as utt
 from theano.gradient import grad_not_implemented, grad_undefined
 from theano.sparse.type import SparseType, _is_sparse
 
@@ -156,7 +155,6 @@ def as_sparse_or_tensor_variable(x, name=None):
     except (ValueError, TypeError):
         return theano.tensor.as_tensor_variable(x, name)
 
-
 def verify_grad_sparse(op, pt, structured=False, *args, **kwargs):
     """
     Wrapper for theano.test.unittest_tools.py:verify_grad wich
@@ -234,8 +232,10 @@ def verify_grad_sparse(op, pt, structured=False, *args, **kwargs):
         out = op(*ipt)
         return oconv(out)
 
-    return utt.verify_grad(conv_op, dpt, *args, **kwargs)
-verify_grad_sparse.E_grad = utt.verify_grad.E_grad
+    seed_rng()
+    rng = numpy.random
+    T.verify_grad(conv_op, dpt, 2, rng, *args, **kwargs)
+verify_grad_sparse.E_grad = T.verify_grad.E_grad
 
 
 def constant(x, name=None):

--- a/theano/sparse/basic.py
+++ b/theano/sparse/basic.py
@@ -19,6 +19,7 @@ from six.moves import xrange
 import scipy.sparse
 
 import theano
+import theano.tensor as T
 from theano import gof, tensor, scalar, config
 from theano.gradient import DisconnectedType
 from theano.sparse.utils import hash_from_sparse

--- a/theano/sparse/basic.py
+++ b/theano/sparse/basic.py
@@ -233,9 +233,7 @@ def verify_grad_sparse(op, pt, structured=False, *args, **kwargs):
         out = op(*ipt)
         return oconv(out)
 
-    seed_rng()
-    rng = numpy.random
-    T.verify_grad(conv_op, dpt, 2, rng, *args, **kwargs)
+    T.verify_grad(conv_op, dpt, 2, numpy.random, *args, **kwargs)
 verify_grad_sparse.E_grad = T.verify_grad.E_grad
 
 


### PR DESCRIPTION
Theano.sparse takes a transitive runtime dependency on nose-parameterized which is not bundled as a dependency when you install theano from pip

This turns out to be due to an import of a test file which imports nose-parameterized.

The util function being called was quite trivial so I inlined it. 

This is causing me trouble trying to add sparse matrix support to Keras https://github.com/fchollet/keras/pull/3695