### PR TITLE
Postpone Composite name creating

### DIFF
--- a/theano/compile/debugmode.py
+++ b/theano/compile/debugmode.py
@@ -1838,9 +1838,7 @@ class _Linker(gof.link.LocalLinker):
                 thunk.outputs = [storage_map[v] for v in node.outputs]
                 thunk_other = thunk
             else:
-                new_node = node.op.prepare_node(node, storage_map, compute_map)
-                if new_node is not None:
-                    node = new_node
+                node.op.prepare_node(node, storage_map, compute_map)
 
             debug = hasattr(node.op, 'debug_perform')
 

--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -1582,6 +1582,9 @@ class CLinker(link.Linker):
             # If we can't get a key, then forget the cache mechanism.
             module = self.compile_cmodule()
         else:
+            # Set compute_map as None as clinker do not support lazy evaluation
+            for node in self.node_order:
+                node.op.prepare_node(node, storage_map, None)
             module = get_module_cache().module_from_key(
                 key=key, lnk=self, keep_lock=keep_lock)
 

--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -795,7 +795,7 @@ class Op(utils.object2, PureOp, CLinkerOp):
         Make any special modifications that the Op needs before doing
         make_thunk().
 
-        This can either modify the node inplace or return a new one.
+        This can modify the node inplace and should return nothing.
 
         """
         pass
@@ -916,10 +916,9 @@ class Op(utils.object2, PureOp, CLinkerOp):
         """
         logger = logging.getLogger('theano.gof.op.Op')
 
-        new_node = self.prepare_node(node, storage_map=storage_map,
-                                     compute_map=compute_map)
-        if new_node is not None:
-            node = new_node
+        self.prepare_node(node, storage_map=storage_map,
+                          compute_map=compute_map)
+
         if not hasattr(self, '_op_use_c_code'):
             warnings.warn(
                 "The  __getstate__ method of '%s' is not implemented correctly."

--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -3478,7 +3478,7 @@ class Composite(ScalarOp):
         if name:
             out.name = name
         else:
-            name = getattr(out, 'name', None)
+            name = out.name
         super(Composite, out).__init__(output_types_preference, name)
         return out
 
@@ -3561,34 +3561,19 @@ class Composite(ScalarOp):
         Return a readable string representation of self.fgraph.
 
         """
-        try:
-            rval = self.name
-            if rval is None:
-                raise AttributeError
-        except AttributeError:
-            if 0:
-                l = []
-                for n in self.fgraph.toposort():
-                    if hasattr(n.op, "name") and n.op.name is not None:
-                        v = n.op.name
-                        if v.startswith("Composite"):
-                            v = v[len("Composite"):]
-                    else:
-                        v = n.op.__class__.__name__
-                    l.append(v)
-                rval = "Composite{" + ",".join(l) + "}"
-            else:
-                for i, r in enumerate(self.fgraph.inputs):
-                    r.name = 'i%i' % i
-                for i, r in enumerate(self.fgraph.outputs):
-                    r.name = 'o%i' % i
-                io = set(self.fgraph.inputs + self.fgraph.outputs)
-                for i, r in enumerate(self.fgraph.variables):
-                    if r not in io and len(r.clients) > 1:
-                        r.name = 't%i' % i
-                rval = "Composite{%s}" % ', '.join([pprint(output) for output
-                                                    in self.fgraph.outputs])
-        self.name = rval
+        rval = self.name
+        if rval is None:
+            for i, r in enumerate(self.fgraph.inputs):
+                r.name = 'i%i' % i
+            for i, r in enumerate(self.fgraph.outputs):
+                r.name = 'o%i' % i
+            io = set(self.fgraph.inputs + self.fgraph.outputs)
+            for i, r in enumerate(self.fgraph.variables):
+                if r not in io and len(r.clients) > 1:
+                    r.name = 't%i' % i
+            rval = "Composite{%s}" % ', '.join([pprint(output) for output
+                                                in self.fgraph.outputs])
+            self.name = rval
 
     def init_fgraph(self):
         # The clone done by FunctionGraph is needed as we don't want

--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -3478,7 +3478,7 @@ class Composite(ScalarOp):
         if name:
             out.name = name
         else:
-            name = getattr(out,'name', None)
+            name = getattr(out, 'name', None)
         super(Composite, out).__init__(output_types_preference, name)
         return out
 

--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -3462,6 +3462,8 @@ class Composite(ScalarOp):
     init_param = ('inputs', 'outputs')
 
     def __str__(self):
+        if self.name is None:
+            self.init_name()
         return self.name
 
     def make_new_inplace(self, output_types_preference=None, name=None):
@@ -3476,7 +3478,7 @@ class Composite(ScalarOp):
         if name:
             out.name = name
         else:
-            name = out.name
+            name = getattr(out,'name', None)
         super(Composite, out).__init__(output_types_preference, name)
         return out
 
@@ -3558,6 +3560,8 @@ class Composite(ScalarOp):
         """
         try:
             rval = self.name
+            if rval is None:
+                raise AttributeError
         except AttributeError:
             if 0:
                 l = []
@@ -3642,7 +3646,10 @@ class Composite(ScalarOp):
         self.nin = len(inputs)
         self.nout = len(outputs)
         self.init_fgraph()       # self.fgraph
-        self.init_name()      # self.name
+
+        # Postpone the creation in case it isn't needed.
+        #  self.init_name()      # self.name
+        self.name = None
         self.init_c_code()    # self._c_code and self.nodenames
         self.init_py_impls()  # self._impls
 

--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -3658,6 +3658,8 @@ class Composite(ScalarOp):
 
     def prepare_node(self, node, storage_map, compute_map):
         self.init_py_impls()  # self._impls
+        for n in theano.gof.graph.list_of_nodes(self.inputs, self.outputs):
+            n.op.prepare_node(n, None, None)
 
     def output_types(self, input_types):
         if tuple(input_types) != self.inputs_type:

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -856,7 +856,7 @@ second dimension
             [get_scalar_type(dtype=output.type.dtype).make_variable()
              for output in node.outputs])
 
-        self.scalar_op.prepare_node(node.tag.fake_node, [], [])
+        self.scalar_op.prepare_node(node.tag.fake_node, None, None)
 
     def perform(self, node, inputs, output_storage):
         if len(node.inputs) >= 32:

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -849,11 +849,12 @@ second dimension
             char = numpy.sctype2char(out_dtype)
             sig = char * node.nin + '->' + char * node.nout
             node.tag.sig = sig
-        node.tag.fake_node = Apply(self.scalar_op,
-                  [get_scalar_type(dtype=input.type.dtype).make_variable()
-                   for input in node.inputs],
-                  [get_scalar_type(dtype=output.type.dtype).make_variable()
-                   for output in node.outputs])
+        node.tag.fake_node = Apply(
+            self.scalar_op,
+            [get_scalar_type(dtype=input.type.dtype).make_variable()
+             for input in node.inputs],
+            [get_scalar_type(dtype=output.type.dtype).make_variable()
+             for output in node.outputs])
 
         self.scalar_op.prepare_node(node.tag.fake_node, [], [])
 

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -999,6 +999,11 @@ second dimension
         return rval
 
     def _c_all(self, node, nodename, inames, onames, sub):
+        # Some ops call directly the Elemwise._c_all or Elemwise.c_code
+        # To not request all of them to call prepare_node(), do it here.
+        # There is no harm if it get called multile time.
+        if not hasattr(node.tag, 'fake_node'):
+            self.prepare_node(node, None, None)
         _inames = inames
         _onames = onames
 

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -7180,7 +7180,9 @@ def local_add_mul_fusion(node):
     for inp in node.inputs:
         if (inp.owner and
                 isinstance(inp.owner.op, Elemwise) and
-                isinstance(inp.owner.op.scalar_op, s_op)):
+                isinstance(inp.owner.op.scalar_op, s_op) and
+                # Do not duplicate the operation.
+                len(inp.clients) == 1):
             new_inp.extend(inp.owner.inputs)
             fused = True
         else:


### PR DESCRIPTION
Fix some compilation getting killed.

I does this. The error was related to the elemwise fusion. I postpone some work from Composite.__init__ to later when we use it as all the stack trace we got when doing CTRL-C during the execution was there. This should speed up compilation, but it also fixed the crashes.