### PR TITLE
gpuarray: Do not pass config.nvcc.compiler-bindir to g++

### DIFF
--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -67,8 +67,6 @@ if ((err = cudnnCreate(&_handle)) != CUDNN_STATUS_SUCCESS) {
         params.append("-I" + config.dnn.include_path)
     if config.dnn.library_path:
         params.append("-L" + config.dnn.library_path)
-    if config.nvcc.compiler_bindir:
-        params.extend(['--compiler-bindir', config.nvcc.compiler_bindir])
     # Do not run here the test program. It would run on the
     # default gpu, not the one selected by the user. If mixed
     # GPU are installed or if the GPUs are configured in


### PR DESCRIPTION
This is one way to fix #4978. It works for me, at least, and it seems logical if the OpenCL library is less dependent on a specific GCC version.