### PR TITLE
Fix crash in Lop

### DIFF
--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -345,7 +345,7 @@ def Lop(f, wrt, eval_points, consider_constant=None,
         wrt = [wrt]
 
     assert len(f) == len(grads)
-    known = dict(izip(f, grads))
+    known = OrderedDict(izip(f, grads))
 
     ret = grad(cost=None, known_grads=known,
                consider_constant=consider_constant, wrt=wrt,


### PR DESCRIPTION
Fix Lop to comply with new requirement that theano.grad's known_grad argument be an OrderedDict.