### PR TITLE
Add compile_args to Compiler._try_compile_tmp

### DIFF
--- a/.jenkins/jenkins_buildbot_python2_32bit.sh
+++ b/.jenkins/jenkins_buildbot_python2_32bit.sh
@@ -15,4 +15,4 @@ echo
 
 FILE=${BUILDBOT_DIR}/theano_python32bit_tests.xml
 set -x
-PYTHONPATH=$HOME/anaconda2_32bit/lib/python2.7/site-packages THEANO_FLAGS=device=cpu,force_device=true,lib.amdlibm=False,compiledir=$WORKSPACE/compile/theano_compile_dir_theano_python2_32bit,blas.ldflags= $HOME/anaconda2_32bit/bin/python bin/theano-nose ${THEANO_PARAM} ${XUNIT}${FILE}
+PYTHONPATH=$HOME/anaconda2_32bit/lib/python2.7/site-packages THEANO_FLAGS=device=cpu,force_device=true,lib.amdlibm=False,compiledir=$WORKSPACE/compile/theano_compile_dir_theano_python2_32bit $HOME/anaconda2_32bit/bin/python bin/theano-nose ${THEANO_PARAM} ${XUNIT}${FILE}

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1804,8 +1804,8 @@ class Compiler(object):
         }
         """ % locals())
         return cls._try_compile_tmp(code, tmp_prefix='try_flags_',
-                                         flags=flag_list, try_run=try_run,
-                                         output=output, compiler=compiler)
+                                    flags=flag_list, try_run=try_run,
+                                    output=output, compiler=compiler)
 
 
 def try_march_flag(flags):
@@ -2163,14 +2163,14 @@ class GCC_compiler(Compiler):
     def try_compile_tmp(cls, src_code, tmp_prefix='', flags=(),
                         try_run=False, output=False):
         return cls._try_compile_tmp(src_code, tmp_prefix, flags,
-                                         try_run, output,
-                                         theano.config.cxx)
+                                    try_run, output,
+                                    theano.config.cxx)
 
     @classmethod
     def try_flags(cls, flag_list, preambule="", body="",
                   try_run=False, output=False):
         return cls._try_flags(flag_list, preambule, body, try_run, output,
-                                   theano.config.cxx)
+                              theano.config.cxx)
 
     @staticmethod
     def compile_str(module_name, src_code, location=None,

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1713,7 +1713,8 @@ class Compiler(object):
 
     @classmethod
     def _try_compile_tmp(cls, src_code, tmp_prefix='', flags=(),
-                         try_run=False, output=False, compiler=None):
+                         try_run=False, output=False, compiler=None,
+                         comp_args=True):
         """
         Try to compile (and run) a test program.
 
@@ -1727,12 +1728,17 @@ class Compiler(object):
         If try_run is True, returns a (compile_status, run_status) pair.
         If output is there, we append the stdout and stderr to the output.
 
+        Compile arguments from the Compiler's compile_args() method are added
+        if comp_args=True.
         """
         if not compiler:
             return False
         flags = list(flags)
-        # Get compile arguments from compiler method
-        args = cls.compile_args()
+        # Get compile arguments from compiler method if required
+        if comp_args:
+            args = cls.compile_args()
+        else:
+            args = []
         compilation_ok = True
         run_ok = False
         out, err = None, None
@@ -1784,12 +1790,16 @@ class Compiler(object):
 
     @classmethod
     def _try_flags(cls, flag_list, preambule="", body="",
-                   try_run=False, output=False, compiler=None):
+                   try_run=False, output=False, compiler=None,
+                   comp_args=True):
         """
         Try to compile a dummy file with these flags.
 
         Returns True if compilation was successful, False if there
         were errors.
+
+        Compile arguments from the Compiler's compile_args() method are added
+        if comp_args=True.
 
         """
         if not compiler:
@@ -1805,7 +1815,8 @@ class Compiler(object):
         """ % locals())
         return cls._try_compile_tmp(code, tmp_prefix='try_flags_',
                                     flags=flag_list, try_run=try_run,
-                                    output=output, compiler=compiler)
+                                    output=output, compiler=compiler,
+                                    comp_args=comp_args)
 
 
 def try_march_flag(flags):
@@ -2161,16 +2172,16 @@ class GCC_compiler(Compiler):
 
     @classmethod
     def try_compile_tmp(cls, src_code, tmp_prefix='', flags=(),
-                        try_run=False, output=False):
+                        try_run=False, output=False, comp_args=True):
         return cls._try_compile_tmp(src_code, tmp_prefix, flags,
-                                    try_run, output,
-                                    theano.config.cxx)
+                                    try_run, output, theano.config.cxx,
+                                    comp_args)
 
     @classmethod
     def try_flags(cls, flag_list, preambule="", body="",
-                  try_run=False, output=False):
+                  try_run=False, output=False, comp_args=True):
         return cls._try_flags(flag_list, preambule, body, try_run, output,
-                              theano.config.cxx)
+                              theano.config.cxx, comp_args)
 
     @staticmethod
     def compile_str(module_name, src_code, location=None,

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1711,8 +1711,8 @@ class Compiler(object):
 
     """
 
-    @staticmethod
-    def _try_compile_tmp(src_code, tmp_prefix='', flags=(),
+    @classmethod
+    def _try_compile_tmp(cls, src_code, tmp_prefix='', flags=(),
                          try_run=False, output=False, compiler=None):
         """
         Try to compile (and run) a test program.
@@ -1730,8 +1730,9 @@ class Compiler(object):
         """
         if not compiler:
             return False
-
         flags = list(flags)
+        # Get compile arguments from compiler method
+        args = cls.compile_args()
         compilation_ok = True
         run_ok = False
         out, err = None, None
@@ -1748,7 +1749,7 @@ class Compiler(object):
                 os.close(fd)
                 fd = None
                 out, err, p_ret = output_subprocess_Popen(
-                    [compiler, path, '-o', exe_path] + flags)
+                    [compiler] + args + [path, '-o', exe_path] + flags)
                 if p_ret != 0:
                     compilation_ok = False
                 elif try_run:
@@ -1781,8 +1782,8 @@ class Compiler(object):
         else:
             return (compilation_ok, run_ok, out, err)
 
-    @staticmethod
-    def _try_flags(flag_list, preambule="", body="",
+    @classmethod
+    def _try_flags(cls, flag_list, preambule="", body="",
                    try_run=False, output=False, compiler=None):
         """
         Try to compile a dummy file with these flags.
@@ -1802,7 +1803,7 @@ class Compiler(object):
             return 0;
         }
         """ % locals())
-        return Compiler._try_compile_tmp(code, tmp_prefix='try_flags_',
+        return cls._try_compile_tmp(code, tmp_prefix='try_flags_',
                                          flags=flag_list, try_run=try_run,
                                          output=output, compiler=compiler)
 
@@ -2158,17 +2159,17 @@ class GCC_compiler(Compiler):
 
         return cxxflags
 
-    @staticmethod
-    def try_compile_tmp(src_code, tmp_prefix='', flags=(),
+    @classmethod
+    def try_compile_tmp(cls, src_code, tmp_prefix='', flags=(),
                         try_run=False, output=False):
-        return Compiler._try_compile_tmp(src_code, tmp_prefix, flags,
+        return cls._try_compile_tmp(src_code, tmp_prefix, flags,
                                          try_run, output,
                                          theano.config.cxx)
 
-    @staticmethod
-    def try_flags(flag_list, preambule="", body="",
+    @classmethod
+    def try_flags(cls, flag_list, preambule="", body="",
                   try_run=False, output=False):
-        return Compiler._try_flags(flag_list, preambule, body, try_run, output,
+        return cls._try_flags(flag_list, preambule, body, try_run, output,
                                    theano.config.cxx)
 
     @staticmethod

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -65,18 +65,17 @@ def add_standard_rpath(rpath):
 class NVCC_compiler(Compiler):
     supports_amdlibm = False
 
-    @staticmethod
-    def try_compile_tmp(src_code, tmp_prefix='', flags=(),
-                        try_run=False, output=False):
-        return Compiler._try_compile_tmp(src_code, tmp_prefix, flags,
-                                         try_run, output,
-                                         nvcc_path)
+    @classmethod
+    def try_compile_tmp(cls, src_code, tmp_prefix='', flags=(),
+                        try_run=False, output=False, comp_args=False):
+        return cls._try_compile_tmp(src_code, tmp_prefix, flags,
+                                    try_run, output, nvcc_path, comp_args)
 
-    @staticmethod
-    def try_flags(flag_list, preambule="", body="",
-                  try_run=False, output=False):
-        return Compiler._try_flags(flag_list, preambule, body, try_run, output,
-                                   nvcc_path)
+    @classmethod
+    def try_flags(cls, flag_list, preambule="", body="",
+                  try_run=False, output=False, comp_args=False):
+        return cls._try_flags(flag_list, preambule, body, try_run, output,
+                              nvcc_path, comp_args)
 
     @staticmethod
     def version_str():


### PR DESCRIPTION
Compiler._try_compile_tmp did not use compile_args. The -m32 flag was missing in the gcc args for 32 bit platforms, preventing the correct BLAS from being linked.