### PR TITLE
remove nose testsuite prefix option

### DIFF
--- a/.jenkins/jenkins_buildbot_python2.sh
+++ b/.jenkins/jenkins_buildbot_python2.sh
@@ -10,7 +10,7 @@ source $HOME/.bashrc
 XUNIT="--with-xunit --xunit-file="
 
 # name test suites
-SUITE="--xunit-prefix-with-testsuite-name --xunit-testsuite-name="
+SUITE="--xunit-testsuite-name="
 
 mkdir -p ${BUILDBOT_DIR}
 ls -l ${BUILDBOT_DIR}


### PR DESCRIPTION
Nose doc says it's an option, but nosetests gives a option doesn't exist error, same version.