### PR TITLE
Fix recursion limit that happen in the new gpu back-end

### DIFF
--- a/theano/gof/fg.py
+++ b/theano/gof/fg.py
@@ -319,10 +319,10 @@ class FunctionGraph(utils.object2):
                 del variable.fgraph
             else:
                 apply_node = variable.owner
-                used_or_output = [output for output in apply_node.outputs
-                                  if output.clients or output in self.outputs]
+                used = [output for output in apply_node.outputs
+                        if output.clients]
                 # If the apply node is not used and is not an output
-                if not used_or_output:
+                if not used:
                     if not hasattr(apply_node.tag, 'removed_by'):
                         apply_node.tag.removed_by = []
                     apply_node.tag.removed_by.append(str(reason))

--- a/theano/gof/fg.py
+++ b/theano/gof/fg.py
@@ -340,26 +340,6 @@ class FunctionGraph(utils.object2):
                 for i, input in enumerate(apply_node.inputs):
                     self.__remove_client__(input, (apply_node, i),
                                            reason=reason)
-        # variable should not have any clients.
-        # assert not variable.clients
-
-        # variable should be in self.variables
-        # Why this assert fail? Making it True could cause opt speed up
-        # I think this is caused as we remove var in self.variables in
-        # another place.
-        # assert variable in self.variables
-
-        if variable in self.variables:
-            # If the owner have other outputs still used,
-            # then we must keep that variable in the graph.
-            if not any(
-                [var for var in variable.owner.outputs
-                 if var.clients]):
-
-                self.variables.remove(variable)
-                # This allow to quickly know if a var is still in the fgraph
-                # or not.
-                del variable.fgraph
         return False
 
     # import #

--- a/theano/gof/fg.py
+++ b/theano/gof/fg.py
@@ -334,7 +334,10 @@ class FunctionGraph(utils.object2):
                     apply_node.tag.removed_by = []
                 apply_node.tag.removed_by.append(str(reason))
                 self.apply_nodes.remove(apply_node)
+                del apply_node.fgraph
                 self.variables.difference_update(apply_node.outputs)
+                for var in apply_node.outputs:
+                    del var.fgraph
                 self.execute_callbacks('on_prune', apply_node, reason)
 
                 for i, input in enumerate(apply_node.inputs):

--- a/theano/gof/fg.py
+++ b/theano/gof/fg.py
@@ -318,7 +318,13 @@ class FunctionGraph(utils.object2):
         if not prune:
             return True
         variable = r
-        if variable.owner:
+        if not variable.owner:
+            # A Constant or input without client. Remove it.
+            self.variables.remove(variable)
+            # This allow to quickly know if a var is still in the fgraph
+            # or not.
+            del variable.fgraph
+        else:
             apply_node = variable.owner
             used_or_output = [output for output in apply_node.outputs
                               if output.clients or output in self.outputs]
@@ -346,7 +352,7 @@ class FunctionGraph(utils.object2):
         if variable in self.variables:
             # If the owner have other outputs still used,
             # then we must keep that variable in the graph.
-            if not variable.owner or not any(
+            if not any(
                 [var for var in variable.owner.outputs
                  if var.clients]):
 


### PR DESCRIPTION
In the new gpu back-end, we move the full graph at once to the GPU. So the recursion during the removal of the full graph was hitting python recursion limit. Change the logic to recur manually.

Also, simplify the logic. This also change when on_change_input is called. It was called after the node was changed, but remove all the useless nodes/var where removed from the graph. Now we call it after all the nodes are removed from the graph. This make the logic simpler. I don't see any problems with that change of logic and hopefully the subset of tests I ran was enough.