### PR TITLE
Replace Conv3D references in tests with Corr3dMM

### DIFF
--- a/theano/gpuarray/tests/test_dnn.py
+++ b/theano/gpuarray/tests/test_dnn.py
@@ -832,7 +832,6 @@ def test_conv3d_fwd():
 
         inputs = theano.shared(inputs_val)
         filters = theano.shared(filters_val)
-        bias = theano.shared(numpy.zeros(filters_shape[0]).astype('float32'))
 
         # Compile a theano function for the cuDNN implementation
         conv = dnn.dnn_conv3d(img=inputs, kerns=filters,
@@ -847,33 +846,11 @@ def test_conv3d_fwd():
         else:
             flipped_filters = filters
 
-        # If border mode is anything but 'valid', the reference implementation
-        # should operate on padded inputs
-        if border_mode == 'valid':
-            padded_inputs = inputs
-        else:
-            if border_mode == 'full':
-                pad_per_dim = [filters_shape[i] - 1 for i in range(2, 5)]
-            elif border_mode == 'half':
-                pad_per_dim = [filters_shape[i] // 2 for i in range(2, 5)]
-            else:
-                if isinstance(border_mode, int):
-                    pad_per_dim = [border_mode] * 3
-                else:
-                    pad_per_dim = border_mode
-
-            pad_before_after = ([(0, 0), (0, 0)] +
-                                [(p, p) for p in pad_per_dim])
-            padded_inputs_val = numpy.pad(inputs_val, pad_before_after,
-                                          'constant')
-            padded_inputs = theano.shared(padded_inputs_val)
-
         # Compile a theano function for the reference implementation
-        conv_ref = theano.tensor.nnet.conv3D(
-            V=padded_inputs.dimshuffle(0, 2, 3, 4, 1),
-            W=flipped_filters.dimshuffle(0, 2, 3, 4, 1),
-            b=bias, d=subsample)
-        f_ref = theano.function([], conv_ref.dimshuffle(0, 4, 1, 2, 3), mode="FAST_RUN")
+        conv_ref = theano.tensor.nnet.corr3d.Corr3dMM(border_mode=border_mode,
+                                                      subsample=subsample
+                                                      )(inputs, flipped_filters)
+        f_ref = theano.function([], conv_ref, mode="FAST_RUN")
 
         # Compare the results of the two implementations
         res_ref = f_ref()
@@ -899,7 +876,6 @@ def test_conv3d_bwd():
 
         inputs = theano.shared(inputs_val)
         filters = theano.shared(filters_val)
-        bias = theano.shared(numpy.zeros(filters_shape[0]).astype('float32'))
 
         # Compile a theano function for the cuDNN implementation
         conv = dnn.dnn_conv3d(img=inputs, kerns=filters,
@@ -917,47 +893,13 @@ def test_conv3d_bwd():
         else:
             flipped_filters = filters
 
-        # If border mode is anything but 'valid', the reference implementation
-        # should operate on padded inputs
-        if border_mode == 'valid':
-            padded_inputs = inputs
-        else:
-            if border_mode == 'full':
-                pad_per_dim = [filters_shape[i] - 1 for i in range(2, 5)]
-            elif border_mode == 'half':
-                pad_per_dim = [filters_shape[i] // 2 for i in range(2, 5)]
-            else:
-                if isinstance(border_mode, int):
-                    pad_per_dim = [border_mode] * 3
-                else:
-                    pad_per_dim = border_mode
-
-            pad_before_after = ([(0, 0), (0, 0)] +
-                                [(p, p) for p in pad_per_dim])
-            padded_inputs_val = numpy.pad(inputs_val, pad_before_after,
-                                          'constant')
-            padded_inputs = theano.shared(padded_inputs_val)
-
         # Compile a theano function for the reference implementation
-        conv_ref = theano.tensor.nnet.conv3D(
-            V=padded_inputs.dimshuffle(0, 2, 3, 4, 1),
-            W=flipped_filters.dimshuffle(0, 2, 3, 4, 1),
-            b=bias, d=subsample)
-        (grad_padded_i_ref,
+        conv_ref = theano.tensor.nnet.corr3d.Corr3dMM(border_mode=border_mode,
+                                                      subsample=subsample
+                                                      )(inputs, flipped_filters)
+        (grad_i_ref,
          grad_w_ref) = theano.tensor.grad(conv_ref.sum(),
-                                          [padded_inputs, filters])
-
-        # Recover grad_i_ref from grad_padded_i_ref
-        if border_mode == 'valid':
-            grad_i_ref = grad_padded_i_ref
-        else:
-            shp = grad_padded_i_ref.shape
-            grad_i_ref = grad_padded_i_ref[
-                :, :,
-                pad_per_dim[0]:shp[2] - pad_per_dim[0],
-                pad_per_dim[1]:shp[3] - pad_per_dim[1],
-                pad_per_dim[2]:shp[4] - pad_per_dim[2]]
-
+                                          [inputs, filters])
         f_ref = theano.function([], [grad_i_ref, grad_w_ref], mode="FAST_RUN")
 
         # Compare the results of the two implementations

--- a/theano/sandbox/cuda/tests/test_dnn.py
+++ b/theano/sandbox/cuda/tests/test_dnn.py
@@ -1551,7 +1551,6 @@ def test_conv3d_fwd():
 
         inputs = shared(inputs_val)
         filters = shared(filters_val)
-        bias = shared(numpy.zeros(filters_shape[0]).astype('float32'))
 
         # Compile a theano function for the cuDNN implementation
         conv = dnn.dnn_conv3d(img=inputs, kerns=filters,
@@ -1566,33 +1565,11 @@ def test_conv3d_fwd():
         else:
             flipped_filters = filters
 
-        # If border mode is anything but 'valid', the reference implementation
-        # should operate on padded inputs
-        if border_mode == 'valid':
-            padded_inputs = inputs
-        else:
-            if border_mode == 'full':
-                pad_per_dim = [filters_shape[i] - 1 for i in range(2, 5)]
-            elif border_mode == 'half':
-                pad_per_dim = [filters_shape[i] // 2 for i in range(2, 5)]
-            else:
-                if isinstance(border_mode, int):
-                    pad_per_dim = [border_mode] * 3
-                else:
-                    pad_per_dim = border_mode
-
-            pad_before_after = ([(0, 0), (0, 0)] +
-                                [(p, p) for p in pad_per_dim])
-            padded_inputs_val = numpy.pad(inputs_val, pad_before_after,
-                                          'constant')
-            padded_inputs = shared(padded_inputs_val)
-
         # Compile a theano function for the reference implementation
-        conv_ref = theano.tensor.nnet.conv3D(
-            V=padded_inputs.dimshuffle(0, 2, 3, 4, 1),
-            W=flipped_filters.dimshuffle(0, 2, 3, 4, 1),
-            b=bias, d=subsample)
-        f_ref = theano.function([], conv_ref.dimshuffle(0, 4, 1, 2, 3), mode="FAST_RUN")
+        conv_ref = theano.tensor.nnet.corr3d.Corr3dMM(border_mode=border_mode,
+                                                      subsample=subsample
+                                                      )(inputs, flipped_filters)
+        f_ref = theano.function([], conv_ref, mode="FAST_RUN")
 
         # Compare the results of the two implementations
         res_ref = f_ref()
@@ -1618,7 +1595,6 @@ def test_conv3d_bwd():
 
         inputs = shared(inputs_val)
         filters = shared(filters_val)
-        bias = shared(numpy.zeros(filters_shape[0]).astype('float32'))
 
         # Compile a theano function for the cuDNN implementation
         conv = dnn.dnn_conv3d(img=inputs, kerns=filters,
@@ -1636,46 +1612,13 @@ def test_conv3d_bwd():
         else:
             flipped_filters = filters
 
-        # If border mode is anything but 'valid', the reference implementation
-        # should operate on padded inputs
-        if border_mode == 'valid':
-            padded_inputs = inputs
-        else:
-            if border_mode == 'full':
-                pad_per_dim = [filters_shape[i] - 1 for i in range(2, 5)]
-            elif border_mode == 'half':
-                pad_per_dim = [filters_shape[i] // 2 for i in range(2, 5)]
-            else:
-                if isinstance(border_mode, int):
-                    pad_per_dim = [border_mode] * 3
-                else:
-                    pad_per_dim = border_mode
-
-            pad_before_after = ([(0, 0), (0, 0)] +
-                                [(p, p) for p in pad_per_dim])
-            padded_inputs_val = numpy.pad(inputs_val, pad_before_after,
-                                          'constant')
-            padded_inputs = shared(padded_inputs_val)
-
         # Compile a theano function for the reference implementation
-        conv_ref = theano.tensor.nnet.conv3D(
-            V=padded_inputs.dimshuffle(0, 2, 3, 4, 1),
-            W=flipped_filters.dimshuffle(0, 2, 3, 4, 1),
-            b=bias, d=subsample)
-        (grad_padded_i_ref,
+        conv_ref = theano.tensor.nnet.corr3d.Corr3dMM(border_mode=border_mode,
+                                                      subsample=subsample
+                                                      )(inputs, flipped_filters)
+        (grad_i_ref,
          grad_w_ref) = theano.tensor.grad(conv_ref.sum(),
-                                          [padded_inputs, filters])
-
-        # Recover grad_i_ref from grad_padded_i_ref
-        if border_mode == 'valid':
-            grad_i_ref = grad_padded_i_ref
-        else:
-            shp = grad_padded_i_ref.shape
-            grad_i_ref = grad_padded_i_ref[
-                :, :,
-                pad_per_dim[0]:shp[2] - pad_per_dim[0],
-                pad_per_dim[1]:shp[3] - pad_per_dim[1],
-                pad_per_dim[2]:shp[4] - pad_per_dim[2]]
+                                          [inputs, filters])
 
         f_ref = theano.function([], [grad_i_ref, grad_w_ref], mode="FAST_RUN")
 

--- a/theano/tests/test_gradient.py
+++ b/theano/tests/test_gradient.py
@@ -14,7 +14,6 @@ from theano.compat import izip
 from theano.tests import unittest_tools as utt
 
 from theano import gradient
-from theano.tensor.nnet.Conv3D import conv3D
 from theano import config
 from theano.gof.null_type import NullType
 
@@ -187,16 +186,19 @@ class test_grad(unittest.TestCase):
     def test_undefined_grad_grad(self):
         # tests that undefined grads are caught in the grad method
 
-        V = theano.tensor.TensorType(dtype=config.floatX,
-                                     broadcastable=(False, False, False, False, False))()
-        W = theano.tensor.TensorType(dtype=config.floatX,
-                                     broadcastable=(False, False, False, False, False))()
-        b = theano.tensor.vector()
-        d = theano.tensor.ivector()
+        class DummyOp(gof.Op):
+            __props__ = ()
 
-        Z = conv3D(V, W, b, d)
+            def make_node(self, x):
+                return gof.Apply(self, [x], [x.type()])
 
-        self.assertRaises(TypeError, theano.gradient.grad, Z.sum(), d)
+            def grad(self, inputs, output_grads):
+                return [theano.gradient.grad_undefined(self, 0, inputs[0])]
+
+        a = theano.tensor.scalar()
+        b = DummyOp()(a)
+
+        self.assertRaises(TypeError, theano.gradient.grad, b, a)
 
     def test_grad_name(self):
         A = theano.tensor.matrix('A')


### PR DESCRIPTION
This removes a number of unnecessary calls to the old Conv3D implementation from the tests, replacing them with calls to Corr3dMM instead. Could be part of #5079.