### PR TITLE
buildbot explicit cuda path

### DIFF
--- a/.jenkins/jenkins_buildbot_python2.sh
+++ b/.jenkins/jenkins_buildbot_python2.sh
@@ -3,8 +3,11 @@
 BUILDBOT_DIR=$WORKSPACE/nightly_build
 THEANO_PARAM="theano --with-timer --timer-top-n 10"
 export THEANO_FLAGS=init_gpu_device=gpu
-export GPUARRAY=none
-source $HOME/.bashrc
+
+# CUDA                                                                          
+export PATH=/usr/local/cuda/bin:$PATH
+export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+export LIBRARY_PATH=/usr/local/cuda/lib64:$LIBRARY_PATH
 
 # nosetests xunit for test profiling
 XUNIT="--with-xunit --xunit-file="

--- a/.jenkins/jenkins_buildbot_python2_32bit.sh
+++ b/.jenkins/jenkins_buildbot_python2_32bit.sh
@@ -4,8 +4,6 @@ BUILDBOT_DIR=$WORKSPACE/nightly_build
 THEANO_PARAM="theano --with-timer --timer-top-n 10"
 # Set test reports using nosetests xunit
 XUNIT="--with-xunit --xunit-file="
-export GPUARRAY=none
-source $HOME/.bashrc
 
 mkdir -p ${BUILDBOT_DIR}
 ls -l ${BUILDBOT_DIR}

--- a/.jenkins/jenkins_buildbot_python2_debug.sh
+++ b/.jenkins/jenkins_buildbot_python2_debug.sh
@@ -3,8 +3,11 @@
 BUILDBOT_DIR=$WORKSPACE/nightly_build
 THEANO_PARAM="theano --with-timer --timer-top-n 10"
 export THEANO_FLAGS=init_gpu_device=gpu
-export GPUARRAY=none
-source $HOME/.bashrc
+
+# CUDA
+export PATH=/usr/local/cuda/bin:$PATH
+export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+export LIBRARY_PATH=/usr/local/cuda/lib64:$LIBRARY_PATH
 
 # nosetests xunit for test profiling
 XUNIT="--with-xunit --xunit-file="

--- a/.jenkins/jenkins_buildbot_python3.sh
+++ b/.jenkins/jenkins_buildbot_python3.sh
@@ -5,8 +5,11 @@ THEANO_PARAM="theano --with-timer --timer-top-n 10"
 # Set test reports using nosetests xunit
 XUNIT="--with-xunit --xunit-file="
 export THEANO_FLAGS=init_gpu_device=gpu
-export GPUARRAY=none
-source $HOME/.bashrc
+
+# CUDA
+export PATH=/usr/local/cuda/bin:$PATH
+export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+export LIBRARY_PATH=/usr/local/cuda/lib64:$LIBRARY_PATH
 
 mkdir -p ${BUILDBOT_DIR}
 ls -l ${BUILDBOT_DIR}


### PR DESCRIPTION
With Ubuntu 16, jenkins no longer seems to source the bashrc properly for CUDA paths.