### PR TITLE
New optimization: DimShuffle(Alloc(...)) -> Alloc(..., use dims of 1 for new dimensions) #5024

### DIFF
--- a/theano/tensor/opt_uncanonicalize.py
+++ b/theano/tensor/opt_uncanonicalize.py
@@ -157,17 +157,19 @@ def local_dimshuffle_alloc(node):
 
     dimshuffle{x, 0, 1}(alloc([3 4], 3, 2) => alloc([3 4], 1, 3, 2)
     """
-    if isinstance(node.op, T.DimShuffle) and isinstance(node.inputs[0].owner.op, T.Alloc):
-        # check if it only adds dimension to the left
-        new_order = node.op.new_order
-        expected_new_order = ('x',) * (len(new_order) - node.inputs[0].ndim) + \
-            tuple(range(node.inputs[0].ndim))
-        if new_order != expected_new_order:
-            return False
+    if isinstance(node.op, T.DimShuffle) and node.inputs[0].owner:
+        input_ = node.inputs[0]
+        if isinstance(input_.owner.op, T.Alloc):
+            # check if it only adds dimension to the left
+            new_order = node.op.new_order
+            expected_new_order = ('x',) * (len(new_order) - input_.ndim) + \
+                tuple(range(input_.ndim))
+            if new_order != expected_new_order:
+                return False
 
-        # count numbers of 'x'
-        nb_new_dims = len(new_order) - node.inputs[0].ndim
-        new_shape_input = (1,) * nb_new_dims + tuple(node.inputs[0].owner.inputs[1:])
+            # count numbers of 'x'
+            nb_new_dims = len(new_order) - input_.ndim
+            new_shape_input = (1,) * nb_new_dims + tuple(input_.owner.inputs[1:])
 
-        return [T.alloc(node.inputs[0].owner.inputs[0], *new_shape_input)]
+            return [T.alloc(input_.owner.inputs[0], *new_shape_input)]
     return False

--- a/theano/tensor/opt_uncanonicalize.py
+++ b/theano/tensor/opt_uncanonicalize.py
@@ -157,7 +157,7 @@ def local_dimshuffle_alloc(node):
 
     dimshuffle{x, 0, 1}(alloc([3 4], 3, 2) => alloc([3 4], 1, 3, 2)
     """
-    if isinstance(node.op, T.DimShuffle) and isinstance(node.inputs[0], T.Alloc):
+    if isinstance(node.op, T.DimShuffle) and isinstance(node.inputs[0].owner.op, T.Alloc):
         # check if it only adds dimension to the left
         new_order = node.op.new_order
         expected_new_order = ('x',) * (len(new_order) - node.inputs[0].ndim) + \

--- a/theano/tensor/opt_uncanonicalize.py
+++ b/theano/tensor/opt_uncanonicalize.py
@@ -157,8 +157,7 @@ def local_dimshuffle_alloc(node):
 
     dimshuffle{x, 0, 1}(alloc([3 4], 3, 2) => alloc([3 4], 1, 3, 2)
     """
-    if isinstance(node.op, T.DimShuffle):
-        #import ipdb ; ipdb.set_trace()
+    if isinstance(node.op, T.DimShuffle) and isinstance(node.inputs[0], T.Alloc):
         # check if it only adds dimension to the left
         new_order = node.op.new_order
         expected_new_order = ('x',) * (len(new_order) - node.inputs[0].ndim) + \

--- a/theano/tensor/tests/test_opt_uncanonicalize.py
+++ b/theano/tensor/tests/test_opt_uncanonicalize.py
@@ -153,9 +153,9 @@ def test_local_reshape_dimshuffle():
 
     reshape_dimshuffle = out2in(local_dimshuffle_alloc)
 
-    x = tensor.matrix('x')
+    x = tensor.vector('x')
 
-    out = tensor.alloc(x, 3, 2).dimshuffle('x','x',0,1)
+    out = tensor.alloc(x, 3, 2).dimshuffle('x', 'x', 0, 1)
 
     g = FunctionGraph([x], [out])
     reshape_dimshuffle(g)
@@ -164,7 +164,7 @@ def test_local_reshape_dimshuffle():
     l.accept(g)
     f=l.make_function()
 
-    assert f([3,4]).ndim == 4
+    assert f([3, 4]).ndim == 4
 
     topo = g.toposort()
     assert any([not isinstance(x, DimShuffle) for x in topo])

--- a/theano/tensor/tests/test_opt_uncanonicalize.py
+++ b/theano/tensor/tests/test_opt_uncanonicalize.py
@@ -10,7 +10,8 @@ from theano.gof import FunctionGraph
 from theano.gof.opt import out2in
 from theano.tensor.opt_uncanonicalize import (
     local_alloc_dimshuffle,
-    local_reshape_dimshuffle
+    local_reshape_dimshuffle,
+    local_dimshuffle_alloc,
     )
 import theano.tensor as tensor
 #from theano.tensor import matrix,max_and_argmax,MaaxAndArgmax,neg
@@ -142,6 +143,28 @@ def test_local_reshape_dimshuffle():
 
     g = FunctionGraph([x], [out])
     reshape_dimshuffle(g)
+
+    topo = g.toposort()
+    assert any([not isinstance(x, DimShuffle) for x in topo])
+
+
+
+def test_local_reshape_dimshuffle():
+
+    reshape_dimshuffle = out2in(local_dimshuffle_alloc)
+
+    x = tensor.matrix('x')
+
+    out = tensor.alloc(x, 3, 2).dimshuffle('x','x',0,1)
+
+    g = FunctionGraph([x], [out])
+    reshape_dimshuffle(g)
+
+    l=theano.gof.PerformLinker()
+    l.accept(g)
+    f=l.make_function()
+
+    assert f([3,4]).ndim == 4
 
     topo = g.toposort()
     assert any([not isinstance(x, DimShuffle) for x in topo])


### PR DESCRIPTION
PR for new optimization dealing with 

`dimshuffle{x, 0, 1}(alloc([3 4], 3, 2) => alloc([3 4], 1, 3, 2)` 

in uncanonicalize phase

gh-5024