### PR TITLE
Speed up GpuCorrMM in the new back-end

### DIFF
--- a/theano/gpuarray/basic_ops.py
+++ b/theano/gpuarray/basic_ops.py
@@ -263,6 +263,9 @@ class Kernel(object):
 def get_ctype(dtype):
     if dtype is gpuarray.GpuArray:
         return "gpudata *"
+    elif isinstance(dtype, numpy.dtype):
+        # The if is needed as numpy.dtype can't be compared to gpuarray.[S]SIZE
+        return 'npy_' + dtype.name
     elif dtype == gpuarray.SIZE:
         return "size_t"
     elif dtype == gpuarray.SSIZE:

--- a/theano/gpuarray/blas.py
+++ b/theano/gpuarray/blas.py
@@ -488,6 +488,11 @@ class BaseGpuCorrMM(CGpuKernelBase, BlasOp):
     def get_params(self, node):
         return node.inputs[0].type.context
 
+    def get_op_params(self):
+        return [("ADDR32_MAX", "4294967295"),
+                ("SADDR32_MIN", "-2147483648"),
+                ("SADDR32_MAX",  "2147483647")]
+
     def c_code_cache_version(self):
         # raise this whenever modifying any of the support_code_files
         return (0, 1)


### PR DESCRIPTION
There was a slow down in the new back-end compared to the old one related to GpuCorrMM. This should fix it. I didn't benchmark it yet. I'll ask the user the reported this to benchmark it.
