### PR TITLE
warn when profiling.ignore_first_call isn't used.

### DIFF
--- a/theano/compile/profiling.py
+++ b/theano/compile/profiling.py
@@ -213,9 +213,9 @@ class ProfileStats(object):
         if (config.profile and
                 ((hasattr(theano, 'sandbox') and
                   hasattr(theano.sandbox, 'cuda') and
-                  theano.sandbox.cuda.cuda_enabled)) or(
+                  theano.sandbox.cuda.cuda_enabled) or (
                       hasattr(theano, 'gpuarray') and
-                      theano.gpuarray.pygpu_activated)):
+                      theano.gpuarray.pygpu_activated))):
             if os.environ.get('CUDA_LAUNCH_BLOCKING', '0') != '1':
                 raise Exception(
                     "You are running the Theano profiler with CUDA enabled."

--- a/theano/compile/profiling.py
+++ b/theano/compile/profiling.py
@@ -9,6 +9,8 @@ ProfileStats object for runtime and memory profiling.
 #
 from __future__ import absolute_import, print_function, division
 
+import logging
+
 __authors__ = "James Bergstra"
 __reviewer__ = "Razvan Pascanu"
 __copyright__ = "(c) 2011, Universite de Montreal"
@@ -29,6 +31,8 @@ import numpy
 import theano
 from six import iteritems
 from theano.gof import graph
+
+logger = logging.getLogger('theano.compile.profiling')
 
 theano_imported_time = time.time()
 config = theano.config
@@ -220,6 +224,14 @@ class ProfileStats(object):
                     " You must set the environment variable"
                     " CUDA_LAUNCH_BLOCKING to 1 to tell the CUDA driver to"
                     " synchronize the execution to get a meaningful profile.")
+        if (config.profile and
+                hasattr(theano, 'gpuarray') and
+                theano.gpuarray.pygpu_activated and
+                not config.profiling.ignore_first_call):
+            logger.warn(
+                "Theano flag profiling.ignore_first_call is False."
+                " This cause bad profiling result in the new gpu"
+                " back-end, we as sometimes we compile at the first call.")
 
         self.apply_callcount = {}
         self.output_size = {}

--- a/theano/compile/profiling.py
+++ b/theano/compile/profiling.py
@@ -206,9 +206,12 @@ class ProfileStats(object):
     # param is called flag_time_thunks because most other attributes with time
     # in the name are times *of* something, rather than configuration flags.
     def __init__(self, atexit_print=True, flag_time_thunks=None, **kwargs):
-        if (hasattr(theano, 'sandbox') and
-                hasattr(theano.sandbox, 'cuda') and
-                theano.sandbox.cuda.cuda_enabled):
+        if (config.profile and
+                ((hasattr(theano, 'sandbox') and
+                  hasattr(theano.sandbox, 'cuda') and
+                  theano.sandbox.cuda.cuda_enabled)) or(
+                      hasattr(theano, 'gpuarray') and
+                      theano.gpuarray.pygpu_activated)):
             if os.environ.get('CUDA_LAUNCH_BLOCKING', '0') != '1':
                 raise Exception(
                     "You are running the Theano profiler with CUDA enabled."

--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -752,9 +752,11 @@ class VM_Linker(link.LocalLinker):
 
         """
         if (config.profile and
-                hasattr(theano, 'sandbox') and
-                hasattr(theano.sandbox, 'cuda') and
-                theano.sandbox.cuda.cuda_enabled):
+                ((hasattr(theano, 'sandbox') and
+                  hasattr(theano.sandbox, 'cuda') and
+                  theano.sandbox.cuda.cuda_enabled)) or(
+                      hasattr(theano, 'gpuarray') and
+                      theano.gpuarray.pygpu_activated)):
             if os.environ.get('CUDA_LAUNCH_BLOCKING', '0') != '1':
                 raise Exception(
                     "You are running the Theano profiler with CUDA enabled."

--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -754,9 +754,9 @@ class VM_Linker(link.LocalLinker):
         if (config.profile and
                 ((hasattr(theano, 'sandbox') and
                   hasattr(theano.sandbox, 'cuda') and
-                  theano.sandbox.cuda.cuda_enabled) or(
-                      hasattr(theano, 'gpuarray') and
-                      theano.gpuarray.pygpu_activated))):
+                  theano.sandbox.cuda.cuda_enabled) or
+                 (hasattr(theano, 'gpuarray') and
+                  theano.gpuarray.pygpu_activated))):
             if os.environ.get('CUDA_LAUNCH_BLOCKING', '0') != '1':
                 raise Exception(
                     "You are running the Theano profiler with CUDA enabled."

--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -754,9 +754,9 @@ class VM_Linker(link.LocalLinker):
         if (config.profile and
                 ((hasattr(theano, 'sandbox') and
                   hasattr(theano.sandbox, 'cuda') and
-                  theano.sandbox.cuda.cuda_enabled)) or(
+                  theano.sandbox.cuda.cuda_enabled) or(
                       hasattr(theano, 'gpuarray') and
-                      theano.gpuarray.pygpu_activated)):
+                      theano.gpuarray.pygpu_activated))):
             if os.environ.get('CUDA_LAUNCH_BLOCKING', '0') != '1':
                 raise Exception(
                     "You are running the Theano profiler with CUDA enabled."


### PR DESCRIPTION
This will help user find the strange profiling information themself without asking questions.
