### PR TITLE
Dimshuffle{0,2}(Subtensor[i:j, :, k:l]) => Subtensor[i:j, 0, k:l] #4647

### DIFF
--- a/theano/tensor/opt_uncanonicalize.py
+++ b/theano/tensor/opt_uncanonicalize.py
@@ -203,7 +203,7 @@ def local_dimshuffle_subtensor(node):
             # the arguments missing from the dimshuffles must be dims that are broadcastable
             broadcastable = input_.broadcastable
 
-            missing_dims = range(input_.ndim)
+            missing_dims = list(range(input_.ndim))
             for dim in new_order:
                 missing_dims.remove(dim)
 

--- a/theano/tensor/opt_uncanonicalize.py
+++ b/theano/tensor/opt_uncanonicalize.py
@@ -220,16 +220,19 @@ def local_dimshuffle_subtensor(node):
             zero = T.constant(0)
             slice_attr_list = ['start','stop','step']
             j = 0
+            slice_i = -1
             for idx in input_.owner.op.idx_list:
                 if isinstance(idx, slice):
                     past_j = j
+                    slice_i += 1
                     for slice_attr in slice_attr_list:
                         if getattr(idx, slice_attr) is not None:
                             new_inputs += [input_.owner.inputs[1+j]]
                             j += 1
-                    if past_j == j:
-                        # here is a slice(None, None, None), that's where
-                        # we want to index with 0.
+                    # if past_j == j indicates a slice(None, None, None), that's where
+                    # we want to index with 0 if it is also at the same
+                    # spot of a missing dim
+                    if past_j == j and slice_i in missing_dims:
                         new_idx_list[j] = zero
                         new_inputs += [zero]
                 else:

--- a/theano/tensor/opt_uncanonicalize.py
+++ b/theano/tensor/opt_uncanonicalize.py
@@ -186,7 +186,7 @@ def local_dimshuffle_subtensor(node):
     """
     if isinstance(node.op, DimShuffle) and node.inputs[0].owner:
         # the dimshuffle can only drop dimensions (cannot reshape nor add 'x')
-        if 'x' in node.op.new_order :
+        if 'x' in node.op.new_order:
             return False
         new_order = node.op.new_order
         # new order could be empty
@@ -218,7 +218,7 @@ def local_dimshuffle_subtensor(node):
             new_idx_list = list(input_.owner.op.idx_list)
             new_inputs = [input_.owner.inputs[0]]
             zero = T.constant(0)
-            slice_attr_list = ['start','stop','step']
+            slice_attr_list = ['start', 'stop', 'step']
             j = 0
             slice_i = -1
             for idx in input_.owner.op.idx_list:
@@ -227,7 +227,7 @@ def local_dimshuffle_subtensor(node):
                     slice_i += 1
                     for slice_attr in slice_attr_list:
                         if getattr(idx, slice_attr) is not None:
-                            new_inputs += [input_.owner.inputs[1+j]]
+                            new_inputs += [input_.owner.inputs[1 + j]]
                             j += 1
                     # if past_j == j indicates a slice(None, None, None), that's where
                     # we want to index with 0 if it is also at the same
@@ -236,7 +236,7 @@ def local_dimshuffle_subtensor(node):
                         new_idx_list[j] = zero
                         new_inputs += [zero]
                 else:
-                    new_inputs += [input_.owner.inputs[1+j]]
+                    new_inputs += [input_.owner.inputs[1 + j]]
                     j += 1
             return [Subtensor(new_idx_list)(*new_inputs)]
     return False

--- a/theano/tensor/opt_uncanonicalize.py
+++ b/theano/tensor/opt_uncanonicalize.py
@@ -220,7 +220,6 @@ def local_dimshuffle_subtensor(node):
             zero = T.constant(0)
             slice_attr_list = ['start','stop','step']
             j = 0
-            import ipdb; ipdb.set_trace()
             for idx in input_.owner.op.idx_list:
                 if isinstance(idx, slice):
                     past_j = j
@@ -236,6 +235,5 @@ def local_dimshuffle_subtensor(node):
                 else:
                     new_inputs += [input_.owner.inputs[1+j]]
                     j += 1
-            import ipdb; ipdb.set_trace()
             return [Subtensor(new_idx_list)(*new_inputs)]
     return False

--- a/theano/tensor/tests/test_opt_uncanonicalize.py
+++ b/theano/tensor/tests/test_opt_uncanonicalize.py
@@ -178,7 +178,7 @@ def test_local_dimshuffle_subtensor():
     x = tensor.patternbroadcast(x, (False, True, False, False))
     i = tensor.iscalar('i')
 
-    out = x[i, :, 10:30, ::-1].dimshuffle(1,2)
+    out = x[:, :, 10:30, ::i].dimshuffle(0,2,3)
 
     g = FunctionGraph([x,i], [out])
     dimshuffle_subtensor(g)

--- a/theano/tensor/tests/test_opt_uncanonicalize.py
+++ b/theano/tensor/tests/test_opt_uncanonicalize.py
@@ -178,10 +178,9 @@ def test_local_dimshuffle_subtensor():
     x = tensor.patternbroadcast(x, (False, True, False, False))
     i = tensor.iscalar('i')
 
-    out = x[i, :, 10:30, :-1].dimshuffle(1,2)
+    out = x[i, :, 10:30, ::-1].dimshuffle(1,2)
 
     g = FunctionGraph([x,i], [out])
-    import ipdb; ipdb.set_trace()
     dimshuffle_subtensor(g)
 
     topo = g.toposort()

--- a/theano/tensor/tests/test_opt_uncanonicalize.py
+++ b/theano/tensor/tests/test_opt_uncanonicalize.py
@@ -12,6 +12,7 @@ from theano.tensor.opt_uncanonicalize import (
     local_alloc_dimshuffle,
     local_reshape_dimshuffle,
     local_dimshuffle_alloc,
+    local_dimshuffle_subtensor,
     )
 import theano.tensor as tensor
 #from theano.tensor import matrix,max_and_argmax,MaaxAndArgmax,neg
@@ -148,8 +149,7 @@ def test_local_reshape_dimshuffle():
     assert any([not isinstance(x, DimShuffle) for x in topo])
 
 
-
-def test_local_reshape_dimshuffle():
+def test_local_dimshuffle_alloc():
 
     reshape_dimshuffle = out2in(local_dimshuffle_alloc)
 
@@ -165,6 +165,24 @@ def test_local_reshape_dimshuffle():
     f=l.make_function()
 
     assert f([3, 4]).ndim == 4
+
+    topo = g.toposort()
+    assert any([not isinstance(x, DimShuffle) for x in topo])
+
+
+def test_local_dimshuffle_subtensor():
+
+    dimshuffle_subtensor = out2in(local_dimshuffle_subtensor)
+
+    x = tensor.tensor4('x')
+    x = tensor.patternbroadcast(x, (False, True, False, False))
+    i = tensor.iscalar('i')
+
+    out = x[i, :, 10:30, :-1].dimshuffle(1,2)
+
+    g = FunctionGraph([x,i], [out])
+    import ipdb; ipdb.set_trace()
+    dimshuffle_subtensor(g)
 
     topo = g.toposort()
     assert any([not isinstance(x, DimShuffle) for x in topo])


### PR DESCRIPTION
Note: I also fixed some things I found were not good on my previous gh-4647 tickets. I mistakenly used the same name twice for a test.

This does crash into an error but I don't know how to fix it. I tried to give back a new Subtensor object then realized that this could not be done as it would lack the inputs! So I tried to modify directly the Subtensor.idx_list and then replace the dimshuffle with its Subtensor.idx_list changed input, but it throws an error...almost there!

gh-4647
