### PR TITLE
GpuDownsampleFactorMaxGradGrad3d in cuda (+bug?)

### DIFF
--- a/theano/sandbox/cuda/blas.py
+++ b/theano/sandbox/cuda/blas.py
@@ -2855,6 +2855,11 @@ class GpuDownsampleFactorMaxGradGrad(GpuOp):
                             my_gx = gx[i0*gxS0 + i1*gxS1 + x_row*gxS2 + x_col*gxS3];
 
                             if (my_z == x[i0*xS0 + i1*xS1 + x_row*xS2 + x_col*xS3]) {
+                                // TODO: This assumes that there is only one maximum.
+                                // The cpu implementation accepts multiple, by incrementing
+                                // with my_gx instead:
+                                // gz[i0 *  gzS0 + i1 *  gzS1 + i2 *  gzS2 + z_col* gzS3] += my_gx;
+                                // (That doesn't work in this parallelized version.)
                                 gz[i0 *  gzS0 + i1 *  gzS1 + i2 *  gzS2 + z_col* gzS3] = my_gx;
                             }
                         }
@@ -3062,6 +3067,11 @@ class GpuDownsampleFactorMaxGradGrad3d(GpuOp):
                                 my_gx = gx[i0*gxS0 + i1*gxS1 + x_row*gxS2 + x_col*gxS3 + x_slice*gxS4];
 
                                 if (my_z == x[i0*xS0 + i1*xS1 + x_row*xS2 + x_col*xS3 + x_slice*xS4]) {
+                                    // TODO: This assumes that there is only one maximum.
+                                    // The cpu implementation accepts multiple, by incrementing
+                                    // with my_gx instead:
+                                    // gz[i0*gzS0 + i1*gzS1 + z_row*gzS2 + z_col*gzS3 + z_slice*gzS4] += my_gx;
+                                    // (That doesn't work in this parallelized version.)
                                     gz[i0*gzS0 + i1*gzS1 + z_row*gzS2 + z_col*gzS3 + z_slice*gzS4] = my_gx;
                                 }
                             }


### PR DESCRIPTION
Given #5159, I thought it might be useful to have a 3D version of `GpuDownsampleFactorMaxGradGrad` as well. While trying to build that, I discovered (what I suspect is) a bug in the existing 2D code. It assumes that there is only one maximum per region (unlike the cpu version, which correctly sums all maxima in the region).

Miraculously, the random test samples do not contain multiple maxima, so the 2D test runs correctly. If you give an input of all ones the tests will fail.

The 3D function in this patch is a straightforward copy of the 2D function, so it has the same problem. I 'fixed' this by using unique values in the tests.

The new gpuarray function in #5159 seems to implement this correctly.