### PR TITLE
Add grad_scale op

### DIFF
--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -2067,7 +2067,7 @@ def grad_clip(x, lower_bound, upper_bound):
 class GradScale(ViewOp):
     def __init__(self,multiplier):
         self.multiplier=multiplier
-        
+
     def grad(self, args, g_outs):
         return [self.multiplier*g_out for g_out in g_outs]
 
@@ -2075,14 +2075,14 @@ class GradScale(ViewOp):
 def grad_scale(x,multiplier):
     """
     This op scale or inverse the gradient in the backpropagation.
-    
+
     :param x: the variable we want its gradient inputs scale
     :param multiplier: scale of the gradient
-    
+
     :examples:
     x = theano.tensor.fscalar()
     fx = theano.tensor.sin(x)
-    
+
     fp = theano.tensor.grad(fx, wrt=x)
     fprime = theano.function([x], fp)
     print(fprime(2))#-0.416

--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -2093,3 +2093,4 @@ def grad_scale(x,multiplier):
     print(fpprime(2))#0.416
     """
     return GradScale(multiplier)(x)
+

--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -2062,3 +2062,34 @@ def grad_clip(x, lower_bound, upper_bound):
 
     """
     return GradClip(lower_bound, upper_bound)(x)
+
+
+class GradScale(ViewOp):
+    def __init__(self,multiplier):
+        self.multiplier=multiplier
+        
+    def grad(self, args, g_outs):
+        return [self.multiplier*g_out for g_out in g_outs]
+
+
+def grad_scale(x,multiplier):
+    """
+    This op scale or inverse the gradient in the backpropagation.
+    
+    :param x: the variable we want its gradient inputs scale
+    :param multiplier: scale of the gradient
+    
+    :examples:
+    x = theano.tensor.fscalar()
+    fx = theano.tensor.sin(x)
+    
+    fp = theano.tensor.grad(fx, wrt=x)
+    fprime = theano.function([x], fp)
+    print(fprime(2))#-0.416
+
+    f_inverse=grad_scale(fx,-1.)
+    fpp = theano.tensor.grad(f_inverse, wrt=x)
+    fpprime = theano.function([x], fpp)
+    print(fpprime(2))#0.416
+    """
+    return GradScale(multiplier)(x)


### PR DESCRIPTION
I added a new grad_scale op to scale or inverse gradient in back-propagation.

This op could be helpful if you want to
1, Implement adversarial optimization which requires gradient inverse:
https://arxiv.org/abs/1409.7495
https://arxiv.org/abs/1511.06434

2, Have relatively different learning rates across the graph.