### PR TITLE
Update to fix python 3 error

### DIFF
--- a/theano/misc/tests/test_pycuda_theano_simple.py
+++ b/theano/misc/tests/test_pycuda_theano_simple.py
@@ -86,7 +86,7 @@ def test_pycuda_memory_to_theano():
     initial_refcount = sys.getrefcount(y)
     print("gpuarray ref count before creating a CudaNdarray", end=' ')
     print(sys.getrefcount(y))
-    # assert sys.getrefcount(y) == 2
+    assert sys.getrefcount(y) == initial_refcount
     rand = numpy.random.randn(*y.shape).astype(numpy.float32)
     cuda_rand = cuda_ndarray.CudaNdarray(rand)
 
@@ -101,18 +101,15 @@ def test_pycuda_memory_to_theano():
     y_ptr = int(y.gpudata)
     z = cuda_ndarray.from_gpu_pointer(y_ptr, y.shape, strides, y)
     print("gpuarray ref count after creating a CudaNdarray", sys.getrefcount(y))
-    # assert sys.getrefcount(y) == 3
     assert sys.getrefcount(y) == initial_refcount + 1
     assert (numpy.asarray(z) == 0).all()
     assert z.base is y
 
     # Test that we can take a view from this cuda view on pycuda memory
     zz = z.view()
-    # assert sys.getrefcount(y) == 4
     assert sys.getrefcount(y) == initial_refcount + 2
     assert zz.base is y
     del zz
-    # assert sys.getrefcount(y) == 3
     assert sys.getrefcount(y) == initial_refcount + 1
 
     cuda_ones = cuda_ndarray.CudaNdarray(numpy.asarray([[[1]]],
@@ -131,5 +128,4 @@ def test_pycuda_memory_to_theano():
     del z
     print("gpuarray ref count after deleting the CudaNdarray", end=' ')
     print(sys.getrefcount(y))
-    # assert sys.getrefcount(y) == 2
     assert sys.getrefcount(y) == initial_refcount

--- a/theano/misc/tests/test_pycuda_theano_simple.py
+++ b/theano/misc/tests/test_pycuda_theano_simple.py
@@ -83,9 +83,10 @@ def test_pycuda_memory_to_theano():
     # This increase the ref count with never pycuda. Do pycuda also
     # cache ndarray?
     # print y.get()
+    initial_refcount = sys.getrefcount(y)
     print("gpuarray ref count before creating a CudaNdarray", end=' ')
     print(sys.getrefcount(y))
-    assert sys.getrefcount(y) == 2
+    # assert sys.getrefcount(y) == 2
     rand = numpy.random.randn(*y.shape).astype(numpy.float32)
     cuda_rand = cuda_ndarray.CudaNdarray(rand)
 
@@ -100,16 +101,19 @@ def test_pycuda_memory_to_theano():
     y_ptr = int(y.gpudata)
     z = cuda_ndarray.from_gpu_pointer(y_ptr, y.shape, strides, y)
     print("gpuarray ref count after creating a CudaNdarray", sys.getrefcount(y))
-    assert sys.getrefcount(y) == 3
+    # assert sys.getrefcount(y) == 3
+    assert sys.getrefcount(y) == initial_refcount + 1
     assert (numpy.asarray(z) == 0).all()
     assert z.base is y
 
     # Test that we can take a view from this cuda view on pycuda memory
     zz = z.view()
-    assert sys.getrefcount(y) == 4
+    # assert sys.getrefcount(y) == 4
+    assert sys.getrefcount(y) == initial_refcount + 2
     assert zz.base is y
     del zz
-    assert sys.getrefcount(y) == 3
+    # assert sys.getrefcount(y) == 3
+    assert sys.getrefcount(y) == initial_refcount + 1
 
     cuda_ones = cuda_ndarray.CudaNdarray(numpy.asarray([[[1]]],
                                                        dtype='float32'))
@@ -127,4 +131,5 @@ def test_pycuda_memory_to_theano():
     del z
     print("gpuarray ref count after deleting the CudaNdarray", end=' ')
     print(sys.getrefcount(y))
-    assert sys.getrefcount(y) == 2
+    # assert sys.getrefcount(y) == 2
+    assert sys.getrefcount(y) == initial_refcount


### PR DESCRIPTION
Update test function test_pycuda_memory_to_theano() to fix Python 3 error.

The refcount of a variable seems to be different between Python 2 and Python 3. So it seems better to stock an initial refcount in a variable and then do the checkings with that variable instead of directly using comparing to constant values.

Tests passed with Python 3 (Anaconda):

```
$ nosetests --verbose --nocapture theano/misc/tests/test_pycuda_theano_simple.py
Run pycuda only example to test that pycuda works. ... ok
Simple example with pycuda function and Theano CudaNdarray object. ... ok
theano.misc.tests.test_pycuda_theano_simple.test_pycuda_memory_to_theano ... 4
gpuarray ref count before creating a CudaNdarray 4
strides (20, 5, 1)
gpuarray ref count after creating a CudaNdarray 5
gpuarray ref count after deleting the CudaNdarray 4
ok

----------------------------------------------------------------------
Ran 3 tests in 0.297s

OK
```