### PR TITLE
AWS Marketplace AMI install doc section

### DIFF
--- a/doc/install_others.txt
+++ b/doc/install_others.txt
@@ -25,6 +25,13 @@ focusing on how to install the appropriate dependencies.
 
 Nicolas Pinto provides `ebuild scripts <https://github.com/npinto/sekyfsr-gentoo-overlay/tree/master/sci-libs/Theano>`_.
 
+AWS Marketplace with Bitfusion AMI
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+AWS EC2 AMI pre-installed with Nvidia drivers, CUDA, cuDNN, Theano, Keras, Lasagne, Python 2, Python 3, PyCuda, Scikit-Learn, Pandas, Enum34, iPython, and Jupyter. Also includes Bitfusion Boost which lets you combine multiple instances into a single virtual instance for max-performance applications and analysis without any code changes required. Note, as always there is no charge for Theano and other open software, however there is a charge for AWS hosting + Bitfusion software.
+
+`Launch <https://aws.amazon.com/marketplace/pp/B01IRAMCM8/ref=_ptnr_referral_docs_theano>`_ an instance from the AWS Marketplace.
+
 Docker
 ~~~~~~
 

--- a/doc/install_others.txt
+++ b/doc/install_others.txt
@@ -28,7 +28,7 @@ Nicolas Pinto provides `ebuild scripts <https://github.com/npinto/sekyfsr-gentoo
 AWS Marketplace with Bitfusion AMI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-AWS EC2 AMI pre-installed with Nvidia drivers, CUDA, cuDNN, Theano, Keras, Lasagne, Python 2, Python 3, PyCuda, Scikit-Learn, Pandas, Enum34, iPython, and Jupyter. Also includes Bitfusion Boost which lets you combine multiple instances into a single virtual instance for max-performance applications and analysis without any code changes required. Note, as always there is no charge for Theano and other open software, however there is a charge for AWS hosting + Bitfusion software.
+AWS EC2 AMI pre-installed with Nvidia drivers, CUDA, cuDNN, Theano, Keras, Lasagne, Python 2, Python 3, PyCuda, Scikit-Learn, Pandas, Enum34, iPython, and Jupyter. Note, as always there is no charge for Theano and other open software, however there is a charge for AWS hosting + Bitfusion.
 
 `Launch <https://aws.amazon.com/marketplace/pp/B01IRAMCM8/ref=_ptnr_referral_docs_theano>`_ an instance from the AWS Marketplace.
 


### PR DESCRIPTION
Added small section on AWS Marketplace AMI for Theano by Bitfusion. This was okayed by nouiz a couple months ago in the google group: https://groups.google.com/forum/#!searchin/theano-users/AMI%7Csort:relevance/theano-users/bZczMYoqdFU/gXEdvohhBAAJ