### PR TITLE
Pci bus ID now printed for GPU cards

### DIFF
--- a/theano/gpuarray/__init__.py
+++ b/theano/gpuarray/__init__.py
@@ -85,8 +85,16 @@ def init_dev(dev, name=None):
     # This will map the context name to the real context object.
     reg_context(name, context)
     if config.print_active_device:
+        try:
+            pcibusid = context.pcibusid
+        except pygpu.gpuarray.UnsupportedException:
+            pcibusid = '(unsupported for device %s)' % dev
+        except:
+            warnings.warn('Unable to get PCI Bus ID. Please consider updating libgpuarray and pygpu.')
+            pcibusid = 'unknown'
+
         print("Mapped name %s to device %s: %s; PCI Bus ID: %s" %
-              (name, dev, context.devname, context.pcibusid),
+              (name, dev, context.devname, pcibusid),
               file=sys.stderr)
     pygpu_activated = True
     ctx_props = _get_props(name)

--- a/theano/gpuarray/__init__.py
+++ b/theano/gpuarray/__init__.py
@@ -93,9 +93,10 @@ def init_dev(dev, name=None):
             warnings.warn('Unable to get PCI Bus ID. Please consider updating libgpuarray and pygpu.')
             pcibusid = 'unknown'
 
-        print("Mapped name %s to device %s: %s; PCI Bus ID: %s" %
-              (name, dev, context.devname, pcibusid),
+        print("Mapped name %s to device %s: %s" %
+              (name, dev, context.devname),
               file=sys.stderr)
+        print("PCI Bus ID:", pcibusid, file=sys.stderr)
     pygpu_activated = True
     ctx_props = _get_props(name)
     ctx_props['dev'] = dev

--- a/theano/gpuarray/__init__.py
+++ b/theano/gpuarray/__init__.py
@@ -85,8 +85,8 @@ def init_dev(dev, name=None):
     # This will map the context name to the real context object.
     reg_context(name, context)
     if config.print_active_device:
-        print("Mapped name %s to device %s: %s" %
-              (name, dev, context.devname),
+        print("Mapped name %s to device %s: %s; PCI Bus ID: %s" %
+              (name, dev, context.devname, context.pcibusid),
               file=sys.stderr)
     pygpu_activated = True
     ctx_props = _get_props(name)

--- a/theano/gpuarray/__init__.py
+++ b/theano/gpuarray/__init__.py
@@ -89,7 +89,7 @@ def init_dev(dev, name=None):
             pcibusid = context.pcibusid
         except pygpu.gpuarray.UnsupportedException:
             pcibusid = '(unsupported for device %s)' % dev
-        except:
+        except Exception:
             warnings.warn('Unable to get PCI Bus ID. Please consider updating libgpuarray and pygpu.')
             pcibusid = 'unknown'
 


### PR DESCRIPTION
This update allows Theano to print PCI bus ID for the GPU card (related to issue #5176 ).

This will works with CUDA devices and with the last version of libgpuarray ( see this pull request: https://github.com/Theano/libgpuarray/pull/283 ).

OpenCL devices are currently not supported (an "unsupported" message should be printed).

Tested on both Python 2 and Python 3. On my computer:

NVIDIA infos:

```nvidia-smi```:

```
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 370.28                 Driver Version: 370.28                    |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|===============================+======================+======================|
|   0  GeForce 840M        Off  | 0000:0A:00.0     Off |                  N/A |
| N/A   51C    P0    N/A /  N/A |    267MiB /  2002MiB |      5%      Default |
+-------------------------------+----------------------+----------------------+
```

Short test with CUDA:

```THEANO_FLAGS=device=cuda python -c "import theano"```
```
Mapped name None to device cuda: GeForce 840M; PCI Bus ID: 0000:0A:00.0
```

Short test with OpenCL:

```THEANO_FLAGS=device=opencl0:0 python -c "import theano"```
```
Mapped name None to device opencl0:0: GeForce 840M; PCI Bus ID: (unsupported for device opencl0:0)
```
