### PR TITLE
Port opt from the old backend.

### DIFF
--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -756,6 +756,8 @@ inplace_gpu_elemwise_opt = tensor.opt.InplaceElemwiseOptimizer(
 optdb.register('gpua_inplace_opt', inplace_gpu_elemwise_opt, 75,
                'inplace_elemwise_optimizer', 'fast_run', 'inplace', 'gpuarray')
 
+register_opt(tensor.opt.local_useless_elemwise)
+
 
 @register_opt('fast_compile')
 @op_lifter([tensor.DimShuffle])


### PR DESCRIPTION
Since gpu_elemwise_alloc is reused from tensor, I've ported it

I've looked at local_gpu_extract_diagonal, but since we don't have extract_diag, there is little point for now.