### PR TITLE
Add miniconda.sh to TRAVIS cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 # Install miniconda to avoid compiling scipy
   - mkdir -p download
   - cd download
-  - "[ -f $HOME/download/miniconda.sh ] || wget -c https://repo.continuum.io/miniconda/Miniconda2-4.1.11-Linux-x86_64.sh -O miniconda.sh"
+  - wget -c https://repo.continuum.io/miniconda/Miniconda2-4.1.11-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 cache:
   directories:
     - $HOME/download
+    - $HOME/download/miniconda.sh
     - $HOME/.cache/pip
     - $HOME/.theano
 
@@ -17,7 +18,7 @@ before_install:
 # Install miniconda to avoid compiling scipy
   - mkdir -p download
   - cd download
-  - wget -c https://repo.continuum.io/miniconda/Miniconda2-4.1.11-Linux-x86_64.sh -O miniconda.sh
+  - "[ -f $HOME/download/miniconda.sh ] || wget -c https://repo.continuum.io/miniconda/Miniconda2-4.1.11-Linux-x86_64.sh -O miniconda.sh"
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
     - $HOME/.cache/pip
     - $HOME/.theano
 
+
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
Trying to add miniconda.sh to TRAVIS cache.
The goal is to avoid re-downloading of this resource for every build.

Inspired from https://github.com/travis-ci/travis-ci/issues/1510#issuecomment-26274388
Need to be tested.

@nouiz 