### PR TITLE
Fix master build on readthedocs

### DIFF
--- a/requirement-rtd.txt
+++ b/requirement-rtd.txt
@@ -2,3 +2,5 @@ sphinx>=1.3.0
 pygments
 nose>=1.3.0
 nose-parameterized>=0.5.0
+scipy==0.13
+-e . --install-option="--no-deps"


### PR DESCRIPTION
The idea is to bypass the dependency on scipy that is in setup.py, by
- providing it explicitly in the requirement file, and
- explicitly installing theano, telling setup.py to ignore "install_requirements"

This is needed because the version of scipy on readthedocs is older than
the required one, but it is not an issue for building the doc itself.