### PR TITLE
Upgraded OpFromGraph with inline support and gradient override

### DIFF
--- a/theano/__init__.py
+++ b/theano/__init__.py
@@ -69,7 +69,7 @@ from theano.compile import (
     Mode,
     predefined_modes, predefined_linkers, predefined_optimizers,
     FunctionMaker, function, function_dump,
-    OpFromGraph, OpFromGraphInline, OpFromGraphPrecompiled, op_from_graph,
+    OpFromGraph, op_from_graph,
     ProfileStats,
     Param, shared, as_op)
 

--- a/theano/__init__.py
+++ b/theano/__init__.py
@@ -69,7 +69,7 @@ from theano.compile import (
     Mode,
     predefined_modes, predefined_linkers, predefined_optimizers,
     FunctionMaker, function, function_dump,
-    OpFromGraph, op_from_graph,
+    OpFromGraph,
     ProfileStats,
     Param, shared, as_op)
 

--- a/theano/__init__.py
+++ b/theano/__init__.py
@@ -68,7 +68,8 @@ from theano.compile import (
     SymbolicOutput, Out,
     Mode,
     predefined_modes, predefined_linkers, predefined_optimizers,
-    FunctionMaker, function, function_dump, OpFromGraph,
+    FunctionMaker, function, function_dump,
+    OpFromGraph, OpFromGrpahInline, OpFromGraphPrecompiled, op_from_graph
     ProfileStats,
     Param, shared, as_op)
 

--- a/theano/__init__.py
+++ b/theano/__init__.py
@@ -69,7 +69,7 @@ from theano.compile import (
     Mode,
     predefined_modes, predefined_linkers, predefined_optimizers,
     FunctionMaker, function, function_dump,
-    OpFromGraph, OpFromGrpahInline, OpFromGraphPrecompiled, op_from_graph
+    OpFromGraph, OpFromGraphInline, OpFromGraphPrecompiled, op_from_graph,
     ProfileStats,
     Param, shared, as_op)
 

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -340,11 +340,10 @@ class OpFromGraph(gof.Op):
         return self._grad_op(*(list(inputs) + list(output_grads)), return_list=True)
 
     def make_node(self, *inputs):
-        for input, type in zip(inputs, self.input_types):
-            if not type == input.type:
-                raise TypeError("Wrong type, expected %s but got %s" %
-                                (type, input.type))
-
+        num_expected_inps = len(self.local_inputs) - len(self.shared_inputs)
+        if len(inputs) != num_expected_inps:
+            raise ValueError("Expected %d inputs, got %d" % (num_expected_inps, len(inputs)))
+        inputs = [inp_t.filter_variable(inp) for inp, inp_t in izip(inputs, self.input_types)]
         apply_node = gof.Apply(
             self, list(inputs) + self.shared_inputs,
             [type() for type in self.output_types])

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -19,16 +19,20 @@ class OpFromGraph(gof.Op):
     `Op`'s perform will do the same operation as::
 
         orig_function(inputs, outputs, **kwargs)
+
     Currently does not support 'updates' or 'givens' argument.
 
     Parameters
     ----------
 
     inputs: list of variables
+
     outputs: list of variables
+
     inline: bool, optional
         if True, will cause the Op's original graph being used during
         compilation, otherwise will use a pre-compiled function inside.
+
     grad_overrides: None | undef | OpFromGraph instance | function | \
         list of (None|undef|function), optional
         Used to override default gradient routine.
@@ -44,17 +48,19 @@ class OpFromGraph(gof.Op):
         - function : must return list of Variable.
         - list : each function must return a single Variable. The order
             of the list must corresponds to inputs
+
     rop_overrides: None | undef | OpFromGraph instance | function | \
         list of (None|undef|function), optional
         similar to grad_overrides, list order should match two list of "inputs"
         concatenated.
+
     **kwargs: optional
         Whenever this OfG instance is precompiled instead of inline, a call to
         theano.compile.function_module.orig_function during precompile phase
         will take the extra keyword args
 
 
-    TODO:
+    .. TODO:
         - examples for a multi-layer mlp. where?
         - __hash__, __eq__ otherwise won't merge, try
           gof.opt.is_same_graph_with_merge(op1.local_outputs, op2,

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -20,7 +20,7 @@ class OpFromGraph(gof.Op):
     The signature is similar to :func:`theano.function <theano.function>`
     and the resulting ``Op``'s perform will do the same operation as::
 
-        orig_function(inputs, outputs, \*\*kwargs)
+        orig_function(inputs, outputs, **kwargs)
 
     Currently does not support ``updates`` or ``givens`` argument.
 
@@ -43,7 +43,7 @@ class OpFromGraph(gof.Op):
     grad_overrides : single or list of {'default', OpFromGraph, callable, Variable with special type}, optional
         Defaults to ``'default'``.
 
-        ``'default' : Do not override, use default grad() result
+        ``'default'`` : Do not override, use default grad() result
 
         OpFromGraph instance : Override with another OpFromGraph, should
         accept inputs as the same order and types of "inputs" and "output_grads"
@@ -63,7 +63,7 @@ class OpFromGraph(gof.Op):
     rop_overrides : single or list of {'default', OpFromGraph, callable, Variable with special type}, optional
         Defaults to ``default``.
 
-        ``default : Do not override, use default R_op() result
+        ``'default'`` : Do not override, use default R_op() result
 
         OpFromGraph instance : Override with another OpFromGraph, should
         accept inputs as the same order and types of "inputs" and "output_grads"

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -20,7 +20,7 @@ class OpFromGraphBase(gof.Op):
     def __init__(self, inputs, outputs, grad_overrides=None, **kwargs):
         if not isinstance(outputs, list):
             raise TypeError('outputs must be list', outputs)
-        for i in inputs+outputs:
+        for i in inputs + outputs:
             if not isinstance(i, gof.Variable):
                 raise TypeError(
                     'inputs and outputs must be Variable instances', i)
@@ -75,7 +75,7 @@ class OpFromGraphBase(gof.Op):
             if isinstance(grad_ops_l, list):
                 assert len(grad_ops_l) <= len(self.internal_inputs)
                 if len(grad_ops_l) < len(self.internal_inputs):
-                    grad_ops_l += [None]*(
+                    grad_ops_l += [None] * (
                         len(self.internal_inputs) - len(grad_ops_l))
                 # It is normal if some inputs are not needed in order
                 # to compute the gradient, so we ignore them.
@@ -94,7 +94,7 @@ class OpFromGraphBase(gof.Op):
                 # additional filtering is needed
                 def grad_ops(inps, grds):
                     # nonlocal gs, grad_ops_l
-                    return [(go(inps, grds) if ov else go(*(inps+grds)))
+                    return [(go(inps, grds) if ov else go(*(inps + grds)))
                             for go, ov in izip(gs, grad_ops_l)]
             else:
                 grad_ops = grad_ops_l
@@ -115,7 +115,7 @@ class OpFromGraphBase(gof.Op):
 
             def grad_ops(inps, grds):
                 # nonlocal grad_ops_l
-                return [go(*(inps+grds)) for go in grad_ops_l]
+                return [go(*(inps + grds)) for go in grad_ops_l]
             self.grad_ops = grad_ops
         self.cached_grad_ops = True
         return grad_ops(inputs, output_grads)
@@ -194,7 +194,7 @@ class OpFromGraphInline(OpFromGraphBase):
     """
     def perform(self, node, inputs, outputs):
         raise RuntimeError(
-            type(self).__name__+' is not supposed to be executed at runtime')
+            type(self).__name__ + ' is not supposed to be executed at runtime')
 
 
 @gof.local_optimizer([OpFromGraphInline])

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -213,7 +213,7 @@ class OpFromGraph(gof.Op):
     def __str__(self):
         name = self.__class__.__name__ if self.name is None else self.name
         is_inline = 'inline' if self.is_inline else 'compiled'
-        return '%(name)s{%(is_inline)s}'%locals()
+        return '%(name)s{%(is_inline)s}' % locals()
 
     def _recompute_grad_op(self):
         if isinstance(self._grad_op, OpFromGraph):

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -75,7 +75,7 @@ class OpFromGraph(gof.Op):
     name : string, optional
         A name for debugging purposes
 
-    **kwargs : optional
+    \*\*kwargs : optional
         Check
         :func:`orig_function <theano.compile.function_module.orig_function>`
         for more arguments, only works when not inline.

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -93,7 +93,7 @@ class OpFromGraphBase(gof.Op):
                 # since OpFromGraphBase only accepts input sequence,
                 # additional filtering is needed
                 def grad_ops(inps, grds):
-                    nonlocal gs, grad_ops_l
+                    # nonlocal gs, grad_ops_l
                     return [(go(inps, grds) if ov else go(*(inps+grds)))
                             for go, ov in izip(gs, grad_ops_l)]
             else:
@@ -114,7 +114,7 @@ class OpFromGraphBase(gof.Op):
                         grad_inps, [g], on_unused_input='ignore'))
 
             def grad_ops(inps, grds):
-                nonlocal grad_ops_l
+                # nonlocal grad_ops_l
                 return [go(*(inps+grds)) for go in grad_ops_l]
             self.grad_ops = grad_ops
         self.cached_grad_ops = True

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -33,8 +33,8 @@ class OpFromGraph(gof.Op):
         if True, will cause the Op's original graph being used during
         compilation, otherwise will use a pre-compiled function inside.
 
-    grad_overrides: None | undef | OpFromGraph instance | function | \
-        list of (None|undef|function), optional
+    grad_overrides: None | undef | OpFromGraph instance | function \
+        list of (None | undef | function), optional
         Used to override default gradient routine.
         Overriding function(s) must take two list of variable(s) as inputs,
         the original inputs and ups gradients
@@ -49,9 +49,9 @@ class OpFromGraph(gof.Op):
         - list : each function must return a single Variable. The order
             of the list must corresponds to inputs
 
-    rop_overrides: None | undef | OpFromGraph instance | function | \
-        list of (None|undef|function), optional
-        similar to grad_overrides, list order should match two list of "inputs"
+    rop_overrides: None | undef | OpFromGraph instance | function \
+        list of (None | undef | function), optional
+        Similar to grad_overrides, list order should match two list of "inputs"
         concatenated.
 
     **kwargs: optional
@@ -72,7 +72,7 @@ class OpFromGraph(gof.Op):
         - Add support for the GPU? Probably just need an opt to remove transfer
         - Add support to pickle this Op.
         - Add support/test with random generator
-        - Add optimization prior to inilne expansion such as removing unused
+        - Add optimizations prior to inline expansion such as removing unused
           inputs/outputs
 
     Notes
@@ -82,7 +82,7 @@ class OpFromGraph(gof.Op):
       the inner graph.
     - We support unused inputs. This is needed for the grad.
     - `inline=True` will cause better runtime optimization at the cost
-      of compilation time. Like "inline" keyword in C, this is merely a
+      of compilation time. Like "inline" keyword in C/C++, this is merely a
       suggestion to compiler which is not guaranteed. Currently only
       works with "fast_compile" or "fast_run" mode.
     - The function(s) supplied for overrding gradient/rop will be called

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -212,8 +212,8 @@ class OpFromGraph(gof.Op):
 
     def __str__(self):
         name = self.__class__.__name__ if self.name is None else self.name
-        is_inline = 'inline' if self.is_inline else 'compiled'
-        return '%(name)s{%(is_inline)s}' % locals()
+        is_inline = self.is_inline
+        return '%(name)s{inline=%(is_inline)s}' % locals()
 
     def _recompute_grad_op(self):
         if isinstance(self._grad_op, OpFromGraph):

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -1,5 +1,5 @@
 """Define new Ops from existing Ops"""
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 from functools import reduce, partial
 from collections import OrderedDict
 
@@ -20,7 +20,7 @@ class OpFromGraph(gof.Op):
     The signature is similar to :func:`theano.function <theano.function>`
     and the resulting ``Op``'s perform will do the same operation as::
 
-        orig_function(inputs, outputs, **kwargs)
+        orig_function(inputs, outputs, \*\*kwargs)
 
     Currently does not support ``updates`` or ``givens`` argument.
 

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -213,7 +213,7 @@ class OpFromGraph(gof.Op):
             name=None, **kwargs
     ):
         if not isinstance(outputs, list):
-            raise TypeError('outputs must be list, got %s' % type(outputs), outputs)
+            raise TypeError('outputs must be list, got %s' % type(outputs))
         for i in inputs + outputs:
             if not isinstance(i, gof.Variable):
                 raise TypeError(
@@ -297,7 +297,7 @@ class OpFromGraph(gof.Op):
         elif grad_op is None:
             all_grads_l = [inp.zeros_like() for inp in local_inputs]
             all_grads_ov_l = [self.ofg_null_t()] * inp_len
-        elif grad_op is 0:
+        elif type(grad_op) is int and grad_op == 0:
             all_grads_l = [inp.zeros_like() for inp in local_inputs]
             all_grads_ov_l = [self.ofg_discon_t()] * inp_len
         elif isinstance(grad_op, list):

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -1,15 +1,241 @@
+"""Define new Ops from existing Ops"""
 from __future__ import absolute_import, print_function, division
+from functools import reduce
+
 import theano
 from theano import gof
 from theano.compat import izip
 from theano.compile.function_module import orig_function
 from theano.compile import SharedVariable, rebuild_collect_shared
+from theano.compile import optdb
 from theano.gof import ops_with_inner_function
 from theano.gof.graph import io_connection_pattern
 
-from functools import reduce
+
+class BaseOpFromGraph(gof.Op):
+    """
+    General syntax is similar to theano.function
+    Currently does not support 'updates' or 'givens'argument
+
+    Parameters
+    ----------
+
+    inputs: list of variables
+    outputs: list of variables
+    grad_overrides: None or function or list of [None|function]
+        Used to override default gradient routine.
+        Overriding function must take two list as inputs: original inputs
+        and upstream gradients
+        If is None, will use default gradient routine.
+        If is function, must return list of Variable.
+        If is list, each function must return a single Variable. The order
+            of the list must corresponds to inputs
+
+    Notes
+    -----
+
+    You can use regular function for grad_overrides, but the function
+    must take (list of) Variable as input and output.
+    """
+    def __init__(self, inputs, outputs, grad_overrides=None, **kwargs):
+        if not isinstance(outputs, list):
+            raise TypeError('outputs must be list', outputs)
+        for i in inputs+outputs:
+            if not isinstance(i, gof.Variable):
+                raise TypeError(
+                    'inputs and outputs must be Variable instances', i)
+        if 'updates' in kwargs or 'givens' in kwargs:
+            raise TypeError('updates and givens are not allowed here')
 
 
+        # To correctly support shared variables the inner fct should
+        # not see them. Otherwise there is a problem with the gradient.
+        self.shared_inputs = [var for var in gof.graph.inputs(outputs)
+                              if isinstance(var, SharedVariable)]
+        shared_vars = [var.type() for var in self.shared_inputs]
+
+        new = rebuild_collect_shared(outputs, inputs=inputs + shared_vars,
+                                     replace=dict(izip(
+                                         self.shared_inputs, shared_vars)),
+                                     copy_inputs_over=False)
+        (internal_inputs, internal_outputs,
+         [clone_d, update_d, update_expr, shared_inputs]) = new
+        assert len(internal_inputs) == len(inputs) + len(self.shared_inputs)
+        assert len(internal_outputs) == len(outputs)
+        assert not update_d
+        assert not update_expr
+        assert not shared_inputs
+
+
+        self.internal_inputs = internal_inputs
+        self.internal_outputs = internal_outputs
+        self.inputs = inputs
+        self.outputs = outputs
+        self.kwargs = kwargs
+        self.input_types = [inp.type for inp in inputs]
+        self.output_types = [out.type for out in outputs]
+        # used to cache gradient for subgraph
+        self.grad_ops = grad_overrides
+        # should be True after 1st call to grad()
+        self.cached_grad_ops = False
+
+    def __eq__(self, other):
+        # TODO: recognize a copy
+        return self is other
+
+    def __hash__(self):
+        # TODO: use internal variables in hash
+        return hash(type(self))
+
+    def grad(self, inputs, output_grads):
+        if self.cached_grad_ops:
+            return self.grad_ops(inputs+output_grads)
+
+        grad_inps = self.internal_inputs + output_grads
+        upstream_grads = dict(izip(self.internal_outputs, output_grads))
+        if self.grad_ops is not None:
+            grad_ops_l = self.grad_ops
+            if isinstance(grad_ops_l, list):
+                assert len(grad_ops_l) <= len(self.internal_inputs)
+                if len(grad_ops_l)<len(self.internal_inputs):
+                    grad_ops_l += [None]*(
+                        len(self.internal_inputs) - len(grad_ops_l))
+                # It is normal if some inputs are not needed in order
+                # to compute the gradient, so we ignore them.
+                gs = [go if go else type(self)(
+                    grad_inps,
+                    theano.gradient.grad(
+                        cost=None,
+                        known_grads=upstream_grads,
+                        wrt=[inp],
+                        disconnected_inputs='ignore'),
+                    on_unused_input='ignore'
+                ) for go, inp in izip(grad_ops_l, self.internal_inputs)]
+                # since BaseOpFromGraph only accepts and outputs list,
+                # additional filtering is needed
+                grad_ops = lambda inps:[
+                    (go(inps) if ov else go(*inps))
+                    for go, ov in izip(gs, grad_ops_l)]
+            else:
+                grad_ops = grad_ops_l
+            self.grad_ops = grad_ops
+        else:
+            gs = theano.gradient.grad(
+                cost=None,
+                known_grads=upstream_grads,
+                wrt=self.internal_inputs,
+                disconnected_inputs='ignore')
+            grad_ops_l = []
+            for g in gs:
+                if g is None:
+                    grad_ops_l.append(lambda *args: None)
+                else:
+                    grad_ops_l.append(type(self)(grad_inps,
+                                                [g],
+                                                on_unused_input='ignore'))
+            grad_ops = lambda inps:[go(*inps) for go in grad_ops_l]
+            self.grad_ops = grad_ops
+        self.cached_grad_ops = True
+        return grad_ops(inputs+output_grads)
+
+    def make_node(self, *inputs):
+        for input, type in zip(inputs, self.input_types):
+            if not type == input.type:
+                raise TypeError("Wrong type, expected %s but got %s" %
+                                (type, input.type))
+
+        apply_node = gof.Apply(self,
+                         list(inputs) + self.shared_inputs,
+                         [type() for type in self.output_types])
+        apply_node.internal_inputs = self.internal_inputs
+        apply_node.internal_outputs = self.internal_outputs
+        return apply_node
+
+    def connection_pattern(self, node):
+        """
+        Return connection pattern of subfgraph defined by inputs and outputs.
+
+        """
+        return io_connection_pattern(self.internal_inputs, self.internal_outputs)
+
+    def infer_shape(self, node, shapes):
+        out_shp = theano.scan_module.scan_utils.infer_shape(
+            self.internal_outputs,
+            self.internal_inputs,
+            shapes)
+
+        # Clone the output shape so that shape are computed from outer inputs.
+        # Note:
+        # Here we can do it more simply like:
+        #      ret = [theano.clone(shp, replace=repl) for shp in out_shp]
+        # But  doing it multiple time could duplicate common subgraph between
+        # each shape call. Theano optimizer will clean this up later, but this
+        # will ask extra work to the optimizer.
+        repl = dict(zip(self.internal_inputs, node.inputs))
+        cloned = theano.clone(reduce(tuple.__add__, out_shp), replace=repl)
+        ret = []
+        used = 0
+        for i in range(len(out_shp)):
+            nb = len(out_shp[i])
+            ret.append(cloned[used: used + nb])
+            used += nb
+
+        return ret
+    def perform(self, node, inputs, outputs):
+        raise NotImplementedError()
+
+class OpFromGraphPrecompiled(BaseOpFromGraph):
+    """WRITEME"""
+    def prepare_node(self, node, storage_map, compute_map, impl):
+        if not hasattr(self, "fn") and impl == 'py':
+            self.fn = orig_function(self.internal_inputs,
+                                    self.internal_outputs,
+                                    **self.kwargs)
+
+    def perform(self, node, inputs, outputs):
+        variables = self.fn(*inputs)
+        assert len(variables) == len(outputs)
+        for output, variable in zip(outputs, variables):
+            # TODO: when function's output-borrowing semantics are correct,
+            # we wont need this copy anymore
+            output[0] = variable.copy()
+
+class OpFromGraphInline(BaseOpFromGraph):
+    """WRITEME"""
+    def perform(self, node, inputs, outputs):
+        raise RuntimeError('OpFromGraphInline is not supposed to be executed at runtime')
+        pass
+
+@gof.local_optimizer([OpFromGraphInline])
+def inline_ofg_expansion(node):
+    op = node.op
+    if not isinstance(op, OpFromGraphInline):
+        return False
+    outputs = theano.clone(
+        op.internal_outputs, {
+            u:v for u,v in izip(
+                node.op.internal_inputs, node.inputs)})
+    return outputs
+
+optdb.register(
+    'inline_ofg_expansion',
+    gof.opt.in2out(inline_ofg_expansion),
+    0.5, 'fast_compile', 'fast_run')
+
+ops_with_inner_function[OpFromGraphPrecompiled] = 'fn'
+
+# for backward compatibility
+OpFromGraph = OpFromGraphPrecompiled
+
+# APIs for OpFromGraph*
+def op_from_graph(
+    inputs, outputs, inline=False, grad_overrides=None, **kwargs):
+    cls_opfromgraph = OpFromGraphInline if inline else OpFromGraphPrecompiled
+    return cls_opfromgraph(
+        inputs, outputs, grad_overrides=grad_overrides, **kwargs)
+
+#BELOW is the original OpFromGraph
+'''
 class OpFromGraph(gof.Op):
     """
     This creates an `Op` from inputs and outputs lists of variables.
@@ -22,8 +248,8 @@ class OpFromGraph(gof.Op):
     TODO:
         - examples for a multi-layer mlp. where?
         - __hash__, __eq__ otherwise won't merge, try
-          gof.opt.is_same_graph_with_merge(op1.new_outputs, op2,
-          new_outputs)
+          gof.opt.is_same_graph_with_merge(op1.internal_outputs, op2,
+          internal_outputs)
         - c_code() to remove the double overhead?
         - opt to unfold it, work inplace on inputs
         - grad() make it support DisconnectedType and the new interface
@@ -82,8 +308,8 @@ class OpFromGraph(gof.Op):
         if 'updates' in kwargs or 'givens' in kwargs:
             raise TypeError('updates and givens are not allowed in kwargs')
 
-        # To support correctly shared variables the inner fct should
-        # not see them. Otherwise their is problem with the gradient.
+        # To correctly support shared variables the inner fct should
+        # not see them. Otherwise there is a problem with the gradient.
         self.shared_inputs = [var for var in gof.graph.inputs(outputs)
                               if isinstance(var, SharedVariable)]
         shared_vars = [var.type() for var in self.shared_inputs]
@@ -91,16 +317,16 @@ class OpFromGraph(gof.Op):
                                      replace=dict(izip(self.shared_inputs,
                                                        shared_vars)),
                                      copy_inputs_over=False)
-        (new_inputs, new_outputs,
+        (internal_inputs, internal_outputs,
          [clone_d, update_d, update_expr, shared_inputs]) = new
-        assert len(new_inputs) == len(inputs) + len(self.shared_inputs)
-        assert len(new_outputs) == len(outputs)
+        assert len(internal_inputs) == len(inputs) + len(self.shared_inputs)
+        assert len(internal_outputs) == len(outputs)
         assert not update_d
         assert not update_expr
         assert not shared_inputs
 
-        self.new_inputs = new_inputs
-        self.new_outputs = new_outputs
+        self.internal_inputs = internal_inputs
+        self.internal_outputs = internal_outputs
         self.inputs = inputs
         self.outputs = outputs
         self.kwargs = kwargs
@@ -126,8 +352,8 @@ class OpFromGraph(gof.Op):
 
     def prepare_node(self, node, storage_map, compute_map, impl):
         if not hasattr(self, "fn") and impl == 'py':
-            self.fn = orig_function(self.new_inputs,
-                                    self.new_outputs,
+            self.fn = orig_function(self.internal_inputs,
+                                    self.internal_outputs,
                                     **self.kwargs)
 
     def perform(self, node, inputs, outputs):
@@ -143,11 +369,11 @@ class OpFromGraph(gof.Op):
         Return connection pattern of subfgraph defined by inputs and outputs.
 
         """
-        return io_connection_pattern(self.new_inputs, self.new_outputs)
+        return io_connection_pattern(self.internal_inputs, self.internal_outputs)
 
     def infer_shape(self, node, shapes):
-        out_shp = theano.scan_module.scan_utils.infer_shape(self.new_outputs,
-                                                            self.new_inputs,
+        out_shp = theano.scan_module.scan_utils.infer_shape(self.internal_outputs,
+                                                            self.internal_inputs,
                                                             shapes)
 
         # Clone the output shape so that shape are computed from outer inputs.
@@ -157,7 +383,7 @@ class OpFromGraph(gof.Op):
         # But  doing it multiple time could duplicate common subgraph between
         # each shape call. Theano optimizer will clean this up later, but this
         # will ask extra work to the optimizer.
-        repl = dict(zip(self.new_inputs, node.inputs))
+        repl = dict(zip(self.internal_inputs, node.inputs))
         cloned = theano.clone(reduce(tuple.__add__, out_shp), replace=repl)
         ret = []
         used = 0
@@ -173,9 +399,9 @@ class OpFromGraph(gof.Op):
             grad_ops = self.grad_ops
         else:
             gs = theano.gradient.grad(cost=None,
-                                      known_grads=dict(izip(self.new_outputs,
+                                      known_grads=dict(izip(self.internal_outputs,
                                                             output_grads)),
-                                      wrt=self.new_inputs,
+                                      wrt=self.internal_inputs,
                                       disconnected_inputs='ignore')
 
             grad_ops = []
@@ -185,13 +411,10 @@ class OpFromGraph(gof.Op):
                 else:
                     # It is normal if some inputs are not needed in order
                     # to compute the gradient, so we ignore them.
-                    grad_ops.append(OpFromGraph(self.new_inputs + output_grads,
+                    grad_ops.append(OpFromGraph(self.internal_inputs + output_grads,
                                                 [g],
                                                 on_unused_input='ignore'))
             self.grad_ops = grad_ops
 
         return [go(*(inputs + output_grads)) for go in grad_ops]
-
-# Since OpFromGraph contains a Theano compiled function, we should let
-# DebugMode know about it
-ops_with_inner_function[OpFromGraph] = 'fn'
+'''

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -126,11 +126,11 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         def go(inps, gs):
             x, y = inps
             g = gs[0]
-            return [g*y*2, g*x*1.5]
+            return [g * y * 2, g * x * 1.5]
         # no override case is coverd in "grad" test
 
         # single override case
-        op_mul = cls_ofg([x, y], [x*y], grad_overrides=go)
+        op_mul = cls_ofg([x, y], [x * y], grad_overrides=go)
         xx, yy = T.vector('xx'), T.vector('yy')
         zz = T.sum(op_mul(xx, yy))
         dx, dy = T.grad(zz, [xx, yy])
@@ -138,23 +138,23 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         xv = numpy.random.rand(16).astype(config.floatX)
         yv = numpy.random.rand(16).astype(config.floatX)
         dxv, dyv = fn(xv, yv)
-        assert numpy.allclose(yv*2, dxv)
-        assert numpy.allclose(xv*1.5, dyv)
+        assert numpy.allclose(yv * 2, dxv)
+        assert numpy.allclose(xv * 1.5, dyv)
 
         # list override case
         def go1(inps, gs):
             x, w, b = inps
             g = gs[0]
-            return g*w*2
+            return g * w * 2
 
         def go2(inps, gs):
             x, w, b = inps
             g = gs[0]
-            return g*x*1.5
+            return g * x * 1.5
 
         w, b = T.vectors('wb')
         # we make the 3rd gradient default (no override)
-        op_linear = cls_ofg([x, w, b], [x*w+b], grad_overrides=[go1, go2])
+        op_linear = cls_ofg([x, w, b], [x * w + b], grad_overrides=[go1, go2])
         xx, ww, bb = T.vector('xx'), T.vector('yy'), T.vector('bb')
         zz = T.sum(op_linear(xx, ww, bb))
         dx, dw, db = T.grad(zz, [xx, ww, bb])
@@ -163,16 +163,16 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         wv = numpy.random.rand(16).astype(config.floatX)
         bv = numpy.random.rand(16).astype(config.floatX)
         dxv, dwv, dbv = fn(xv, wv, bv)
-        assert numpy.allclose(wv*2, dxv)
-        assert numpy.allclose(xv*1.5, dwv)
+        assert numpy.allclose(wv * 2, dxv)
+        assert numpy.allclose(xv * 1.5, dwv)
         assert numpy.allclose(numpy.ones(16, dtype=config.floatX), dbv)
 
     @test_params
     def test_nested(self, cls_ofg):
         x, y = T.vectors('xy')
-        u, v = x+y, x-y
+        u, v = x + y, x - y
         op_ft = cls_ofg([x, y], [u, v])
-        op_ift = cls_ofg([x, y], [u/2, v/2])
+        op_ift = cls_ofg([x, y], [u / 2, v / 2])
 
         xx, yy = T.vector('xx'), T.vector('yy')
         xx2, yy2 = op_ift(*op_ft(xx, yy))

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -124,12 +124,13 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
     def test_grad_override(self, cls_ofg):
         x,y = T.vectors('xy')
 
-        def go(args):
-            x, y, g = args
+        def go(inps, gs):
+            x, y = inps
+            g = gs[0]
             return [g*y*2, g*x*1.5]
-        # no override is coverd in "grad" test
+        # no override case is coverd in "grad" test
 
-        # single override
+        # single override case
         op_mul = cls_ofg([x, y], [x*y], grad_overrides=go)
         xx,yy = T.vector('xx'), T.vector('yy')
         zz = T.sum(op_mul(xx,yy))
@@ -141,13 +142,15 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         assert numpy.allclose(yv*2, dxv)
         assert numpy.allclose(xv*1.5, dyv)
 
-        # list override
-        def go1(args):
-            x, w, b, g = args
+        # list override case
+        def go1(inps, gs):
+            x, w, b = inps
+            g = gs[0]
             return g*w*2
 
-        def go2(args):
-            x, w, b, g = args
+        def go2(inps, gs):
+            x, w, b = inps
+            g = gs[0]
             return g*x*1.5
 
         w, b = T.vectors('wb')

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -181,12 +181,12 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         dx2, dw2, db2 = T.grad(
             zz2, [xx, ww, bb],
             return_disconnected='Disconnected',
+            disconnected_inputs='ignore',
             null_gradients='return')
-        fn2 = function([xx, ww, bb], [dx2, dw2, db2])
-        dxv2, dwv2, dbv2 = fn2(xv, wv, bv)
-        assert numpy.allclose(wv * 2, dxv)
-        assert isinstance(dwv2.type, NullType)
-        assert isinstance(dbv2.type, DisconnectedType)
+        assert isinstance(dx2.type, T.TensorType)
+        assert dx2.ndim == 1
+        assert isinstance(dw2.type, NullType)
+        assert isinstance(db2.type, DisconnectedType)
 
     @test_params
     def test_rop(self, cls_ofg):

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -18,7 +18,6 @@ test_params = unittest_tools.parameterized.expand(
 
 class T_OpFromGraph(unittest_tools.InferShapeTester):
 
-
     @test_params
     def test_straightforward(self, cls_ofg):
         x, y, z = T.matrices('xyz')
@@ -122,7 +121,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
 
     @test_params
     def test_grad_override(self, cls_ofg):
-        x,y = T.vectors('xy')
+        x, y = T.vectors('xy')
 
         def go(inps, gs):
             x, y = inps
@@ -132,8 +131,8 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
 
         # single override case
         op_mul = cls_ofg([x, y], [x*y], grad_overrides=go)
-        xx,yy = T.vector('xx'), T.vector('yy')
-        zz = T.sum(op_mul(xx,yy))
+        xx, yy = T.vector('xx'), T.vector('yy')
+        zz = T.sum(op_mul(xx, yy))
         dx, dy = T.grad(zz, [xx, yy])
         fn = function([xx, yy], [dx, dy])
         xv = numpy.random.rand(16).astype(config.floatX)
@@ -247,4 +246,3 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
                                  np.ones([3, 4], dtype=config.floatX)],
                                 cls_ofg,
                                 check_topo=is_compile)
-

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -162,7 +162,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
 
         w, b = T.vectors('wb')
         # we make the 3rd gradient default (no override)
-        op_linear = cls_ofg([x, w, b], [x * w + b], grad_overrides=[go1, go2, Ellipsis])
+        op_linear = cls_ofg([x, w, b], [x * w + b], grad_overrides=[go1, go2, 'default'])
         xx, ww, bb = T.vector('xx'), T.vector('yy'), T.vector('bb')
         zz = T.sum(op_linear(xx, ww, bb))
         dx, dw, db = T.grad(zz, [xx, ww, bb])
@@ -176,7 +176,9 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         assert np.allclose(np.ones(16, dtype=config.floatX), dbv)
 
         # NullType and DisconnectedType
-        op_linear2 = cls_ofg([x, w, b], [x * w + b], grad_overrides=[go1, None, 0])
+        op_linear2 = cls_ofg(
+            [x, w, b], [x * w + b],
+            grad_overrides=[go1, NullType()(), DisconnectedType()()])
         zz2 = T.sum(op_linear2(xx, ww, bb))
         dx2, dw2, db2 = T.grad(
             zz2, [xx, ww, bb],
@@ -205,7 +207,6 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         duval = np.random.rand(16).astype(config.floatX)
         dvval = np.dot(duval, Wval)
         dvval2 = fn(xval, Wval, duval)
-        print(dvval, dvval2)
         assert np.allclose(dvval2, dvval)
 
     @test_params

--- a/theano/compile/tests/test_builders.py
+++ b/theano/compile/tests/test_builders.py
@@ -8,17 +8,22 @@ from theano.compile import function
 from theano import tensor as T
 from theano.tensor.shared_randomstreams import RandomStreams
 
-from theano.compile.builders import OpFromGraph
+from theano.compile.builders import OpFromGraphInline, OpFromGraphPrecompiled
 
 from theano.tests import unittest_tools
+
+test_params = unittest_tools.parameterized.expand(
+    [(OpFromGraphInline,), (OpFromGraphPrecompiled,)])
 
 
 class T_OpFromGraph(unittest_tools.InferShapeTester):
 
-    def test_straightforward(self):
+
+    @test_params
+    def test_straightforward(self, cls_ofg):
         x, y, z = T.matrices('xyz')
         e = x + y * z
-        op = OpFromGraph([x, y, z], [e])
+        op = cls_ofg([x, y, z], [e])
         # (1+3*5=array of 16) - (3+1*5=array of 8)
         f = op(x, y, z) - op(y, z, x)
 
@@ -32,10 +37,11 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         assert np.all(8.0 == fn(xv, yv, zv))
         assert np.all(8.0 == fn(xv, yv, zv))
 
-    def test_size_changes(self):
+    @test_params
+    def test_size_changes(self, cls_ofg):
         x, y, z = T.matrices('xyz')
         e = T.dot(x, y)
-        op = OpFromGraph([x, y], [e])
+        op = cls_ofg([x, y], [e])
         f = op(x, op(y, z))
         fn = function([x, y, z], f)
         xv = np.ones((2, 3), dtype=config.floatX)
@@ -48,10 +54,11 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         assert res.shape == (2, 5)
         assert np.all(180.0 == res)
 
-    def test_grad(self):
+    @test_params
+    def test_grad(self, cls_ofg):
         x, y, z = T.matrices('xyz')
         e = x + y * z
-        op = OpFromGraph([x, y, z], [e])
+        op = cls_ofg([x, y, z], [e])
         f = op(x, y, z)
         f = f - T.grad(T.sum(f), y)
         fn = function([x, y, z], f)
@@ -60,10 +67,11 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         zv = np.ones((2, 2), dtype=config.floatX) * 5
         assert np.all(11.0 == fn(xv, yv, zv))
 
-    def test_grad_grad(self):
+    @test_params
+    def test_grad_grad(self, cls_ofg):
         x, y, z = T.matrices('xyz')
         e = x + y * z
-        op = OpFromGraph([x, y, z], [e])
+        op = cls_ofg([x, y, z], [e])
         f = op(x, y, z)
         f = f - T.grad(T.sum(f), y)
         f = f - T.grad(T.sum(f), y)
@@ -73,11 +81,12 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         zv = np.ones((2, 2), dtype=config.floatX) * 5
         assert np.allclose(6.0, fn(xv, yv, zv))
 
-    def test_shared(self):
+    @test_params
+    def test_shared(self, cls_ofg):
         x, y, z = T.matrices('xyz')
         s = shared(np.random.rand(2, 2).astype(config.floatX))
         e = x + y * z + s
-        op = OpFromGraph([x, y, z], [e])
+        op = cls_ofg([x, y, z], [e])
         # (1+3*5=array of 16) - (3+1*5=array of 8)
         f = op(x, y, z) - op(y, z, x)
 
@@ -90,11 +99,12 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         assert np.allclose(8.0, fn(xv, yv, zv))
         assert np.allclose(8.0, fn(xv, yv, zv))
 
-    def test_shared_grad(self):
+    @test_params
+    def test_shared_grad(self, cls_ofg):
         x, y, z = T.matrices('xyz')
         s = shared(np.random.rand(2, 2).astype(config.floatX))
         e = x + y * z + s
-        op = OpFromGraph([x, y, z], [e])
+        op = cls_ofg([x, y, z], [e])
         f = op(x, y, z)
         f = f - T.grad(T.sum(f), y)
         fn = function([x, y, z], f)
@@ -110,13 +120,76 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         assert np.allclose(15.0 + s.get_value(),
                            fn(xv, yv, zv))
 
-    def test_connection_pattern(self):
+    @test_params
+    def test_grad_override(self, cls_ofg):
+        x,y = T.vectors('xy')
+
+        def go(args):
+            x, y, g = args
+            return [g*y*2, g*x*1.5]
+        # no override is coverd in "grad" test
+
+        # single override
+        op_mul = cls_ofg([x, y], [x*y], grad_overrides=go)
+        xx,yy = T.vector('xx'), T.vector('yy')
+        zz = T.sum(op_mul(xx,yy))
+        dx, dy = T.grad(zz, [xx, yy])
+        fn = function([xx, yy], [dx, dy])
+        xv = numpy.random.rand(16).astype(config.floatX)
+        yv = numpy.random.rand(16).astype(config.floatX)
+        dxv, dyv = fn(xv, yv)
+        assert numpy.allclose(yv*2, dxv)
+        assert numpy.allclose(xv*1.5, dyv)
+
+        # list override
+        def go1(args):
+            x, w, b, g = args
+            return g*w*2
+
+        def go2(args):
+            x, w, b, g = args
+            return g*x*1.5
+
+        w, b = T.vectors('wb')
+        # we make the 3rd gradient default (no override)
+        op_linear = cls_ofg([x, w, b], [x*w+b], grad_overrides=[go1, go2])
+        xx, ww, bb = T.vector('xx'), T.vector('yy'), T.vector('bb')
+        zz = T.sum(op_linear(xx, ww, bb))
+        dx, dw, db = T.grad(zz, [xx, ww, bb])
+        fn = function([xx, ww, bb], [dx, dw, db])
+        xv = numpy.random.rand(16).astype(config.floatX)
+        wv = numpy.random.rand(16).astype(config.floatX)
+        bv = numpy.random.rand(16).astype(config.floatX)
+        dxv, dwv, dbv = fn(xv, wv, bv)
+        assert numpy.allclose(wv*2, dxv)
+        assert numpy.allclose(xv*1.5, dwv)
+        assert numpy.allclose(numpy.ones(16, dtype=config.floatX), dbv)
+
+    @test_params
+    def test_nested(self, cls_ofg):
+        x, y = T.vectors('xy')
+        u, v = x+y, x-y
+        op_ft = cls_ofg([x, y], [u, v])
+        op_ift = cls_ofg([x, y], [u/2, v/2])
+
+        xx, yy = T.vector('xx'), T.vector('yy')
+        xx2, yy2 = op_ift(*op_ft(xx, yy))
+        fn = function([xx, yy], [xx2, yy2])
+
+        xv = numpy.random.rand(16).astype(config.floatX)
+        yv = numpy.random.rand(16).astype(config.floatX)
+        xv2, yv2 = fn(xv, yv)
+        assert numpy.allclose(xv, xv2)
+        assert numpy.allclose(yv, yv2)
+
+    @test_params
+    def test_connection_pattern(self, cls_ofg):
         # Basic case
         x, y, z = T.matrices('xyz')
         out1 = x * y
         out2 = y * z
 
-        op1 = OpFromGraph([x, y, z], [out1, out2])
+        op1 = cls_ofg([x, y, z], [out1, out2])
         results = op1.connection_pattern(None)
         expect_result = [[True, False],
                          [True, True],
@@ -128,7 +201,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         m, n, p, q = T.matrices('mnpq')
         o1, o2 = op1(m, n, p)
         out1, out2 = op1(o1, q, o2)
-        op2 = OpFromGraph([m, n, p, q], [out1, out2])
+        op2 = cls_ofg([m, n, p, q], [out1, out2])
 
         results = op2.connection_pattern(None)
         expect_result = [[True, False],
@@ -144,7 +217,7 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
         out1 = x + rv_u
         out2 = y + 3
         out3 = 3 + rv_u
-        op3 = OpFromGraph([x, y], [out1, out2, out3])
+        op3 = cls_ofg([x, y], [out1, out2, out3])
 
         results = op3.connection_pattern(None)
         expect_result = [[True, False, False],
@@ -152,17 +225,23 @@ class T_OpFromGraph(unittest_tools.InferShapeTester):
                          [True, False, True]]
         assert results == expect_result
 
-    def test_infer_shape(self):
+    @test_params
+    def test_infer_shape(self, cls_ofg):
         x = T.matrix('x')
         y = T.matrix('y')
         o1 = x + y
         o2 = x * y
-        op_graph = OpFromGraph([x, y], [o1, o2])
+        op_graph = cls_ofg([x, y], [o1, o2])
 
         q = T.matrix('q')
         p = T.matrix('p')
+        # we don't want check_topo for inline ops
+        # since the inline op is replaced during optimization
+        is_compile = not issubclass(cls_ofg, OpFromGraphInline)
         self._compile_and_check([q, p],
                                 op_graph(q, p),
                                 [np.ones([3, 4], dtype=config.floatX),
                                  np.ones([3, 4], dtype=config.floatX)],
-                                OpFromGraph)
+                                cls_ofg,
+                                check_topo=is_compile)
+

--- a/theano/d3viz/formatting.py
+++ b/theano/d3viz/formatting.py
@@ -228,6 +228,7 @@ class PyDotFormatter(object):
                                            label=vparams['dtype']))
 
             # Create sub-graph for OpFromGraph nodes
+            # FIXME:
             if isinstance(node.op, builders.OpFromGraph):
                 subgraph = pd.Cluster(__node_id)
                 gf = PyDotFormatter()
@@ -244,15 +245,14 @@ class PyDotFormatter(object):
                 # Inputs mapping
                 ext_inputs = [self.__node_id(x) for x in node.inputs]
                 int_inputs = [gf.__node_id(x)
-                              for x in node.op.fn.maker.fgraph.inputs]
+                              for x in node.op.local_inputs]
                 assert len(ext_inputs) == len(int_inputs)
                 h = format_map(zip(ext_inputs, int_inputs))
                 pd_node.get_attributes()['subg_map_inputs'] = h
 
                 # Outputs mapping
                 ext_outputs = [self.__node_id(x) for x in node.outputs]
-                int_outputs = node.op.fn.maker.fgraph.outputs
-                int_outputs = [gf.__node_id(x) for x in int_outputs]
+                int_outputs = [gf.__node_id(x) for x in node.op.local_outputs]
                 assert len(ext_outputs) == len(int_outputs)
                 h = format_map(zip(int_outputs, ext_outputs))
                 pd_node.get_attributes()['subg_map_outputs'] = h

--- a/theano/d3viz/formatting.py
+++ b/theano/d3viz/formatting.py
@@ -228,7 +228,6 @@ class PyDotFormatter(object):
                                            label=vparams['dtype']))
 
             # Create sub-graph for OpFromGraph nodes
-            # FIXME:
             if isinstance(node.op, builders.OpFromGraph):
                 subgraph = pd.Cluster(__node_id)
                 gf = PyDotFormatter()

--- a/theano/gof/graph.py
+++ b/theano/gof/graph.py
@@ -1099,7 +1099,10 @@ def io_connection_pattern(inputs, outputs):
     # connnection patterns of the individual outputs
     global_connection_pattern = [[] for o in range(len(inputs))]
     for out in outputs:
-        out_connection_pattern = connect_pattern_by_var[out]
+        out_connection_pattern = connect_pattern_by_var.get(out)
+        if out_connection_pattern is None:
+            # the output is completely isolated from inputs
+            out_connection_pattern = [False] * len(inputs)
         for i in range(len(inputs)):
             global_connection_pattern[i].append(out_connection_pattern[i])
 

--- a/theano/gof/tests/test_graph.py
+++ b/theano/gof/tests/test_graph.py
@@ -340,6 +340,12 @@ class TestAutoName:
         assert r2.auto_name == "auto_" + str(autoname_id + 1)
 
     def test_constant(self):
+        # Make sure the value we will use for the test aren't yet in the cache.
+        r1 = tensor.constant(1.5)
+        del tensor.constant_cache[r1.signature()]
+        r1 = tensor.constant(1.6)
+        del tensor.constant_cache[r1.signature()]
+
         # Get counter value
         autoname_id = next(Variable.__count__)
         Variable.__count__ = count(autoname_id)

--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -1201,24 +1201,24 @@ def _populate_grad_dict(var_to_app_to_idx,
                         is_zero = _is_zero(term)
                         assert is_zero in ['yes', 'no', 'maybe']
                         if is_zero == 'maybe':
-                            msg = "%s.grad returned %s of type %s for input" \
-                                " %d. This input's only connections to " \
-                                "the cost through this op are via " \
-                                "integer-valued outputs so it should be " \
-                                "NullType, DisconnectedType, or some form " \
-                                "of zeros. It is not NullType or " \
-                                "DisconnectedType and theano can't " \
-                                "simplify it to a constant, so it's not " \
-                                "verifiably zeros."
+                            msg = ("%s.grad returned %s of type %s for input"
+                                   " %d. This input's only connections to "
+                                   "the cost through this op are via "
+                                   "integer-valued outputs so it should be "
+                                   "NullType, DisconnectedType, or some form "
+                                   "of zeros. It is not NullType or "
+                                   "DisconnectedType and theano can't "
+                                   "simplify it to a constant, so it's not "
+                                   "verifiably zeros.")
 
                             msg %= (node.op, term, type(term), i)
 
                         elif is_zero == 'no':
-                            msg = "%s.grad returned %s of type %s for input" \
-                                " %d. Since this input is only connected " \
-                                "to integer-valued outputs, it should " \
-                                "evaluate to zeros, but it evaluates to" \
-                                "%s."
+                            msg = ("%s.grad returned %s of type %s for input"
+                                   " %d. Since this input is only connected "
+                                   "to integer-valued outputs, it should "
+                                   "evaluate to zeros, but it evaluates to"
+                                   "%s.")
 
                             msg %= (node.op, term, type(term), i,
                                     theano.get_scalar_constant_value(term))
@@ -1240,24 +1240,23 @@ def _populate_grad_dict(var_to_app_to_idx,
                             ov.type, DisconnectedType)
 
                 if actually_connected and not connected:
-                    msg = "%s.grad returned %s of type %s for input %d." \
-                        " Expected DisconnectedType instance based on " \
-                        " the output of the op's connection_pattern " \
-                        "method."
+                    msg = ("%s.grad returned %s of type %s for input %d."
+                           " Expected DisconnectedType instance based on "
+                           " the output of the op's connection_pattern "
+                           "method.")
                     msg %= (str(node.op), str(ig), str(ig.type), i)
                     raise TypeError(msg)
 
                 elif connected and not actually_connected:
-                    msg = "%s.grad returned DisconnectedType for input" \
-                        " %d."
-                    msg = msg % (str(node.op), i)
+                    msg = "%s.grad returned DisconnectedType for input %d."
+                    msg %= (str(node.op), i)
                     if hasattr(node.op, 'connection_pattern'):
-                        msg += ' Its connection_pattern method does not' \
-                            ' allow this.'
+                        msg += (' Its connection_pattern method does not'
+                                ' allow this.')
                         raise TypeError(msg)
                     else:
-                        msg += ' You may want to implement a ' \
-                            'connection_pattern method for it.'
+                        msg += (' You may want to implement a '
+                                'connection_pattern method for it.')
                         warnings.warn(msg)
 
             # cache the result

--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -1221,14 +1221,15 @@ def _populate_grad_dict(var_to_app_to_idx,
                                 "%s."
 
                             msg %= (node.op, term, type(term), i,
-                                   theano.get_scalar_constant_value(term))
+                                    theano.get_scalar_constant_value(term))
 
                             raise ValueError(msg)
 
             # Check that op.connection_pattern matches the connectivity
             # logic driving the op.grad method
             for i, (ipt, ig, connected) in enumerate(
-                zip(inputs, input_grads, inputs_connected)):
+                zip(inputs, input_grads, inputs_connected)
+            ):
                 actually_connected = \
                     not isinstance(ig.type, DisconnectedType)
 

--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -1233,12 +1233,6 @@ def _populate_grad_dict(var_to_app_to_idx,
                 actually_connected = \
                     not isinstance(ig.type, DisconnectedType)
 
-                if isinstance(node.op, theano.OpFromGraph):
-                    ov = node.op._grad_op_overrides_l[i]
-                    if ov is not None:
-                        connected &= not isinstance(
-                            ov.type, DisconnectedType)
-
                 if actually_connected and not connected:
                     msg = ("%s.grad returned %s of type %s for input %d."
                            " Expected DisconnectedType instance based on "

--- a/theano/gradient.py
+++ b/theano/gradient.py
@@ -1201,58 +1201,62 @@ def _populate_grad_dict(var_to_app_to_idx,
                         is_zero = _is_zero(term)
                         assert is_zero in ['yes', 'no', 'maybe']
                         if is_zero == 'maybe':
-                            msg = "%s.grad returned %s of type %s for input"
-                            msg += " %d. This input's only connections to "
-                            msg += "the cost through this op are via "
-                            msg += "integer-valued outputs so it should be "
-                            msg += "NullType, DisconnectedType, or some form "
-                            msg += "of zeros. It is not NullType or "
-                            msg += "DisconnectedType and theano can't "
-                            msg += "simplify it to a constant, so it's not "
-                            msg += "verifiably zeros."
+                            msg = "%s.grad returned %s of type %s for input" \
+                                " %d. This input's only connections to " \
+                                "the cost through this op are via " \
+                                "integer-valued outputs so it should be " \
+                                "NullType, DisconnectedType, or some form " \
+                                "of zeros. It is not NullType or " \
+                                "DisconnectedType and theano can't " \
+                                "simplify it to a constant, so it's not " \
+                                "verifiably zeros."
 
-                            msg = msg % (str(node.op), str(term),
-                                         str(type(term)), i)
+                            msg %= (node.op, term, type(term), i)
 
-                        if is_zero == 'no':
-                            msg = "%s.grad returned %s of type %s for input"
-                            msg += " %d. Since this input is only connected "
-                            msg += "to integer-valued outputs, it should "
-                            msg += "evaluate to zeros, but it evaluates to"
-                            msg += "%s."
+                        elif is_zero == 'no':
+                            msg = "%s.grad returned %s of type %s for input" \
+                                " %d. Since this input is only connected " \
+                                "to integer-valued outputs, it should " \
+                                "evaluate to zeros, but it evaluates to" \
+                                "%s."
 
-                            msg % (node.op, term, type(term), i,
+                            msg %= (node.op, term, type(term), i,
                                    theano.get_scalar_constant_value(term))
 
                             raise ValueError(msg)
 
             # Check that op.connection_pattern matches the connectivity
             # logic driving the op.grad method
-            for i, packed in enumerate(zip(inputs, input_grads,
-                                           inputs_connected)):
-                ipt, ig, connected = packed
+            for i, (ipt, ig, connected) in enumerate(
+                zip(inputs, input_grads, inputs_connected)):
                 actually_connected = \
                     not isinstance(ig.type, DisconnectedType)
 
+                if isinstance(node.op, theano.OpFromGraph):
+                    ov = node.op._grad_op_overrides_l[i]
+                    if ov is not None:
+                        connected &= not isinstance(
+                            ov.type, DisconnectedType)
+
                 if actually_connected and not connected:
-                    msg = "%s.grad returned %s of type %s for input %d."
-                    msg += " Expected DisconnectedType instance based on "
-                    msg += " the output of the op's connection_pattern "
-                    msg += "method."
-                    msg = msg % (str(node.op), str(ig), str(ig.type), i)
+                    msg = "%s.grad returned %s of type %s for input %d." \
+                        " Expected DisconnectedType instance based on " \
+                        " the output of the op's connection_pattern " \
+                        "method."
+                    msg %= (str(node.op), str(ig), str(ig.type), i)
                     raise TypeError(msg)
 
-                if connected and not actually_connected:
-                    msg = "%s.grad returned DisconnectedType for input"
-                    msg += " %d."
+                elif connected and not actually_connected:
+                    msg = "%s.grad returned DisconnectedType for input" \
+                        " %d."
                     msg = msg % (str(node.op), i)
                     if hasattr(node.op, 'connection_pattern'):
-                        msg += ' Its connection_pattern method does not'
-                        msg += ' allow this.'
+                        msg += ' Its connection_pattern method does not' \
+                            ' allow this.'
                         raise TypeError(msg)
                     else:
-                        msg += ' You may want to implement a '
-                        msg += 'connection_pattern method for it.'
+                        msg += ' You may want to implement a ' \
+                            'connection_pattern method for it.'
                         warnings.warn(msg)
 
             # cache the result

--- a/theano/tests/unittest_tools.py
+++ b/theano/tests/unittest_tools.py
@@ -244,9 +244,9 @@ class InferShapeTester(unittest.TestCase):
         # Check that the Op is removed from the compiled function.
         if check_topo:
             topo_shape = shapes_function.maker.fgraph.toposort()
+            topo_out = outputs_function.maker.fgraph.toposort()
             assert not any(isinstance(t.op, cls) for t in topo_shape)
-        topo_out = outputs_function.maker.fgraph.toposort()
-        assert any(isinstance(t.op, cls) for t in topo_out)
+            assert any(isinstance(t.op, cls) for t in topo_out)
         # Check that the shape produced agrees with the actual shape.
         numeric_outputs = outputs_function(*numeric_inputs)
         numeric_shapes = shapes_function(*numeric_inputs)

--- a/theano/tests/unittest_tools.py
+++ b/theano/tests/unittest_tools.py
@@ -244,9 +244,9 @@ class InferShapeTester(unittest.TestCase):
         # Check that the Op is removed from the compiled function.
         if check_topo:
             topo_shape = shapes_function.maker.fgraph.toposort()
-            topo_out = outputs_function.maker.fgraph.toposort()
             assert not any(isinstance(t.op, cls) for t in topo_shape)
-            assert any(isinstance(t.op, cls) for t in topo_out)
+        topo_out = outputs_function.maker.fgraph.toposort()
+        assert any(isinstance(t.op, cls) for t in topo_out)
         # Check that the shape produced agrees with the actual shape.
         numeric_outputs = outputs_function(*numeric_inputs)
         numeric_shapes = shapes_function(*numeric_inputs)


### PR DESCRIPTION
For #5225. Allowing inlined `OpFromGraph` at compile time and overriding gradient.

### Changes:
- ~~Refactored `OpFromGraph` into `OpFromGraphBase` (abstract) and subclass `OpFromGraphPrecompiled`,  `OpFromGraphInline`~~
- ~~`OpFromGraph = OpFromGraphPrecompiled` for compatibility~~
- OpFromGraph `__init__` method now have `inline` argument
- Can now override gradient/Rop for `OpFromGraph*` by supplying `grad_overrides` or `rop_overrides`  parameters respectively.
- Added an graph optimizer to expand inlined `OpFromGraph` at compile time.
- ~~new convenient function `op_from_graph(inputs, outputs, inline=False, grad_overrides=None, rop_overrides=None, **kwargs)`~~
- new tests for `compile/tests/test_builders.py`: `nested`, `grad_override` and `rop_override`
- tests in `compile/tests/test_builders.py` now test against both inline/precompiled mode.
- `name` and `__str__` for better debugging
- Docs

### Problems / Ideas:
- ~~Instead of refactoring `OpFromGraph` into 3 classes, how about adding a `inline` parameter to `OpFromGraph`, resulting simpler code?~~
- Made a commit to combine 3 classes back into one single `OpFromGraph`. This is different to the original plan on dividing `OpFromGraph`, but I think this makes the code cleaner. Is this OK?

### Related
#1603 #2982