### PR TITLE
fix crash in MRG_RandomStreams with the new backend

### DIFF
--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -25,7 +25,7 @@ from . import multinomial
 import theano.sandbox.cuda
 from theano.sandbox.cuda import GpuOp
 from theano.sandbox.cuda.basic_ops import as_cuda_ndarray_variable
-from theano.gpuarray.basic_ops import GpuKernelBase, Kernel, infer_context_name,as_gpuarray_variable
+from theano.gpuarray.basic_ops import GpuKernelBase, Kernel, infer_context_name, as_gpuarray_variable
 from theano.gpuarray.type import GpuArrayType
 from theano.gpuarray.fp16_help import write_w
 from theano.gpuarray.opt import (register_opt as register_gpua,
@@ -326,7 +326,6 @@ class mrg_uniform_base(Op):
 class mrg_uniform(mrg_uniform_base):
     # CPU VERSION
 
-
     def make_node(self, rstate, size):
         # error checking slightly redundant here, since
         # this op should not be called directly.
@@ -566,7 +565,7 @@ class mrg_uniform(mrg_uniform_base):
 
 class GPU_mrg_uniform(mrg_uniform_base, GpuOp):
     # GPU VERSION
-    
+
     def make_node(self, rstate, size):
         # error checking slightly redundant here, since
         # this op should not be called directly.
@@ -835,7 +834,7 @@ class GPUA_mrg_uniform(GpuKernelBase, mrg_uniform_base):
         for i in range(self.output_type.ndim):
                 broad.append(tensor.extract_constant(size[i]) == 1)
         output_type = self.output_type.clone(broadcastable=broad)()
-        rstate = as_gpuarray_variable(rstate,infer_context_name(rstate))
+        rstate = as_gpuarray_variable(rstate, infer_context_name(rstate))
         return Apply(self,
                      [rstate, size],
                      [rstate.type(), output_type])

--- a/theano/sandbox/tests/test_rng_mrg.py
+++ b/theano/sandbox/tests/test_rng_mrg.py
@@ -18,6 +18,7 @@ from theano.sandbox.rng_mrg import MRG_RandomStreams
 from theano.sandbox.cuda import cuda_available
 from theano.tests import unittest_tools as utt
 from theano.tests.unittest_tools import attr
+import theano.gpuarray.tests.config
 
 if cuda_available:
     from theano.sandbox.cuda import float32_shared_constructor
@@ -1162,6 +1163,16 @@ def test_overflow_gpu_new_backend():
              (numpy.int32(2), numpy.int32(2**10), numpy.int32(2**10))]
     rng_mrg_overflow(sizes, fct, mode, should_raise_error=False)
 
+
+def test_validate_input_types_gpuarray_backend():
+    from theano.sandbox.rng_mrg import mrg_uniform
+    from theano.gpuarray.type import gpuarray_shared_constructor
+    from theano.configparser import change_flags
+
+    with change_flags(compute_test_value="raise"):
+        rstate = numpy.zeros((7, 6), dtype="int32")
+        rstate = gpuarray_shared_constructor(rstate)
+        mrg_uniform.new(rstate, ndim=None, dtype="float32", size=(3,))
 
 if __name__ == "__main__":
     rng = MRG_RandomStreams(numpy.random.randint(2147462579))


### PR DESCRIPTION
Moved the make_node() from the base class "mrg_uniform_base" to the derived classes ( CPU, old GPU and new GPU backend) to avoid incorrect dtype settings for "rstate"

fix gh-4916