### PR TITLE
Close file as reading file done

### DIFF
--- a/theano/gof/utils.py
+++ b/theano/gof/utils.py
@@ -569,7 +569,9 @@ def hash_from_file(file_path):
     Return the MD5 hash of a file.
 
     """
-    return hash_from_code(open(file_path, 'rb').read())
+    with open(file_path, 'rb') as f:
+        file_content = f.read()
+    return hash_from_code(file_content)
 
 
 def hash_from_dict(d):


### PR DESCRIPTION
Received warning while running test saying file unclosed (line 571 in old version). Close it using ``with``.

Suppose this is a tiny change so didn't run tests.  

The function ``hash_from_dict`` is from merged upstream.

fix gh-5261