### PR TITLE
GPU gemv->dot speedup for new backend

### DIFF
--- a/theano/gpuarray/blas.py
+++ b/theano/gpuarray/blas.py
@@ -75,7 +75,6 @@ class GpuGemv(BlasOp):
         inplace = self.inplace
         if inplace and y.strides[0] < 0:
             inplace = False
-        print(alpha, beta)
         out_storage[0][0] = blas.gemv(alpha, A, x, beta, y,
                                       overwrite_y=inplace)
 

--- a/theano/gpuarray/blas.py
+++ b/theano/gpuarray/blas.py
@@ -138,7 +138,7 @@ class GpuGemv(BlasOp):
         return code
 
     def c_code_cache_version(self):
-        return (5,)
+        return (6,)
 
 gpugemv_no_inplace = GpuGemv(inplace=False)
 gpugemv_inplace = GpuGemv(inplace=True)

--- a/theano/gpuarray/blas.py
+++ b/theano/gpuarray/blas.py
@@ -9,7 +9,6 @@ from theano.compile import optdb
 from theano.gof import LocalOptGroup
 from theano.tensor.basic import as_tensor_variable
 from theano.tensor.opt import in2out
-from theano.tensor.var import TensorConstant
 
 from .basic_ops import (GpuArrayType, CGpuKernelBase,
                         as_gpuarray_variable, gpu_contiguous, infer_context_name)
@@ -54,14 +53,6 @@ class GpuGemv(BlasOp):
         alpha = as_tensor_variable(alpha).astype('float64')
         beta = as_tensor_variable(beta).astype('float64')
 
-        # if alpha==1. and beta==0., we add runtime check
-        # for possible speed up using vector-vector dot as
-        # gemv tend to be slower for vector-vector dot
-        self._use_rt_dot_check = False
-        if all(map(lambda v: isinstance(v, TensorConstant), [alpha, beta])):
-            if alpha.value == 1. and beta.value == 0.:
-                self._use_rt_dot_check = True
-
         assert alpha.ndim == 0
         assert beta.ndim == 0
         assert A.ndim == 2
@@ -101,6 +92,8 @@ class GpuGemv(BlasOp):
                        %(fail)s
                    }
                    """ % vars
+        # in case of possible speed up using blas dot,
+        # temporary hack A to 1D for vector-vector dot
         code += """
         if (PyGpuArray_DIM(%(A)s, 1) == 0) {
           int code;
@@ -109,37 +102,32 @@ class GpuGemv(BlasOp):
             PyErr_SetString(PyExc_RuntimeError, "Memset failed");
             %(fail)s
           }
-        } """ % vars
-        if self._use_rt_dot_check:
-            # temporary hack A to 1D for vector-vector dot
-            code += """
-            else if (%(A)s->ga.dimensions[0]==1) {
-                %(out)s->ga.nd = 0;
-                %(A)s->ga.nd = 1;
-                if (%(A)s->ga.flags & GA_C_CONTIGUOUS) {
-                    %(A)s->ga.strides[0] ^= %(A)s->ga.strides[1];
-                    %(A)s->ga.strides[1] ^= %(A)s->ga.strides[0];
-                    %(A)s->ga.strides[0] ^= %(A)s->ga.strides[1];
-                }
-                %(A)s->ga.dimensions[0] = %(A)s->ga.dimensions[1];
+        } else if ( PyGpuArray_DIM(%(A)s, 0) == 1
+         &&((dtype_%(alpha)s*)PyArray_DATA(%(alpha)s))[0] == (dtype_%(alpha)s)1.
+         &&((dtype_%(beta)s*)PyArray_DATA(%(beta)s))[0] == (dtype_%(beta)s)0.
+        ) {
+            %(out)s->ga.nd = 0;
+            %(A)s->ga.nd = 1;
+            %(A)s->ga.dimensions[0] = %(A)s->ga.dimensions[1];
+            if (%(A)s->ga.flags & GA_C_CONTIGUOUS) {
+                ssize_t a_stride0 = %(A)s->ga.strides[0];
+                %(A)s->ga.strides[0] = %(A)s->ga.strides[1];
                 if (pygpu_blas_rdot(%(x)s, %(A)s, %(y)s, 0) == -1) {
                     %(fail)s
                 }
-                %(A)s->ga.dimensions[0] = 1;
-                if (%(A)s->ga.flags & GA_C_CONTIGUOUS) {
-                    %(A)s->ga.strides[0] ^= %(A)s->ga.strides[1];
-                    %(A)s->ga.strides[1] ^= %(A)s->ga.strides[0];
-                    %(A)s->ga.strides[0] ^= %(A)s->ga.strides[1];
-                }
-                %(A)s->ga.nd = 2;
-                %(out)s->ga.nd = 1;
-            } """ % vars
-        code += """
-        else if (pygpu_blas_rgemv(cb_no_trans,
-                             ((dtype_%(alpha)s *)PyArray_DATA(%(alpha)s))[0],
-                             %(A)s, %(x)s,
-                             ((dtype_%(beta)s *)PyArray_DATA(%(beta)s))[0],
-                             %(out)s, 0) == -1) {
+                %(A)s->ga.strides[0] = a_stride0;
+            } else if (pygpu_blas_rdot(%(x)s, %(A)s, %(y)s, 0) == -1) {
+                %(fail)s
+            }
+            %(out)s->ga.nd = 1;
+            %(A)s->ga.nd = 2;
+            %(A)s->ga.dimensions[0] = 1;
+        } else if (
+            pygpu_blas_rgemv(cb_no_trans,
+            ((dtype_%(alpha)s *)PyArray_DATA(%(alpha)s))[0],
+            %(A)s, %(x)s,
+            ((dtype_%(beta)s *)PyArray_DATA(%(beta)s))[0],
+            %(out)s, 0) == -1) {
             %(fail)s
         }
         """ % vars


### PR DESCRIPTION
Similar to #5257, this PR applies to the new backend.

~~**ONLY merge this after libgpuarray-294 is merged.**~~
To test this, newer `libgpuarray` with [this PR](https://github.com/Theano/libgpuarray/pull/294) merged is needed.

Results of running [this](https://gist.github.com/khaotik/9c7c72e562a919e241c9a09522fc4df5) test script on my laptop (GeForce GT 650m):

(time used in seconds, lower is better)

Before:
```
  scan with dot  |  scan with sum   |  full unrolled
 3.502193689346  |  0.411211490631  |  0.089465141296  
 1.447018623352  |  0.412187576294  |  0.086945295334  
 1.446414470673  |  0.411444425583  |  0.089369773865  
 1.447574138641  |  0.413084506989  |  0.091281890869  
 1.452363491058  |  0.412972927094  |  0.088017463684  
...
```

After:
```
  scan with dot  |  scan with sum   |  full unrolled
 2.389663457870  |  0.413246393204  |  0.089257478714  
 0.485583782196  |  0.413187980652  |  0.086747169495  
 0.486212968826  |  0.413235425949  |  0.088805198669  
 0.489252328873  |  0.413118600845  |  0.088519096375  
 0.484216928482  |  0.413124799728  |  0.087159156799  
...
```

I'm not sure this also works for OpenCL. Could use some help for testing. For OpenCL device, both Intel/AMD GPU, both clBLAS and clBLAST library, should be tested.