### PR TITLE
Port erfinv and erfcinv to new backend.

### DIFF
--- a/theano/gpuarray/elemwise.py
+++ b/theano/gpuarray/elemwise.py
@@ -2603,7 +2603,7 @@ class GpuErfinv(Erfinv):
         return "%(z)s = (%(x)s <= -1) ? erfinv(-1.0): ((%(x)s >= 1) ? erfinv(1.0): erfinv(%(x)s));" % locals()
 
 
-class GpuErfcinv(Erfinv):
+class GpuErfcinv(Erfcinv):
     """
     Inverse complementary error function for GPU.
 
@@ -2625,6 +2625,7 @@ class GpuErfcinv(Erfinv):
 
 gpu_erfinv = GpuErfinv(upgrade_to_float_no_complex, name='gpu_erfinv')
 gpu_erfcinv = GpuErfcinv(upgrade_to_float_no_complex, name='gpu_erfcinv')
+
 
 # Caching GpuCAReduceCuda
 def gpu_ca_reduce_cuda(scalar_op, axis=None, reduce_mask=None, dtype=None, acc_dtype=None,

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -702,9 +702,9 @@ def local_gpua_elemwise(op, context_name, inputs, outputs):
     have_opencl = False
     if inputs and isinstance(inputs[0].type, GpuArrayType):
         kind = inputs[0].type.context.kind
-        if kind.startswith('opencl'):
+        if kind.startswith(b'opencl'):
             have_opencl = True
-        elif kind.startswith('cuda'):
+        elif kind.startswith(b'cuda'):
             have_cuda = True
     opname = False
     if isinstance(scal_op, Erfinv):

--- a/theano/gpuarray/tests/test_elemwise.py
+++ b/theano/gpuarray/tests/test_elemwise.py
@@ -80,57 +80,41 @@ class TestMathErrorFunctions(TestCase):
         theano.printing.debugprint(theano_function)
         return False
 
-    def compute_erfinv_host(self, dtype):
-        vector = theano.tensor.vector(dtype=dtype)
-        output = theano.tensor.erfinv(vector)
-        f = theano.function([vector], output, name='HOST/erfinv/' + dtype, mode=mode_without_gpu)
-        assert len([n for n in f.maker.fgraph.apply_nodes if isinstance(n.op, GpuElemwise)]) == 0
-        vector_val = self.default_arrays[dtype]
-        f(vector_val)
-        out = f(vector_val)
-        assert_allclose(self.expected_erfinv_outputs[dtype], out)
-
-    def compute_erfinv_gpu(self, dtype):
-        vector = theano.tensor.vector(dtype=dtype)
-        output = theano.tensor.erfinv(vector)
-        f = theano.function([vector], output, name='GPU/erfinv/' + dtype, mode=mode_with_gpu)
-        if not theano.config.device.startswith('opencl'):
-            assert self.check_gpu_scalar_op(f, GpuErfinv), 'Function graph does not contains scalar op "GpuErfinv".'
-        vector_val = self.default_arrays[dtype]
-        f(vector_val)
-        out = f(vector_val)
-        assert_allclose(self.expected_erfinv_outputs[dtype], out)
-
-    def compute_erfcinv_host(self, dtype):
-        vector = theano.tensor.vector(dtype=dtype)
-        output = theano.tensor.erfcinv(vector)
-        f = theano.function([vector], output, name='HOST/erfcinv/' + dtype, mode=mode_without_gpu)
-        assert len([n for n in f.maker.fgraph.apply_nodes if isinstance(n.op, GpuElemwise)]) == 0
-        vector_val = self.default_arrays[dtype]
-        f(vector_val)
-        out = f(vector_val)
-        assert_allclose(self.expected_erfcinv_outputs[dtype], out)
-
-    def compute_erfcinv_gpu(self, dtype):
-        vector = theano.tensor.vector(dtype=dtype)
-        output = theano.tensor.erfcinv(vector)
-        f = theano.function([vector], output, name='GPU/erfcinv/' + dtype, mode=mode_with_gpu)
-        if not theano.config.device.startswith('opencl'):
-            assert self.check_gpu_scalar_op(f, GpuErfcinv), 'Function graph does not contains scalar op "GpuErfcinv".'
-        vector_val = self.default_arrays[dtype]
-        f(vector_val)
-        out = f(vector_val)
-        assert_allclose(self.expected_erfcinv_outputs[dtype], out)
-
     def test_elemwise_erfinv(self):
         for dtype in self.dtypes:
-            self.compute_erfinv_host(dtype)
-            self.compute_erfinv_gpu(dtype)
+            vector = theano.tensor.vector(dtype=dtype)
+            output = theano.tensor.erfinv(vector)
+            f_host = theano.function([vector], output, name='HOST/erfinv/' + dtype, mode=mode_without_gpu)
+            f_gpu = theano.function([vector], output, name='GPU/erfinv/' + dtype, mode=mode_with_gpu)
+            assert len([n for n in f_host.maker.fgraph.apply_nodes if isinstance(n.op, GpuElemwise)]) == 0
+            if not theano.config.device.startswith('opencl'):
+                assert self.check_gpu_scalar_op(f_gpu, GpuErfinv), \
+                    'Function graph does not contains scalar op "GpuErfinv".'
+            vector_val = self.default_arrays[dtype]
+            f_host(vector_val)
+            f_gpu(vector_val)
+            out_host = f_host(vector_val)
+            out_gpu = f_gpu(vector_val)
+            assert_allclose(out_host, out_gpu)
+            assert_allclose(self.expected_erfinv_outputs[dtype], out_gpu)
 
     def test_elemwise_erfcinv(self):
         for dtype in self.dtypes:
-            self.compute_erfcinv_host(dtype)
-            self.compute_erfcinv_gpu(dtype)
+            vector = theano.tensor.vector(dtype=dtype)
+            output = theano.tensor.erfcinv(vector)
+            f_host = theano.function([vector], output, name='HOST/erfcinv/' + dtype, mode=mode_without_gpu)
+            f_gpu = theano.function([vector], output, name='GPU/erfcinv/' + dtype, mode=mode_with_gpu)
+            assert len([n for n in f_host.maker.fgraph.apply_nodes if isinstance(n.op, GpuElemwise)]) == 0
+            if not theano.config.device.startswith('opencl'):
+                assert self.check_gpu_scalar_op(f_gpu, GpuErfcinv), \
+                    'Function graph does not contains scalar op "GpuErfcinv".'
+            vector_val = self.default_arrays[dtype]
+            f_host(vector_val)
+            f_gpu(vector_val)
+            out_host = f_host(vector_val)
+            out_gpu = f_gpu(vector_val)
+            assert_allclose(out_host, out_gpu)
+            assert_allclose(self.expected_erfcinv_outputs[dtype], out_gpu)
 
 
 class test_float16():

--- a/theano/gpuarray/tests/test_elemwise.py
+++ b/theano/gpuarray/tests/test_elemwise.py
@@ -63,7 +63,7 @@ class TestMathErrorFunctions(TestCase):
     def setUp(self):
         # NB: erfinv is defined in ]-1;1[, and erfcinv is defined in ]0;2[,
         # so we just take some values in an interval that covers both domains
-        #  (this will also allow to test some values outside the domains).
+        # (this will also allow to test some values outside the domains).
         # We take [-5;5[ by default and we concatenate it 1000 times
         # to have the GPU ops run on large data.
         default_array = [x / 10.0 for x in range(-50, 50)] * 1000
@@ -131,6 +131,7 @@ class TestMathErrorFunctions(TestCase):
         for dtype in self.dtypes:
             self.compute_erfcinv_host(dtype)
             self.compute_erfcinv_gpu(dtype)
+
 
 class test_float16():
     def test_composite_elemwise_float16(self):


### PR DESCRIPTION
Create GpuErfinv and GpuErfcinv in `theano.gpuarray.elemwise`. These ops currently only works with CUDA (OpenCL does not currently provide `erfinv` and `erfcinv` functions).

Make sure these GPU ops return the same values as CPU (`scipy.special`) equivalent ops. Currently:
* erfinv is defined in `]-1;1[`. CUDA returns `-inf` and `+inf` if input is -1 and 1, and NaN for any other input outside the domain of definition. Scipy returns `-inf` if `input <= -1` and `+inf` if `input >= 1`.
* erfcinv is defined in `]0;2[`. CUDA returns `+inf` and `-inf` if input is 0 and 2, and NaN for any other input outside the domain of definition. Scipy returns `+inf` if `input <= 0` and `-inf` if `input >= 2`.

So, the code adds checkings to ensure that both GPU and CPU ops return the same values, that is currently the Scipy values.

Update optimization to take account of these ops. Optimization is applied only with CUDA device. If OpenCL is used, a warning message is printed and optimization is skipped (Elemwise will not be replaced with GpuElemwise neither erf(c)inv with GpuErf(c)inv).

Add tests. GPU ops are effectively clearly faster than CPU ops, but currently (with 100 000 values as input), still slower than GpuFromHost and HostFromGpu.

#### Profiling:
##### Command:
```
CUDA_LAUNCH_BLOCKING=1 THEANO_FLAGS=profile=True,profiling.ignore_first_call=True,profiling.n_apply=1000,profiling.n_ops=1000 nosetests -vs theano/gpuarray/tests/test_elemwise.py:TestMathErrorFunctions > erfinv.log.txt 2>&1
```
##### File:
[erfinv.log.txt](https://github.com/Theano/Theano/files/625711/erfinv.log.txt)
##### Excerpt:
```
Function profiling
==================
  Message: Sum of all(12) printed profiles at exit excluding Scan op profile.

# ...

Class
---
<% time> <sum %> <apply time> <time per call> <type> <#call> <#apply> <Class name>
  99.8%    99.8%       5.297s       8.83e-01s     Py       6       6   theano.tensor.elemwise.Elemwise
   0.1%    99.9%       0.006s       1.04e-03s     C        6       6   theano.gpuarray.elemwise.GpuElemwise
   0.1%   100.0%       0.003s       4.56e-04s     C        6       6   theano.gpuarray.basic_ops.HostFromGpu
   0.0%   100.0%       0.001s       1.73e-04s     C        6       6   theano.gpuarray.basic_ops.GpuFromHost
   ... (remaining 0 Classes account for   0.00%(0.00s) of the runtime)

Ops
---
<% time> <sum %> <apply time> <time per call> <type> <#call> <#apply> <Op name>
  50.5%    50.5%       2.679s       8.93e-01s     Py       3        3   Elemwise{erfcinv,no_inplace}
  49.3%    99.8%       2.618s       8.73e-01s     Py       3        3   Elemwise{erfinv,no_inplace}
   0.1%    99.9%       0.004s       1.41e-03s     C        3        3   GpuElemwise{GpuErfcinv}[(0, 0)]<gpuarray>
   0.1%    99.9%       0.003s       4.56e-04s     C        6        6   HostFromGpu(gpuarray)
   0.0%   100.0%       0.002s       6.65e-04s     C        3        3   GpuElemwise{GpuErfinv}[(0, 0)]<gpuarray>
   0.0%   100.0%       0.001s       1.73e-04s     C        6        6   GpuFromHost<None>
   ... (remaining 0 Ops account for   0.00%(0.00s) of the runtime)
```
##### Command with OpenCL:
```
CUDA_LAUNCH_BLOCKING=1 THEANO_FLAGS=device=opencl0:0,profile=True,profiling.ignore_first_call=True,profiling.n_apply=1000,profiling.n_ops=1000 nosetests -vs theano/gpuarray/tests/test_elemwise.py:TestMathErrorFunctions > erfinv-opencl.log.txt 2>&1
```
##### File:
[erfinv-opencl.log.txt](https://github.com/Theano/Theano/files/625713/erfinv-opencl.log.txt)
##### Excerpts:
```
Mapped name None to device opencl0:0: GeForce 840M
PCI Bus ID: (unsupported for device opencl0:0)
test_elemwise_erfcinv (theano.gpuarray.tests.test_elemwise.TestMathErrorFunctions) ... WARNING (theano.gpuarray.opt): Function "erfcinv" is not supported with OpenCL. Use "device=cuda" instead.
WARNING (theano.gpuarray.opt): Function "erfcinv" is not supported with OpenCL. Use "device=cuda" instead.
WARNING (theano.gpuarray.opt): Function "erfcinv" is not supported with OpenCL. Use "device=cuda" instead.
ok
test_elemwise_erfinv (theano.gpuarray.tests.test_elemwise.TestMathErrorFunctions) ... WARNING (theano.gpuarray.opt): Function "erfinv" is not supported with OpenCL. Use "device=cuda" instead.
WARNING (theano.gpuarray.opt): Function "erfinv" is not supported with OpenCL. Use "device=cuda" instead.
WARNING (theano.gpuarray.opt): Function "erfinv" is not supported with OpenCL. Use "device=cuda" instead.
ok

----------------------------------------------------------------------
Ran 2 tests in 22.168s

OK
```
```
Function profiling
==================
  Message: Sum of all(12) printed profiles at exit excluding Scan op profile.

# ...

Class
---
<% time> <sum %> <apply time> <time per call> <type> <#call> <#apply> <Class name>
  100.0%   100.0%      10.278s       8.56e-01s     Py      12      12   theano.tensor.elemwise.Elemwise
   ... (remaining 0 Classes account for   0.00%(0.00s) of the runtime)

Ops
---
<% time> <sum %> <apply time> <time per call> <type> <#call> <#apply> <Op name>
  50.0%    50.0%       5.141s       8.57e-01s     Py       6        6   Elemwise{erfcinv,no_inplace}
  50.0%   100.0%       5.137s       8.56e-01s     Py       6        6   Elemwise{erfinv,no_inplace}
   ... (remaining 0 Ops account for   0.00%(0.00s) of the runtime)
```


@nouiz @abergeron @lamblin 