### PR TITLE
Adding Copy to SparseVariable

### DIFF
--- a/theano/sparse/basic.py
+++ b/theano/sparse/basic.py
@@ -309,6 +309,16 @@ class _sparse_py_operators:
             ret = get_item_2d(self, args)
         return ret
 
+    # COPYING
+    def copy(self, name=None):
+        """Return a symbolic copy and optionally assign a name.
+
+        Does not copy the tags.
+        """
+        copied_variable = CSM(self.format)(*csm_properties(self))
+        copied_variable.name = name
+        return copied_variable
+
 
 class SparseVariable(_sparse_py_operators, gof.Variable):
     dtype = property(lambda self: self.type.dtype)

--- a/theano/sparse/tests/test_basic.py
+++ b/theano/sparse/tests/test_basic.py
@@ -3189,12 +3189,13 @@ class TestSparseOp(utt.InferShapeTester):
 
     def test_sparse_copy(self):
         for sp_format in ['csr', 'csc']:
-            x = theano.sparse.SparseType(format=sp_format,
-                    dtype=theano.config.floatX)(name='input')
+            x = theano.sparse.SparseType(
+                format=sp_format,
+                dtype=theano.config.floatX)(name='input')
             y = x.copy(name='output')
-            warn_msg = r"%s"%' '.join(["Optimization Warning:",
-                "input idx 0 marked as viewed but new memory allocated by node"
-                ])
+            warn_msg = r"%s" % ' '.join([
+                "Optimization Warning:",
+                "input idx 0 marked as viewed but new memory allocated by node"])
             f = theano.function([x], y)
             x_inp = scipy.sparse.eye(5).tocsr()
             if theano.config.mode == 'DebugMode':

--- a/theano/sparse/tests/test_basic.py
+++ b/theano/sparse/tests/test_basic.py
@@ -3196,7 +3196,7 @@ class TestSparseOp(utt.InferShapeTester):
                 "input idx 0 marked as viewed but new memory allocated by node"
                 ])
             f = theano.function([x], y)
-            x_inp = sp.sparse.eye(5).tocsr()
+            x_inp = scipy.sparse.eye(5).tocsr()
             if theano.config.mode == 'DebugMode':
                 with self.assertLogs("theano.compile", level='WARNING') as logs:
                     y_inp = f(x_inp)


### PR DESCRIPTION
There's a minor problem in debug mode when checking input's viewmap ( _check_inputs when executing compiled function) where it will examine each output generated from CSMProperties and checking if the memory is shared and if not shared then issue the Optimization warning:   
   
The problem is because the type of outputs in CSMProperties Op is TensorType and its  may_share_memory (see  theano/tensor/theano/tensor/type.py@7215c905f96a9d20) will return False if both are not numpy.ndarray. However, this block of code (see theano/compile/debugmode.py:853@23e43b1b9e36e6beb) actually pass one ndarray (because they are properties of sparse array) and one sparse array. Checking may_share_memory in this way might have problem in other scenarios.   
    
Could it be possible to call SpareType.may_share_memory for preventing other potential problems in advance?   
    
Anyway, since the optimization warning does not occur in other modes, I still check in the solution as advised above with a test case added. Thanks for any suggestions in advance. 