### PR TITLE
Update checking of integer types. 

### DIFF
--- a/theano/compile/ops.py
+++ b/theano/compile/ops.py
@@ -339,7 +339,7 @@ class Shape_i(gof.Op):
         # As i will be used in the hash and that ndarray are not hashable,
         # we need to convert it to an int as it is hashable.
         if isinstance(i, numpy.ndarray):
-            assert "int" in str(i.dtype)
+            assert i.dtype in theano.tensor.integer_dtypes
         assert i == int(i)
         i = int(i)
         self.i = i
@@ -826,7 +826,7 @@ class SpecifyShape(gof.Op):
             x = theano.tensor.as_tensor_variable(x)
         shape = theano.tensor.as_tensor_variable(shape)
         assert shape.ndim == 1
-        assert "int" in shape.dtype
+        assert shape.dtype in theano.tensor.integer_dtypes
         if isinstance(shape, theano.tensor.TensorConstant):
             assert shape.data.size == x.ndim
         return gof.Apply(self, [x, shape], [x.type()])

--- a/theano/gpuarray/fft.py
+++ b/theano/gpuarray/fft.py
@@ -70,7 +70,7 @@ class CuRFFTOp(Op):
 
         assert inp.dtype == "float32"
         assert s.ndim == 1
-        assert 'int' in s.dtype
+        assert s.dtype in theano.tensor.integer_dtypes
 
         return theano.Apply(self, [inp, s], [self.output_type(inp)()])
 

--- a/theano/gpuarray/neighbours.py
+++ b/theano/gpuarray/neighbours.py
@@ -38,8 +38,8 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
         assert ten4.ndim == 4
         assert neib_shape.ndim == 1
         assert neib_step.ndim == 1
-        assert "int" in neib_shape.dtype
-        assert "int" in neib_step.dtype
+        assert neib_shape.dtype in T.integer_dtypes
+        assert neib_step.dtype in T.integer_dtypes
 
         return Apply(self, [ten4, neib_shape, neib_step],
                      [GpuArrayType(broadcastable=(False, False),

--- a/theano/gpuarray/pool.py
+++ b/theano/gpuarray/pool.py
@@ -61,11 +61,11 @@ class GpuPool(CGpuKernelBase):
         pad = as_tensor_variable(pad)
         assert ws.ndim == stride.ndim and ws.ndim == pad.ndim
         assert ws.ndim == 1
-        if not ws.dtype.startswith('int'):
+        if ws.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Window shape parameters must be ints.')
-        if not stride.dtype.startswith('int'):
+        if stride.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Stride parameters must be ints.')
-        if not pad.dtype.startswith('int'):
+        if pad.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
 
         return Apply(self, [inp, ws, stride, pad], [inp.type()])
@@ -157,11 +157,11 @@ class GpuMaxPoolGrad(CGpuKernelBase):
         pad = as_tensor_variable(pad)
         assert ws.ndim == stride.ndim and ws.ndim == pad.ndim
         assert ws.ndim == 1
-        if not ws.dtype.startswith('int'):
+        if ws.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Window shape parameters must be ints.')
-        if not stride.dtype.startswith('int'):
+        if stride.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Stride parameters must be ints.')
-        if not pad.dtype.startswith('int'):
+        if pad.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
         return Apply(self, [inp, out, out_grad, ws, stride, pad], [inp.type()])
 
@@ -231,11 +231,11 @@ class GpuAveragePoolGrad(CGpuKernelBase):
         pad = as_tensor_variable(pad)
         assert ws.ndim == stride.ndim and ws.ndim == pad.ndim
         assert ws.ndim == 1
-        if not ws.dtype.startswith('int'):
+        if ws.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Window shape parameters must be ints.')
-        if not stride.dtype.startswith('int'):
+        if stride.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Stride parameters must be ints.')
-        if not pad.dtype.startswith('int'):
+        if pad.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
         return Apply(self, [inp, out_grad, ws, stride, pad], [inp.type()])
 
@@ -308,11 +308,11 @@ class GpuDownsampleFactorMaxGradGrad(CGpuKernelBase):
         pad = as_tensor_variable(pad)
         assert ws.ndim == stride.ndim and ws.ndim == pad.ndim
         assert ws.ndim == 1
-        if not ws.dtype.startswith('int'):
+        if ws.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Window shape parameters must be ints.')
-        if not stride.dtype.startswith('int'):
+        if stride.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Stride parameters must be ints.')
-        if not pad.dtype.startswith('int'):
+        if pad.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
         return Apply(self, [inp, out, out_grad, ws, stride, pad], [inp.type()])
 

--- a/theano/gpuarray/subtensor.py
+++ b/theano/gpuarray/subtensor.py
@@ -408,7 +408,7 @@ class GpuAdvancedSubtensor1(HideC, tensor.AdvancedSubtensor1):
         x_ = as_gpuarray_variable(x, ctx_name)
 
         ilist__ = tensor.as_tensor_variable(ilist)
-        if ilist__.type.dtype[:3] not in ('int', 'uin'):
+        if ilist__.type.dtype not in tensor.integer_dtypes:
             raise TypeError('index must be integers')
         if ilist__.type.dtype != 'int64':
             ilist__ = tensor.cast(ilist__, 'int64')
@@ -603,7 +603,7 @@ class GpuAdvancedIncSubtensor1(Op):
 
         assert x_.type.ndim >= y_.type.ndim
 
-        if ilist_.type.dtype[:3] not in ('int', 'uin'):
+        if ilist_.type.dtype not in tensor.integer_dtypes:
             raise TypeError('index must be integers')
         if ilist_.type.ndim != 1:
             raise TypeError('index must be vector')
@@ -806,7 +806,7 @@ class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, HideC,
         assert x_.type.dtype == y_.type.dtype
         assert x_.type.ndim >= y_.type.ndim
 
-        if ilist_.type.dtype[:3] not in ('int', 'uin'):
+        if ilist_.type.dtype not in tensor.integer_dtypes:
             raise TypeError('index must be integers')
         if ilist_.type.ndim != 1:
             raise TypeError('index must be vector')

--- a/theano/gpuarray/type.py
+++ b/theano/gpuarray/type.py
@@ -335,7 +335,7 @@ class GpuArrayType(Type):
                          rtol=None, atol=None):
         if a.shape != b.shape or a.dtype != b.dtype:
             return False
-        if 'int' in str(a.dtype):
+        if str(a.dtype) in theano.tensor.discrete_dtypes:
             return GpuArrayType.values_eq(a, b)
         else:
             if allow_remove_inf or allow_remove_nan:

--- a/theano/sandbox/cuda/basic_ops.py
+++ b/theano/sandbox/cuda/basic_ops.py
@@ -2665,7 +2665,7 @@ class GpuAdvancedSubtensor1(tensor.AdvancedSubtensor1, GpuOp):
     def make_node(self, x, ilist):
         x_ = as_cuda_ndarray_variable(x)
         ilist_ = tensor.as_tensor_variable(ilist)
-        if ilist_.type.dtype[:3] not in ('int', 'uin'):
+        if ilist_.type.dtype not in theano.tensor.integer_dtypes:
             raise TypeError('index must be integers')
         if ilist_.type.ndim != 1:
             raise TypeError('index must be vector')
@@ -2782,7 +2782,7 @@ class GpuAdvancedIncSubtensor1(tensor.AdvancedIncSubtensor1, GpuOp):
         assert x_.type.dtype == y_.type.dtype
         assert x_.type.ndim >= y_.type.ndim
 
-        if ilist_.type.dtype[:3] not in ('int', 'uin'):
+        if ilist_.type.dtype not in theano.tensor.integer_dtypes:
             raise TypeError('index must be integers')
         if ilist_.type.ndim != 1:
             raise TypeError('index must be vector')
@@ -2976,7 +2976,7 @@ class GpuAdvancedIncSubtensor1_dev20(GpuAdvancedIncSubtensor1):
         assert x_.type.dtype == y_.type.dtype
         assert x_.type.ndim >= y_.type.ndim
 
-        if ilist_.type.dtype[:3] not in ('int', 'uin'):
+        if ilist_.type.dtype not in theano.tensor.integer_dtypes:
             raise TypeError('index must be integers')
         if ilist_.type.ndim != 1:
             raise TypeError('index must be vector')

--- a/theano/sandbox/cuda/neighbours.py
+++ b/theano/sandbox/cuda/neighbours.py
@@ -31,8 +31,8 @@ class GpuImages2Neibs(Images2Neibs, GpuOp):
         assert ten4.dtype == 'float32'
         assert neib_shape.ndim == 1
         assert neib_step.ndim == 1
-        assert "int" in neib_shape.dtype
-        assert "int" in neib_step.dtype
+        assert neib_shape.dtype in tensor.integer_dtypes
+        assert neib_step.dtype in tensor.integer_dtypes
 
         return Apply(self, [ten4, neib_shape, neib_step],
                      [CudaNdarrayType(broadcastable=(False, False),

--- a/theano/scan_module/scan.py
+++ b/theano/scan_module/scan.py
@@ -396,7 +396,7 @@ def scan(fn,
 
     # Check n_steps is an int
     if (hasattr(n_steps, 'dtype') and
-        str(n_steps.dtype)[:3] not in ('uin', 'int')):
+        str(n_steps.dtype) not in tensor.integer_dtypes):
         raise ValueError(' n_steps must be an int. dtype provided '
                          'is %s' % n_steps.dtype)
 

--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -601,7 +601,7 @@ class Scan(PureOp):
             # For every nit_sot input we get as input a int/uint that
             # depicts the size in memory for that sequence. This feature is
             # used by truncated BPTT and by scan space optimization
-            if (str(outer_nitsot.type.dtype)[:3] not in ('uin', 'int') or
+            if (str(outer_nitsot.type.dtype) not in tensor.integer_dtypes or
                     outer_nitsot.ndim != 0):
                 raise ValueError('For output %s you need to provide a '
                                  'scalar int !', str(outer_nitsot))
@@ -2012,7 +2012,7 @@ class Scan(PureOp):
             g_y_s = known_grads.values()
 
             for g_y in g_y_s:
-                if 'int' in str(g_y.dtype):
+                if str(g_y.dtype) in tensor.integer_dtypes:
                     raise TypeError("Gradients may never be integers but g_y "
                                     "has type " + str(g_y.type))
 

--- a/theano/sparse/basic.py
+++ b/theano/sparse/basic.py
@@ -1093,7 +1093,6 @@ class GetItem2Lists(gof.op.Op):
         assert ind1.dtype in integer_dtypes
         assert ind2.dtype in integer_dtypes
 
-
         return gof.Apply(self, [x, ind1, ind2],
                          [theano.tensor.vector()])
 

--- a/theano/sparse/basic.py
+++ b/theano/sparse/basic.py
@@ -399,6 +399,7 @@ complex_dtypes = [t for t in all_dtypes if t[:7] == 'complex']
 float_dtypes = [t for t in all_dtypes if t[:5] == 'float']
 int_dtypes = [t for t in all_dtypes if t[:3] == 'int']
 uint_dtypes = [t for t in all_dtypes if t[:4] == 'uint']
+integer_dtypes = int_dtypes + uint_dtypes
 
 continuous_dtypes = complex_dtypes + float_dtypes
 discrete_dtypes = int_dtypes + uint_dtypes
@@ -1001,7 +1002,7 @@ class GetItemList(gof.op.Op):
 
         ind = tensor.as_tensor_variable(index)
         assert ind.ndim == 1
-        assert "int" in ind.dtype
+        assert ind.dtype in integer_dtypes
 
         return gof.Apply(self, [x, ind], [x.type()])
 
@@ -1053,7 +1054,7 @@ class GetItemListGrad(gof.op.Op):
 
         ind = tensor.as_tensor_variable(index)
         assert ind.ndim == 1
-        assert "int" in ind.dtype
+        assert ind.dtype in integer_dtypes
 
         scipy_ver = [int(n) for n in scipy.__version__.split('.')[:2]]
 
@@ -1089,8 +1090,9 @@ class GetItem2Lists(gof.op.Op):
         assert x.format in ["csr", "csc"]
         ind1 = tensor.as_tensor_variable(ind1)
         ind2 = tensor.as_tensor_variable(ind2)
-        assert "int" in ind1.dtype
-        assert "int" in ind2.dtype
+        assert ind1.dtype in integer_dtypes
+        assert ind2.dtype in integer_dtypes
+
 
         return gof.Apply(self, [x, ind1, ind2],
                          [theano.tensor.vector()])
@@ -1150,8 +1152,8 @@ class GetItem2ListsGrad(gof.op.Op):
         ind2 = tensor.as_tensor_variable(ind2)
         assert ind1.ndim == 1
         assert ind2.ndim == 1
-        assert "int" in ind1.dtype
-        assert "int" in ind2.dtype
+        assert ind1.dtype in integer_dtypes
+        assert ind2.dtype in integer_dtypes
 
         return gof.Apply(self, [x, ind1, ind2, gz], [x.type()])
 
@@ -4218,7 +4220,7 @@ class ConstructSparseFromList(gof.Op):
         values_ = theano.tensor.as_tensor_variable(values)
         ilist_ = theano.tensor.as_tensor_variable(ilist)
 
-        if ilist_.type.dtype[:3] not in ('int', 'uin'):
+        if ilist_.type.dtype not in integer_dtypes:
             raise TypeError('index must be integers')
         if ilist_.type.ndim != 1:
             raise TypeError('index must be vector')

--- a/theano/sparse/tests/test_basic.py
+++ b/theano/sparse/tests/test_basic.py
@@ -86,7 +86,7 @@ def random_lil(shape, dtype, nnz):
         idx = np.random.randint(1, huge+1, size=2) % shape
         value = np.random.rand()
         # if dtype *int*, value will always be zeros!
-        if "int" in dtype:
+        if dtype in theano.sparse.integer_dtypes:
             value = int(value * 100)
         # The call to tuple is needed as scipy 0.13.1 do not support
         # ndarray with lenght 2 as idx tuple.

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4567,7 +4567,7 @@ class Reshape(Op):
         x = as_tensor_variable(x)
         shp_orig = shp
         shp = as_tensor_variable(shp, ndim=1)
-        if not (shp.dtype in int_types or
+        if not (shp.dtype in int_dtypes or
                 (isinstance(shp, TensorConstant) and shp.data.size == 0)):
             # It raises an error if shp is not of integer type,
             # except when shp is constant and empty

--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -1076,7 +1076,7 @@ def _as_scalar(res, dtype=None):
             rval = res.dimshuffle()
         else:
             rval = res
-        if rval.type.dtype[:3] in ('int', 'uin'):
+        if rval.type.dtype in theano.tensor.integer_dtypes:
             # We check that the upcast of res and dtype won't change dtype.
             # If dtype is float64, we will cast int64 to float64.
             # This is valid when res is a scalar used as input to a dot22

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -386,7 +386,7 @@ PyArray_SetBaseObject(%(res)s, (PyObject*)%(basename)s);
         # Do not make the DimShuffle inplace as an optimization at the
         # canonicalization optimization phase will remove the inplace.
         # The inplace will be reintroduced automatically later in the graph.
-        if 'int' in inp[0].dtype:
+        if inp[0].dtype in theano.tensor.integer_dtypes:
             return [inp[0].zeros_like(dtype=theano.config.floatX)]
         else:
             return [DimShuffle(gz.type.broadcastable, grad_order)(
@@ -665,7 +665,7 @@ second dimension
                     elem = ipt.zeros_like()
                     if str(elem.type.dtype) not in theano.tensor.continuous_dtypes:
                         elem = elem.astype(theano.config.floatX)
-                    assert str(elem.type.dtype).find('int') == -1
+                    assert str(elem.type.dtype) not in theano.tensor.discrete_dtypes
                     new_rval.append(elem)
             return new_rval
 

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -386,7 +386,7 @@ PyArray_SetBaseObject(%(res)s, (PyObject*)%(basename)s);
         # Do not make the DimShuffle inplace as an optimization at the
         # canonicalization optimization phase will remove the inplace.
         # The inplace will be reintroduced automatically later in the graph.
-        if inp[0].dtype in theano.tensor.integer_dtypes:
+        if inp[0].dtype in theano.tensor.discrete_dtypes:
             return [inp[0].zeros_like(dtype=theano.config.floatX)]
         else:
             return [DimShuffle(gz.type.broadcastable, grad_order)(

--- a/theano/tensor/extra_ops.py
+++ b/theano/tensor/extra_ops.py
@@ -859,8 +859,7 @@ class Bartlett(gof.Op):
         if M.ndim != 0:
             raise TypeError('%s only works on scalar input'
                             % self.__class__.__name__)
-        elif (not M.dtype.startswith('int') and
-              not M.dtype.startswith('uint')):
+        elif M.dtype not in theano.tensor.integer_dtypes:
             # dtype is a theano attribute here
             raise TypeError('%s only works on integer input'
                             % self.__class__.__name__)
@@ -1029,7 +1028,7 @@ class FillDiagonalOffset(gof.Op):
         if val.dtype != a.dtype:
             raise TypeError('%s: type of second parameter must be the same'
                             ' as the first\'s' % self.__class__.__name__)
-        elif offset.dtype[:3] != 'int':
+        elif offset.dtype not in theano.tensor.integer_dtypes:
             raise TypeError('%s: type of third parameter must be as integer'
                             ' use theano.tensor.cast( input, \'int32/int64\')'
                             % self.__class__.__name__)

--- a/theano/tensor/fft.py
+++ b/theano/tensor/fft.py
@@ -25,8 +25,7 @@ class RFFTOp(gof.Op):
             s = T.as_tensor_variable(s)
         else:
             s = T.as_tensor_variable(s)
-            if (not s.dtype.startswith('int')) and \
-               (not s.dtype.startswith('uint')):
+            if s.dtype not in T.integer_dtypes:
                 raise TypeError('%s: length of the transformed axis must be'
                                 ' of type integer' % self.__class__.__name__)
         return gof.Apply(self, [a, s], [self.output_type(a)()])
@@ -82,8 +81,7 @@ class IRFFTOp(gof.Op):
             s = T.as_tensor_variable(s)
         else:
             s = T.as_tensor_variable(s)
-            if (not s.dtype.startswith('int')) and \
-               (not s.dtype.startswith('uint')):
+            if s.dtype not in T.integer_dtypes:
                 raise TypeError('%s: length of the transformed axis must be'
                                 ' of type integer' % self.__class__.__name__)
         return gof.Apply(self, [a, s], [self.output_type(a)()])

--- a/theano/tensor/fourier.py
+++ b/theano/tensor/fourier.py
@@ -51,8 +51,7 @@ class Fourier(gof.Op):
             axis = tensor.as_tensor_variable(axis)
         else:
             axis = tensor.as_tensor_variable(axis)
-            if (not axis.dtype.startswith('int')) and \
-               (not axis.dtype.startswith('uint')):
+            if axis.dtype not in tensor.integer_dtypes:
                 raise TypeError('%s: index of the transformed axis must be'
                                 ' of type integer' % self.__class__.__name__)
             elif axis.ndim != 0 or (isinstance(axis, tensor.TensorConstant) and
@@ -65,8 +64,7 @@ class Fourier(gof.Op):
             n = tensor.as_tensor_variable(n)
         else:
             n = tensor.as_tensor_variable(n)
-            if (not n.dtype.startswith('int')) and \
-               (not n.dtype.startswith('uint')):
+            if n.dtype not in tensor.integer_dtypes:
                 raise TypeError('%s: length of the transformed axis must be'
                                 ' of type integer' % self.__class__.__name__)
             elif n.ndim != 0 or (isinstance(n, tensor.TensorConstant) and

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -812,7 +812,7 @@ class MakeVector(T.Op):
 
     def grad(self, inputs, output_gradients):
         # If the output is of an integer dtype, no gradient shall pass
-        if 'int' in self.dtype:
+        if self.dtype in theano.tensor.discrete_dtypes:
             return [ipt.zeros_like().astype(theano.config.floatX)
                     for ipt in inputs]
 
@@ -1094,7 +1094,7 @@ class ShapeFeature(object):
                 # x should already have been imported, and should be in shape_of.
                 s_i = self.shape_of[x][i]
 
-        if s_i.type.dtype[:3] in ('int', 'uint'):
+        if s_i.type.dtype in theano.tensor.integer_dtypes:
             if getattr(s_i.type, 'ndim', 0):
                 raise TypeError('Shape element must be scalar', s_i)
             return s_i

--- a/theano/tensor/raw_random.py
+++ b/theano/tensor/raw_random.py
@@ -403,8 +403,7 @@ def _infer_ndim_bcast(ndim, shape, *args):
         raise TypeError("shape must be a vector or list of scalar, got '%s'" %
                         v_shape)
 
-    if (not (v_shape.dtype.startswith('int') or
-             v_shape.dtype.startswith('uint'))):
+    if v_shape.dtype not in theano.tensor.integer_dtypes:
         raise TypeError('shape must be an integer vector or list',
                         v_shape.dtype)
 

--- a/theano/tensor/signal/pool.py
+++ b/theano/tensor/signal/pool.py
@@ -1748,7 +1748,7 @@ class DownsampleFactorMaxGradGrad(OpenMPOp):
         assert x.ndim == maxout.ndim == gz.ndim >= nd
         if ws.dtype not in tensor.int_dtypes:
             raise TypeError('Pool downsample parameters must be ints.')
-        if stride.dtypes not in tensor.int_dtypes:
+        if stride.dtype not in tensor.int_dtypes:
             raise TypeError('Stride parameters must be ints.')
         if pad.dtype not in tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')

--- a/theano/tensor/signal/pool.py
+++ b/theano/tensor/signal/pool.py
@@ -493,11 +493,11 @@ class Pool(OpenMPOp):
         assert pad.ndim == 1
         if x.type.ndim < nd:
             raise TypeError()
-        if not ws.dtype.startswith('int'):
+        if ws.dtype not in tensor.int_dtypes:
             raise TypeError('Pool downsample parameters must be ints.')
-        if not stride.dtype.startswith('int'):
+        if stride.dtype not in tensor.int_dtypes:
             raise TypeError('Stride parameters must be ints.')
-        if not pad.dtype.startswith('int'):
+        if pad.dtype not in tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
         # If the input shape are broadcastable we can have 0 in the output shape
         broad = x.broadcastable[:-nd] + (False,) * nd
@@ -1087,11 +1087,11 @@ class MaxPoolGrad(PoolGrad):
         assert isinstance(stride, Variable) and stride.ndim == 1
         assert isinstance(pad, Variable) and pad.ndim == 1
         assert x.ndim == maxout.ndim == gz.ndim >= nd
-        if not ws.dtype.startswith('int'):
+        if ws.dtype not in tensor.int_dtypes:
             raise TypeError('Pool downsample parameters must be ints.')
-        if not stride.dtype.startswith('int'):
+        if stride.dtype not in tensor.int_dtypes:
             raise TypeError('Stride parameters must be ints.')
-        if not pad.dtype.startswith('int'):
+        if pad.dtype not in tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
         return Apply(self, [x, maxout, gz, ws, stride, pad], [x.type()])
 
@@ -1405,11 +1405,11 @@ class AveragePoolGrad(PoolGrad):
         assert isinstance(stride, Variable) and stride.ndim == 1
         assert x.ndim == gz.ndim >= nd
         assert isinstance(pad, Variable) and pad.ndim == 1
-        if not ws.dtype.startswith('int'):
+        if ws.dtype not in tensor.int_dtypes:
             raise TypeError('Pool downsample parameters must be ints.')
-        if not stride.dtype.startswith('int'):
+        if stride.dtype not in tensor.int_dtypes:
             raise TypeError('Stride parameters must be ints.')
-        if not pad.dtype.startswith('int'):
+        if pad.dtype not in tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
         return Apply(self, [x, gz, ws, stride, pad], [x.type()])
 
@@ -1746,11 +1746,11 @@ class DownsampleFactorMaxGradGrad(OpenMPOp):
         assert stride.ndim == 1
         assert pad.ndim == 1
         assert x.ndim == maxout.ndim == gz.ndim >= nd
-        if not ws.dtype.startswith('int'):
+        if ws.dtype not in tensor.int_dtypes:
             raise TypeError('Pool downsample parameters must be ints.')
-        if not stride.dtype.startswith('int'):
+        if stride.dtypes not in tensor.int_dtypes:
             raise TypeError('Stride parameters must be ints.')
-        if not pad.dtype.startswith('int'):
+        if pad.dtype not in tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
         return Apply(self, [x, maxout, gz, ws, stride, pad], [x.type()])
 

--- a/theano/tensor/subtensor.py
+++ b/theano/tensor/subtensor.py
@@ -568,7 +568,7 @@ class Subtensor(Op):
         gz, = grads
         x = inputs[0]
         rest = inputs[1:]
-        if x.dtype.find('int') != -1:
+        if x.dtype in theano.tensor.discrete_dtypes:
             first = x.zeros_like().astype(theano.config.floatX)
         else:
             # For best optimization, we let this as an inc.
@@ -1683,7 +1683,7 @@ class AdvancedSubtensor1(Op):
     def make_node(self, x, ilist):
         x_ = theano.tensor.as_tensor_variable(x)
         ilist_ = theano.tensor.as_tensor_variable(ilist)
-        if ilist_.type.dtype[:3] not in ('int', 'uin'):
+        if ilist_.type.dtype not in theano.tensor.integer_dtypes:
             raise TypeError('index must be integers')
         if ilist_.type.ndim != 1:
             raise TypeError('index must be vector')
@@ -1892,7 +1892,7 @@ class AdvancedIncSubtensor1(Op):
         y_ = theano.tensor.as_tensor_variable(y)
         ilist_ = theano.tensor.as_tensor_variable(ilist)
 
-        if ilist_.type.dtype[:3] not in ('int', 'uin'):
+        if ilist_.type.dtype not in theano.tensor.integer_dtypes:
             raise TypeError('index must be integers')
         if ilist_.type.ndim != 1:
             raise TypeError('index must be vector')
@@ -2080,7 +2080,7 @@ def as_index_variable(idx):
     if isinstance(idx, gof.Variable) and isinstance(idx.type, NoneTypeT):
         return idx
     idx = theano.tensor.as_tensor_variable(idx)
-    if idx.type.dtype[:3] not in ('int', 'uin'):
+    if idx.type.dtype not in theano.tensor.integer_dtypes:
         raise TypeError('index must be integers')
     return idx
 

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -597,11 +597,11 @@ def randc128_ranged(min, max, shape):
 
 
 def rand_of_dtype(shape, dtype):
-    if 'int' in dtype:
+    if dtype in tensor.discrete_dtypes:
         return randint(*shape).astype(dtype)
-    elif 'float' in dtype:
+    elif dtype in tensor.float_dtypes:
         return rand(*shape).astype(dtype)
-    elif 'complex' in dtype:
+    elif dtype in tensor.complex_dtypes:
         return randcomplex(*shape).astype(dtype)
     else:
         raise TypeError()
@@ -6786,7 +6786,7 @@ class T_long_tensor(unittest.TestCase):
             val = L(2 ** exp - 1)
             scalar_ct = constant(val)
 
-            assert scalar_ct.dtype.startswith('int'), (exp, val, scalar_ct.dtype)
+            assert scalar_ct.dtype in tensor.int_dtypes, (exp, val, scalar_ct.dtype)
             assert scalar_ct.value == val
 
             vector_ct = constant([val, val])

--- a/theano/tensor/tests/test_elemwise.py
+++ b/theano/tensor/tests/test_elemwise.py
@@ -370,7 +370,7 @@ class test_CAReduce(unittest_tools.InferShapeTester):
             f = copy(linker).accept(FunctionGraph([x], [e])).make_function()
             xv = numpy.asarray(numpy.random.rand(*xsh))
 
-            if "int" not in dtype:
+            if dtype not in tensor.discrete_dtypes:
                 xv = numpy.asarray(xv, dtype=dtype)
             else:
                 xv = numpy.asarray(xv < 0.5, dtype=dtype)

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -5948,13 +5948,13 @@ class TestMakeVector(utt.InferShapeTester):
             g_val = g(val[b], val[i], val[d])
             # print 'g_val =', g_val
 
-            if dtype.startswith('int'):
+            if dtype in tensor.int_dtypes:
                 # The gradient should be 0
                 utt.assert_allclose(g_val, 0)
             else:
                 for var, grval in zip((b, i, d), g_val):
                     float_inputs = []
-                    if var.dtype.startswith('int'):
+                    if var.dtype in tensor.int_dtypes:
                         pass
                         # Currently we don't do any checks on these variables
                         # verify_grad doesn't support integer inputs yet

--- a/theano/tensor/type_other.py
+++ b/theano/tensor/type_other.py
@@ -16,7 +16,7 @@ def as_int_none_variable(x):
     elif NoneConst.equals(x):
         return x
     x = theano.tensor.as_tensor_variable(x, ndim=0)
-    if x.type.dtype[:3] not in ('int', 'uin'):
+    if x.type.dtype not in theano.tensor.integer_dtypes:
         raise TypeError('index must be integers')
     return x
 
@@ -80,15 +80,15 @@ class SliceConstant(Constant):
         # Numpy ndarray aren't hashable, so get rid of them.
         if isinstance(data.start, numpy.ndarray):
             assert data.start.ndim == 0
-            assert "int" in str(data.start.dtype)
+            assert str(data.start.dtype) in theano.tensor.integer_dtypes
             data = slice(int(data.start), data.stop, data.step)
         elif isinstance(data.stop, numpy.ndarray):
             assert data.stop.ndim == 0
-            assert "int" in str(data.stop.dtype)
+            assert str(data.stop.dtype) in theano.tensor.integer_dtypes
             data = slice(data.start, int(data.stop), data.step)
         elif isinstance(data.step, numpy.ndarray):
             assert data.step.ndim == 0
-            assert "int" in str(data.step.dtype)
+            assert str(data.step.dtype) in theano.tensor.integer_dtypes
             data = slice(data.start, int(data.stop), data.step)
         Constant.__init__(self, type, data, name)
 

--- a/theano/typed_list/tests/test_basic.py
+++ b/theano/typed_list/tests/test_basic.py
@@ -37,7 +37,7 @@ def random_lil(shape, dtype, nnz):
         idx = numpy.random.randint(1, huge + 1, size=2) % shape
         value = numpy.random.rand()
         # if dtype *int*, value will always be zeros!
-        if "int" in dtype:
+        if dtype in theano.tensor.integer_dtypes:
             value = int(value * 100)
         # The call to tuple is needed as scipy 0.13.1 do not support
         # ndarray with lenght 2 as idx tuple.


### PR DESCRIPTION
This fixes #5274.

For integer types, any string-based type-checking (like `'int' in dtype`) is now replaced with a list-based type-checking (like `dtype in list`) using the types lists provided in `theano.tensor` (int_dtypes, uint_dtypes, integer_dtypes and discrete_dtypes).

Remarks:
* Module `theano.sparse` have its own types lists, so they are used in that module instead of `theano.tensor` lists.
* The `discrete_dtypes` list (integer types + `bool` type) is the list to use to fix issue #5274 . When replacing string-based checkings I have tried to use that list where it seems relevant (for e.g. in some `grad()` functions) to prevent other future bugs, but I think it should be discussed.

@lamblin @nouiz !