### PR TITLE
Fix issue #4476 related to BatchedDot.

### DIFF
--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -2149,14 +2149,8 @@ class BatchedDot(Op):
         fail = sub["fail"]
 
         # generate contiguity condition
-        def contiguous(var, ndim):
-            strides = "PyArray_STRIDES(%s)" % var
-            return " && ".join([
-                " && ".join("{strides}[{i}] > 0 && {strides}[{i}] % type_size == 0"
-                            .format(strides=strides, i=i) for i in range(ndim)),
-                "(%s)" % " || ".join("{strides}[{i}] == type_size"
-                                     .format(strides=strides, i=i) for i in range(ndim)),
-            ])
+        def contiguous(var):
+            return "(PyArray_IS_C_CONTIGUOUS(%s) || PyArray_IS_F_CONTIGUOUS(%s))" % (var, var)
 
         x_ndim, y_ndim, z_ndim = node.inputs[0].ndim, node.inputs[1].ndim, node.outputs[0].ndim
 
@@ -2171,7 +2165,7 @@ class BatchedDot(Op):
         z_shape_correct = " && ".join("PyArray_DIMS(%s)[%i] == %s"
                                       % (_z, i, dim) for i, dim in enumerate(z_dims))
         z_shape = ", ".join(z_dims)
-        z_contiguous = contiguous(_z, z_ndim)
+        z_contiguous = contiguous(_z)
         allocate = """
             if (NULL == %(_z)s || !(%(z_shape_correct)s)  || !(%(z_contiguous)s))
             {
@@ -2189,8 +2183,8 @@ class BatchedDot(Op):
 
         # code to reallocate inputs contiguously if necessary
         contiguate = []
-        for var, ndim in [(_x, x_ndim), (_y, y_ndim)]:
-            _contiguous = contiguous(var, ndim)
+        for var in (_x, _y):
+            _contiguous = contiguous(var)
             contiguate.append("""
                 if (!(%(_contiguous)s)) {
                     PyArrayObject * _copy = (PyArrayObject *) PyArray_Copy(%(var)s);
@@ -2309,7 +2303,7 @@ class BatchedDot(Op):
 
     def c_code_cache_version(self):
         from theano.tensor.blas_headers import blas_header_version
-        return (1, blas_header_version())
+        return (2, blas_header_version())
 
     def grad(self, inp, grads):
         x, y = inp

--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -2155,7 +2155,7 @@ class BatchedDot(Op):
                 " && ".join("{strides}[{i}] > 0 && {strides}[{i}] % type_size == 0"
                             .format(strides=strides, i=i) for i in range(ndim)),
                 "(%s)" % (" || ".join("{strides}[{i}] == type_size"
-                                     .format(strides=strides, i=i) for i in range(1, ndim)) or '1'),
+                                      .format(strides=strides, i=i) for i in range(1, ndim)) or '1'),
             ])
 
         x_ndim, y_ndim, z_ndim = node.inputs[0].ndim, node.inputs[1].ndim, node.outputs[0].ndim

--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -2151,11 +2151,13 @@ class BatchedDot(Op):
         # generate contiguity condition
         def contiguous(var, ndim):
             strides = "PyArray_STRIDES(%s)" % var
+            if ndim == 1:
+                return "{strides}[0] == type_size".format(strides=strides)
             return " && ".join([
                 " && ".join("{strides}[{i}] > 0 && {strides}[{i}] % type_size == 0"
-                            .format(strides=strides, i=i) for i in range(ndim)),
-                "(%s)" % (" || ".join("{strides}[{i}] == type_size"
-                                      .format(strides=strides, i=i) for i in range(1, ndim)) or '1'),
+                            .format(strides=strides, i=i) for i in range(1, ndim)),
+                "(%s)" % " || ".join("{strides}[{i}] == type_size"
+                                     .format(strides=strides, i=i) for i in range(1, ndim)),
             ])
 
         x_ndim, y_ndim, z_ndim = node.inputs[0].ndim, node.inputs[1].ndim, node.outputs[0].ndim
@@ -2309,7 +2311,7 @@ class BatchedDot(Op):
 
     def c_code_cache_version(self):
         from theano.tensor.blas_headers import blas_header_version
-        return (2, blas_header_version())
+        return (3, blas_header_version())
 
     def grad(self, inp, grads):
         x, y = inp


### PR DESCRIPTION
fix gh-4476. It is fixed by modifying contiguousity checking in the c_code of BatchedDot. Now the code uses `(PyArray_IS_C_CONTIGUOUS || PyArray_IS_F_CONTIGUOUS)` to do the checking.

Previously the code checked if every stride of the inputs is relevant (strictly positive and multiple of type size) and if at least one of the strides has the size of the type. I think the bug comes from the latter condition, as an array can be not-contiguous even if one stride has the size of the type (for example, a Fortran array in which the first dimension is contiguous but not the last ones).

Remarks:
* I put the test in `test_basic` even if `BatchedDot` is in `blas.py` because the `batched_dot` tests are also in `test_basic`.
* It seems some other codes check the contiguity using the previous conditions, so there is maybe some similar bugs with other ops. For example, we may have to check the Dot22 op: https://github.com/Theano/Theano/blob/master/theano/tensor/blas.py#L603

@lamblin @nouiz !