### PR TITLE
gpuarray: Revert part of c6ffa46

### DIFF
--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -135,7 +135,7 @@ def _dnn_check_version():
     if v < 5000:
         return False, "cuDNN version is too old. Update to v5, was %d." % v
     # 5200 should not print warning with cudnn 5.1 final.
-    if version >= 5200:
+    if v >= 5200:
         warnings.warn("Your cuDNN version is more recent than "
                       "Theano. If you encounter problems, try "
                       "updating Theano or downgrading cuDNN to "

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -116,9 +116,6 @@ if ((err = cudnnCreate(&_handle)) != CUDNN_STATUS_SUCCESS) {
         params.extend(['-I%s%s%s' % (path_wrapper, config.dnn.include_path, path_wrapper)])
     if config.dnn.library_path:
         params.extend(['-L%s%s%s' % (path_wrapper, config.dnn.library_path, path_wrapper)])
-    if config.nvcc.compiler_bindir:
-        params.extend(['--compiler-bindir',
-                       '%s%s%s' % (path_wrapper, config.nvcc.compiler_bindir, path_wrapper)])
     # Do not run here the test program. It would run on the
     # default gpu, not the one selected by the user. If mixed
     # GPU are installed or if the GPUs are configured in


### PR DESCRIPTION
These two patches revert two changes introduced by c6ffa46:
1. The cuDNN version check should use the correct variable name (reported in #5369). This removes an incorrect warning.
2. The `--compiler-bindir` option for `nvcc` should not be passed to the `g++` compiler. This problem was already fixed once in #4978 but reintroduced by the recent merging of #5357.