### PR TITLE
compatible when axis < 0 in tensor.roll(x, shift, axis=None)

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4218,7 +4218,7 @@ def roll(x, shift, axis=None):
             return roll(y, shift, axis=0).reshape(x.shape)
         else:
             axis = 0
-            
+
     if axis < 0:
         if x.ndim == 0:
             axis = 0

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4218,6 +4218,12 @@ def roll(x, shift, axis=None):
             return roll(y, shift, axis=0).reshape(x.shape)
         else:
             axis = 0
+            
+    if axis < 0:
+        if x.ndim == 0:
+            axis = 0
+        else:
+            axis = axis % x.ndim + 1
 
     # Shift may be larger than the size of the axis. If so, since the
     # roll operation is cyclic, we can take the shift modulo the size

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4220,10 +4220,7 @@ def roll(x, shift, axis=None):
             axis = 0
 
     if axis < 0:
-        if x.ndim == 0:
-            axis = 0
-        else:
-            axis = axis % x.ndim
+        axis += x.ndim
 
     # Shift may be larger than the size of the axis. If so, since the
     # roll operation is cyclic, we can take the shift modulo the size

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -4223,7 +4223,7 @@ def roll(x, shift, axis=None):
         if x.ndim == 0:
             axis = 0
         else:
-            axis = axis % x.ndim + 1
+            axis = axis % x.ndim
 
     # Shift may be larger than the size of the axis. If so, since the
     # roll operation is cyclic, we can take the shift modulo the size

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -3782,6 +3782,15 @@ class T_Join_and_Split(unittest.TestCase):
             out = theano.function([], b)()
 
             assert (out == want).all()
+                
+            # Test example when axis < 0 - ensure that behavior matches numpy.roll behavior
+            a = self.shared(numpy.arange(24).reshape((3, 2, 4)).astype(self.floatX))
+            b = roll(a, get_shift(-2), -2)
+
+            want = numpy.roll(a.get_value(borrow=True), -2, -2)
+            out = theano.function([], b)()
+
+            assert (out == want).all()
 
             # Test rolling on axis 0
             want = numpy.roll(a.get_value(borrow=True), -2, 0)


### PR DESCRIPTION
When I use `T.roll(x, 1, axis=-2)` for a tensor `x` of rank `2`, it raised an error as follows:

> ValueError: The index list is longer (size 5) than the number of dimensions of the tensor(namely 3).   You are asking for a dimension of the tensor that does not exist!   You might need to use dimshuffle to add extra dimension to your tensor.