### PR TITLE
Bug: gradient of ifelse with gpu inputs

### DIFF
--- a/theano/ifelse.py
+++ b/theano/ifelse.py
@@ -173,7 +173,9 @@ class IfElse(Op):
             # to keep them be cuda ndarrays
             nw_args = []
             for x in args:
-                if isinstance(x, theano.Variable):
+                if hasattr(x, '_as_TensorVariable'):
+                    nw_args.append(x._as_TensorVariable())
+                elif isinstance(x, theano.Variable):
                     nw_args.append(x)
                 else:
                     nw_args.append(theano.tensor.as_tensor_variable(x))

--- a/theano/tests/test_ifelse.py
+++ b/theano/tests/test_ifelse.py
@@ -153,6 +153,17 @@ class test_ifelse(unittest.TestCase, utt.TestOptimizationMixin):
         assert numpy.all(numpy.asarray(gx0) == 0.)
         assert numpy.all(numpy.asarray(gy0) == 1.)
 
+    def test_grad_cast_input(self):
+        # Tests the gradient when both inputs are on the GPU.
+        x = tensor.vector('x', dtype=self.dtype)
+        y = tensor.vector('y', dtype=self.dtype)
+        c = tensor.iscalar('c')
+        z = ifelse(c, self.cast_output(x), self.cast_output(y))
+        gx, gy = tensor.grad(z.sum(), [x, y])
+
+        theano.function([c, x, y], [gx, gy],
+                        mode=self.mode)
+
     def test_multiple_out(self):
         x1 = tensor.vector('x1', dtype=self.dtype)
         x2 = tensor.vector('x2', dtype=self.dtype)


### PR DESCRIPTION
There is a problem with the `IfElse` gradient when the inputs are on the GPU. There's a small example below. If you compute the gradient of such an `IfElse`, the [`grad` method](https://github.com/Theano/Theano/blob/master/theano/ifelse.py#L220-L227) will construct two new `IfElse` nodes. For these new nodes, one branch will get the gradient (a GPU tensor), while the other branch gets a new variable created with `tensor.zeros_like`. Because that is not a GPU tensor, the `IfElse` will complain that the types of the return values are not the same:
```
TypeError: ('IfElse requires same types for true and false return values',
    GpuFromHost<None>.0, Elemwise{second,no_inplace}.0,
    GpuArrayType<None>(float32, (False,)), TensorType(float32, vector))
```

Partial example script:
```python
x = tensor.vector('x')
y = tensor.vector('y')
c = tensor.iscalar('c')

x_gpu = basic_ops.as_gpuarray_variable(x, test_ctx_name)
y_gpu = basic_ops.as_gpuarray_variable(y, test_ctx_name)

out = theano.ifelse.ifelse(c, x_gpu, y_gpu)
theano.grad(out.sum(), [x, y])
```

This PR adds a test for this. There's also a solution: making sure that inputs for `IfElse` are always converted to normal TensorVariables. I'm not sure if that is the correct solution, but it does help.