### PR TITLE
softmax opti for upstream

### DIFF
--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -384,6 +384,8 @@ class SoftmaxGrad(gof.Op):
             }
         }
 
+        int chunk = 32;
+        #pragma omp parallel for schedule(static, chunk)
         for (size_t i = 0; i < PyArray_DIMS(%(dx)s)[0]; ++i)
         {
             const dtype_%(dy)s* __restrict__ dy_i = (dtype_%(dy)s*) (PyArray_BYTES(%(dy)s) + PyArray_STRIDES(%(dy)s)[0] * i);
@@ -504,6 +506,8 @@ class Softmax(gof.Op):
         """
 
         begin_row_loop = """
+        int chunk = 32;
+        #pragma omp parallel for schedule(static, chunk)
         for (size_t i = 0; i < Nx[0]; ++i)
         {
             size_t j;


### PR DESCRIPTION
This code is used to do softmax and softmaxGrad opti. Can increase the theano RNN/LSTM performance.

The theano UT has all passed.
Don't affect the code style of theano.