### PR TITLE
Change caching method of GpuarrayType to fix issue #5345

### DIFF
--- a/theano/gpuarray/type.py
+++ b/theano/gpuarray/type.py
@@ -476,10 +476,8 @@ class GpuArrayType(Type):
         return ['gpuarray']
 
     def c_code_cache_version(self):
-        ver = pygpu.gpuarray.api_version()
-        # we only use the major version since the minor revision are
-        # API-compatible.
-        return (2, ver[0])
+        ver = pygpu.gpuarray.abi_version()
+        return (2,) + ver
 
 
 class _operators(_tensor_py_operators):

--- a/theano/gpuarray/type.py
+++ b/theano/gpuarray/type.py
@@ -476,7 +476,6 @@ class GpuArrayType(Type):
         return ['gpuarray']
 
     def c_code_cache_version(self):
-        # import pdb; pdb.set_trace()
         ver = pygpu.gpuarray.abi_version()
         # we only use the major version since the minor revision are compatible.
         return (2, ver[0])

--- a/theano/gpuarray/type.py
+++ b/theano/gpuarray/type.py
@@ -476,8 +476,10 @@ class GpuArrayType(Type):
         return ['gpuarray']
 
     def c_code_cache_version(self):
+        # import pdb; pdb.set_trace()
         ver = pygpu.gpuarray.abi_version()
-        return (2,) + ver
+        # we only use the major version since the minor revision are compatible.
+        return (2, ver[0])
 
 
 class _operators(_tensor_py_operators):


### PR DESCRIPTION
This is to fix issue #5345 . The c_code_cache_version() of GpuArrayType now depends on gpuarray ABI version instead of API version, so that cached files linked with an old gpuarray shared library will be recompiled every time the gpuarray ABI version changes. See gpuarray PR https://github.com/Theano/libgpuarray/pull/323 for new ABI methods added.

The fix works on my computer.

@abergeron @nouiz 