### PR TITLE
numpy 1.12.0rc2 compatibility fix related to variable typecasting

### DIFF
--- a/theano/sparse/sandbox/sp2.py
+++ b/theano/sparse/sandbox/sp2.py
@@ -5,6 +5,7 @@ import theano
 import scipy.sparse
 
 from theano import gof, tensor
+from theano.tensor import discrete_dtypes
 from theano.tensor.opt import register_specialize
 from theano.sparse.basic import (
     as_sparse_variable, SparseType, add_s_s, neg,
@@ -116,6 +117,11 @@ class Binomial(gof.op.Op):
         n = tensor.as_tensor_variable(n)
         p = tensor.as_tensor_variable(p)
         shape = tensor.as_tensor_variable(shape)
+
+        assert n.dtype in discrete_dtypes
+        assert p.dtype not in discrete_dtypes
+        assert shape.dtype in discrete_dtypes
+
         return gof.Apply(self, [n, p, shape],
                          [SparseType(dtype=self.dtype,
                                      format=self.format)()])

--- a/theano/sparse/sandbox/sp2.py
+++ b/theano/sparse/sandbox/sp2.py
@@ -5,7 +5,7 @@ import theano
 import scipy.sparse
 
 from theano import gof, tensor
-from theano.tensor import discrete_dtypes
+from theano.tensor import discrete_dtypes, float_dtypes
 from theano.tensor.opt import register_specialize
 from theano.sparse.basic import (
     as_sparse_variable, SparseType, add_s_s, neg,
@@ -119,7 +119,7 @@ class Binomial(gof.op.Op):
         shape = tensor.as_tensor_variable(shape)
 
         assert n.dtype in discrete_dtypes
-        assert p.dtype not in discrete_dtypes
+        assert p.dtype in float_dtypes
         assert shape.dtype in discrete_dtypes
 
         return gof.Apply(self, [n, p, shape],

--- a/theano/sparse/tests/test_sp2.py
+++ b/theano/sparse/tests/test_sp2.py
@@ -62,7 +62,7 @@ class PoissonTester(utt.InferShapeTester):
 
 
 class BinomialTester(utt.InferShapeTester):
-    n = tensor.scalar()
+    n = tensor.scalar(dtype='int64')
     p = tensor.scalar()
     shape = tensor.lvector()
     _n = 5


### PR DESCRIPTION
Fix for TypeError: Cannot cast array data from dtype('float32') to dtype('int64') according to the rule 'safe' can be fixed by making the cast explicit, casting="unsafe".

related to [5396](https://github.com/Theano/Theano/issues/5396)