### PR TITLE
changed optdb.max_use_ratio to 6

### DIFF
--- a/.jenkins/jenkins_test1.sh
+++ b/.jenkins/jenkins_test1.sh
@@ -13,5 +13,5 @@ echo "===== Testing theano core"
 # Test theano core
 PARTS="theano -e cuda -e gpuarray"
 THEANO_PARAM="${PARTS} --with-timer --timer-top-n 10 --with-xunit --xunit-file=theanocore_tests.xml"
-FLAGS="mode=FAST_RUN,floatX=float32"
+FLAGS="mode=FAST_RUN,floatX=float32,on_opt_error=raise,on_shape_error=raise"
 THEANO_FLAGS=${FLAGS} bin/theano-nose ${THEANO_PARAM}

--- a/.jenkins/jenkins_test2.sh
+++ b/.jenkins/jenkins_test2.sh
@@ -76,5 +76,5 @@ THEANO_GPUARRAY_TESTS="theano/gpuarray/tests \
                        theano/sandbox/tests/test_rng_mrg.py:test_consistency_GPUA_parallel \
                        theano/sandbox/tests/test_rng_mrg.py:test_GPUA_full_fill \
                        theano/scan_module/tests/test_scan.py:T_Scan_Gpuarray"
-FLAGS="init_gpu_device=$DEVICE,gpuarray.preallocate=1000,mode=FAST_RUN"
+FLAGS="init_gpu_device=$DEVICE,gpuarray.preallocate=1000,mode=FAST_RUN,on_opt_error=raise,on_shape_error=raise"
 THEANO_FLAGS=${FLAGS} time nosetests -v --with-xunit --xunit-file=theanogpuarray_tests.xml ${THEANO_GPUARRAY_TESTS}

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -1104,7 +1104,7 @@ AddConfigVar('optdb.position_cutoff',
 
 AddConfigVar('optdb.max_use_ratio',
              'A ratio that prevent infinite loop in EquilibriumOptimizer.',
-             FloatParam(5),
+             FloatParam(6),
              in_c_key=False)
 
 AddConfigVar('gcc.cxxflags',

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -1104,7 +1104,7 @@ AddConfigVar('optdb.position_cutoff',
 
 AddConfigVar('optdb.max_use_ratio',
              'A ratio that prevent infinite loop in EquilibriumOptimizer.',
-             FloatParam(6),
+             FloatParam(8),
              in_c_key=False)
 
 AddConfigVar('gcc.cxxflags',

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -2510,10 +2510,14 @@ class EquilibriumOptimizer(NavigatorOptimizer):
         end_nb_nodes = len(fgraph.apply_nodes)
 
         if max_use_abort:
-            _logger.error("EquilibriumOptimizer max'ed out by '%s'" % opt_name +
-                          ". You can safely raise the current threshold of " +
-                          "%f with the theano flag 'optdb.max_use_ratio'." %
-                          config.optdb.max_use_ratio)
+            msg = ("EquilibriumOptimizer max'ed out by '%s'" % opt_name +
+                   ". You can safely raise the current threshold of " +
+                   "%f with the theano flag 'optdb.max_use_ratio'." %
+                   config.optdb.max_use_ratio)
+            if theano.config.on_opt_error == 'raise':
+                raise AssertionError(msg)
+            else:
+                _logger.error(msg)
         fgraph.remove_feature(change_tracker)
         assert len(loop_process_count) == len(loop_timing)
         assert len(loop_process_count) == len(global_opt_timing)

--- a/theano/gof/tests/test_opt.py
+++ b/theano/gof/tests/test_opt.py
@@ -572,6 +572,8 @@ class TestEquilibrium(object):
         assert str(g) == '[Op2(x, y)]'
 
     def test_low_use_ratio(self):
+        backup = theano.config.on_opt_error
+        theano.config.on_opt_error = 'warn'
         x, y, z = map(MyVariable, 'xyz')
         e = op3(op4(x, y))
         g = FunctionGraph([x, y, z], [e])
@@ -590,6 +592,7 @@ class TestEquilibrium(object):
                 max_use_ratio=1. / len(g.apply_nodes))  # each opt can only be applied once
             opt.optimize(g)
         finally:
+            theano.config.on_opt_error = backup
             _logger.setLevel(oldlevel)
         # print 'after', g
         assert str(g) == '[Op1(x, y)]'

--- a/theano/gof/tests/test_opt.py
+++ b/theano/gof/tests/test_opt.py
@@ -572,8 +572,6 @@ class TestEquilibrium(object):
         assert str(g) == '[Op2(x, y)]'
 
     def test_low_use_ratio(self):
-        backup = theano.config.on_opt_error
-        theano.config.on_opt_error = 'warn'
         x, y, z = map(MyVariable, 'xyz')
         e = op3(op4(x, y))
         g = FunctionGraph([x, y, z], [e])
@@ -583,6 +581,8 @@ class TestEquilibrium(object):
         _logger = logging.getLogger('theano.gof.opt')
         oldlevel = _logger.level
         _logger.setLevel(logging.CRITICAL)
+        backup = theano.config.on_opt_error
+        theano.config.on_opt_error = 'warn'
         try:
             opt = EquilibriumOptimizer(
                 [PatternSub((op1, 'x', 'y'), (op2, 'x', 'y')),

--- a/theano/gof/tests/test_opt.py
+++ b/theano/gof/tests/test_opt.py
@@ -571,6 +571,7 @@ class TestEquilibrium(object):
         opt.optimize(g)
         assert str(g) == '[Op2(x, y)]'
 
+    @theano.configparser.change_flags(on_opt_error='ignore')
     def test_low_use_ratio(self):
         x, y, z = map(MyVariable, 'xyz')
         e = op3(op4(x, y))
@@ -581,8 +582,6 @@ class TestEquilibrium(object):
         _logger = logging.getLogger('theano.gof.opt')
         oldlevel = _logger.level
         _logger.setLevel(logging.CRITICAL)
-        backup = theano.config.on_opt_error
-        theano.config.on_opt_error = 'warn'
         try:
             opt = EquilibriumOptimizer(
                 [PatternSub((op1, 'x', 'y'), (op2, 'x', 'y')),
@@ -592,7 +591,6 @@ class TestEquilibrium(object):
                 max_use_ratio=1. / len(g.apply_nodes))  # each opt can only be applied once
             opt.optimize(g)
         finally:
-            theano.config.on_opt_error = backup
             _logger.setLevel(oldlevel)
         # print 'after', g
         assert str(g) == '[Op1(x, y)]'


### PR DESCRIPTION
Regarding issue #4734 , the default value for  `optdb.max_use_ratio`  is changed from 5 to 6 to prevent errors for some tests. For example this test:

```theano.tensor.tests.test_opt.test_local_subtensor_merge```

generated this error:

```ERROR (theano.gof.opt): EquilibriumOptimizer max'ed out by 'local_add_canonizer'. You can safely raise the current threshold of 5.000000 with the theano flag 'optdb.max_use_ratio'. ```