### PR TITLE
Add C code to RoundHalfToEven op.

### DIFF
--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -636,7 +636,7 @@ class Scalar(Type):
         return ["import_array();"]
 
     def c_code_cache_version(self):
-        return (13, numpy.__version__)
+        return (14, numpy.__version__)
 
     def get_shape_info(self, obj):
         return obj.itemsize


### PR DESCRIPTION
Performances are better, as expected:

Without c code:
`THEANO_FLAGS=profile=true,cxx= nosetests -vs theano/tensor/tests/test_basic.py:RoundHalfToEvenTester`

```
Ops
---
<% time> <sum %> <apply time> <time per call> <type> <#call> <#apply> <Op name>
  81.0%    81.0%       0.007s       5.31e-04s     Py      14        1   Elemwise{Composite{(i0 * RoundHalfToEven(i1))}}
  12.2%    93.2%       0.001s       7.98e-05s     Py      14        1   Sum{acc_dtype=float64}
   5.4%    98.6%       0.000s       9.91e-05s     Py       5        5   Elemwise{round_half_to_even,no_inplace}
   0.5%    99.2%       0.000s       2.50e-05s     Py       2        1   Shape_i{1}
   0.5%    99.7%       0.000s       2.41e-05s     Py       2        1   Alloc
   0.3%   100.0%       0.000s       1.35e-05s     Py       2        1   Shape_i{0}
   ... (remaining 0 Ops account for   0.00%(0.00s) of the runtime)
```

With c code:
`THEANO_FLAGS=profile=true nosetests -vs theano/tensor/tests/test_basic.py:RoundHalfToEvenTester`
```
Ops
---
<% time> <sum %> <apply time> <time per call> <type> <#call> <#apply> <Op name>
  35.7%    35.7%       0.000s       1.86e-06s     C       14        1   Elemwise{Composite{(i0 * RoundHalfToEven(i1))}}
  30.2%    65.9%       0.000s       4.39e-06s     C        5        5   Elemwise{round_half_to_even,no_inplace}
  15.1%    81.0%       0.000s       7.83e-07s     C       14        1   Sum{acc_dtype=float64}
  10.8%    91.8%       0.000s       3.93e-06s     C        2        1   Alloc
   4.3%    96.1%       0.000s       1.55e-06s     C        2        1   Shape_i{1}
   3.9%   100.0%       0.000s       1.43e-06s     C        2        1   Shape_i{0}
   ... (remaining 0 Ops account for   0.00%(0.00s) of the runtime)
```

@nouiz @lamblin 