### PR TITLE
print_test_value in debugging tutorial

### DIFF
--- a/doc/tutorial/debug_faq.txt
+++ b/doc/tutorial/debug_faq.txt
@@ -220,6 +220,29 @@ The ``compute_test_value`` mechanism works as follows:
   This feature is currently incompatible with ``Scan`` and also with ops
   which do not implement a ``perform`` method.
 
+It is also possible to override variables ``__repr__`` method to have them return tag.test_value.
+
+.. testcode:: printtestvalue
+
+   x = T.scalar('x')
+   # Assigning test value
+   x.tag.test_value = 42
+
+   # Enable test value printing
+   theano.config.print_test_value = True
+   print(x.__repr__())
+
+   # Disable test value printing
+   theano.config.print_test_value = False
+   print(x.__repr__())
+
+Running the code above returns the following output:
+
+.. testcode:: printtestvalue
+   x
+   array(42.0)
+   x
+
 
 "How do I Print an Intermediate Value in a Function?"
 -----------------------------------------------------

--- a/doc/tutorial/debug_faq.txt
+++ b/doc/tutorial/debug_faq.txt
@@ -239,6 +239,7 @@ It is also possible to override variables ``__repr__`` method to have them retur
 Running the code above returns the following output:
 
 .. testoutput:: printtestvalue
+
    x
    array(42.0)
    x

--- a/doc/tutorial/debug_faq.txt
+++ b/doc/tutorial/debug_faq.txt
@@ -238,7 +238,7 @@ It is also possible to override variables ``__repr__`` method to have them retur
 
 Running the code above returns the following output:
 
-.. testcode:: printtestvalue
+.. testoutput:: printtestvalue
    x
    array(42.0)
    x

--- a/doc/tutorial/debug_faq.txt
+++ b/doc/tutorial/debug_faq.txt
@@ -222,6 +222,12 @@ The ``compute_test_value`` mechanism works as follows:
 
 It is also possible to override variables ``__repr__`` method to have them return tag.test_value.
 
+.. testsetup:: printtestvalue
+
+   import theano
+   import theano.tensor as T
+
+               
 .. testcode:: printtestvalue
 
    x = T.scalar('x')


### PR DESCRIPTION
Extended the debugging tutorial with information and an examples on test value printing.

fix gh-4111