### PR TITLE
(small fix) Update `theano-cache` to prevent an error message printed when `device=cuda` on Windows.

### DIFF
--- a/bin/theano_cache.py
+++ b/bin/theano_cache.py
@@ -5,11 +5,11 @@ import os
 import sys
 
 if sys.platform == 'win32':
-    config_cxx = 'cxx='
+    config_for_theano_cache_script = 'cxx=,device=cpu'
     theano_flags = os.environ['THEANO_FLAGS'] if 'THEANO_FLAGS' in os.environ else ''
     if theano_flags:
         theano_flags += ','
-    theano_flags += config_cxx
+    theano_flags += config_for_theano_cache_script
     os.environ['THEANO_FLAGS'] = theano_flags
 
 import theano


### PR DESCRIPTION
On Windows, if the theano flag `device` is set to `cuda`, then the new backend raises a RuntimeError when `theano-cache` script is executed:

```
(python2) C:\Users\HPPC>set THEANO_FLAGS=device=cuda

(python2) C:\Users\HPPC>theano-cache
ERROR (theano.gpuarray): Could not initialize pygpu, support disabled
Traceback (most recent call last):
  File "c:\users\hppc\mila\dev\git\theano\theano\gpuarray\__init__.py", line 164, in <module>
    use(config.device)
  File "c:\users\hppc\mila\dev\git\theano\theano\gpuarray\__init__.py", line 151, in use
    init_dev(device)
  File "c:\users\hppc\mila\dev\git\theano\theano\gpuarray\__init__.py", line 47, in init_dev
    raise RuntimeError("The new gpu-backend need a c++ compiler.")
RuntimeError: The new gpu-backend need a c++ compiler.
C:\Users\HPPC\AppData\Local\Theano\compiledir_Windows-8.1-6.3.9600-Intel64_Family_6_Model_69_Steppin
g_1_GenuineIntel-2.7.13-64
```
It is a non-blocking error (the cache will be indeed purged with `theano-cache purge`), but just to not print this error, I modified the `theano-cache` script which will now force `device=cpu` just for its execution (as `theano-cache` has nothing to do with the GPU).

@nouiz @lamblin 