### PR TITLE
Merge optimizer 5319

### DIFF
--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -885,12 +885,11 @@ class MergeOptimizer(Optimizer):
 
                 try:
                     fgraph.replace_all_validate(pairs, 'MergeOptimizer')
-                except Exception as ex:
-                    if type(ex) is InconsistencyError:
-                        success = False
-                        nb_fail += 1
-                        fgraph.merge_feature.blacklist.append(
-                            (pairs[0][0].owner, pairs[0][1].owner))
+                except InconsistencyError:
+                    success = False
+                    nb_fail += 1
+                    fgraph.merge_feature.blacklist.append(
+                        (pairs[0][0].owner, pairs[0][1].owner))
 
                 if success:
                     nb_merged += len(pairs)


### PR DESCRIPTION
Regarding issue #5319 , I changed the broadcastable pattern in case of TypeError exception. In an a special case that ```dtypes, ndims``` match but the broadcastable pattern doesn't, we will try to change the broadcastable pattern of one of them to be compatible with the other one. We first check for these conditions and then call the ```fgraph.replace_all_validate``` function.