### PR TITLE
(small fix) Ensure Theano finds libgpuarray folders automatically in Windows with conda package

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1584,7 +1584,12 @@ def std_include_dirs():
     python_inc_dirs = ([py_inc] if py_inc == py_plat_spec_inc
                        else [py_inc, py_plat_spec_inc])
     gof_inc_dir = os.path.abspath(os.path.dirname(__file__))
-    return numpy_inc_dirs + python_inc_dirs + [gof_inc_dir]
+    other_dirs = []
+    if sys.platform == 'win32':
+        alt_inc_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '\Library\include'))
+        if os.path.exists(alt_inc_dir) and os.path.isdir(alt_inc_dir):
+            other_dirs.append(alt_inc_dir)
+    return numpy_inc_dirs + python_inc_dirs + [gof_inc_dir] + other_dirs
 
 
 def std_lib_dirs_and_libs():
@@ -1602,6 +1607,9 @@ def std_lib_dirs_and_libs():
         # Also add directory containing the Python library to the library
         # directories.
         python_lib_dirs = [os.path.join(os.path.dirname(python_inc), 'libs')]
+        alt_inc_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '\Library\lib'))
+        if os.path.exists(alt_inc_dir) and os.path.isdir(alt_inc_dir):
+            python_lib_dirs.append(alt_inc_dir)
         if "Canopy" in python_lib_dirs[0]:
             # Canopy stores libpython27.a and libmsccr90.a in this directory.
             # For some reason, these files are needed when compiling Python

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1584,12 +1584,7 @@ def std_include_dirs():
     python_inc_dirs = ([py_inc] if py_inc == py_plat_spec_inc
                        else [py_inc, py_plat_spec_inc])
     gof_inc_dir = os.path.abspath(os.path.dirname(__file__))
-    other_dirs = []
-    if sys.platform == 'win32':
-        alt_inc_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '\Library\include'))
-        if os.path.exists(alt_inc_dir) and os.path.isdir(alt_inc_dir):
-            other_dirs.append(alt_inc_dir)
-    return numpy_inc_dirs + python_inc_dirs + [gof_inc_dir] + other_dirs
+    return numpy_inc_dirs + python_inc_dirs + [gof_inc_dir]
 
 
 def std_lib_dirs_and_libs():
@@ -1607,9 +1602,6 @@ def std_lib_dirs_and_libs():
         # Also add directory containing the Python library to the library
         # directories.
         python_lib_dirs = [os.path.join(os.path.dirname(python_inc), 'libs')]
-        alt_inc_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '\Library\lib'))
-        if os.path.exists(alt_inc_dir) and os.path.isdir(alt_inc_dir):
-            python_lib_dirs.append(alt_inc_dir)
         if "Canopy" in python_lib_dirs[0]:
             # Canopy stores libpython27.a and libmsccr90.a in this directory.
             # For some reason, these files are needed when compiling Python

--- a/theano/gpuarray/type.py
+++ b/theano/gpuarray/type.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, print_function, division
+import sys, os
 import numpy as np
 import six.moves.copyreg as copyreg
 from six import iteritems
@@ -470,7 +471,19 @@ class GpuArrayType(Type):
                 '<gpuarray_api.h>']
 
     def c_header_dirs(self):
-        return [pygpu.get_include(), np.get_include()]
+        other_dirs = []
+        if sys.platform == 'win32':
+            alt_inc_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '\Library\include'))
+            if os.path.exists(alt_inc_dir) and os.path.isdir(alt_inc_dir):
+                other_dirs.append(alt_inc_dir)
+        return [pygpu.get_include(), numpy.get_include()] + other_dirs
+
+    def c_lib_dirs(self):
+        if sys.platform == 'win32':
+            alt_lib_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '\Library\lib'))
+            if os.path.exists(alt_lib_dir) and os.path.isdir(alt_lib_dir):
+                return [alt_lib_dir]
+        return []
 
     def c_libraries(self):
         return ['gpuarray']

--- a/theano/gpuarray/type.py
+++ b/theano/gpuarray/type.py
@@ -476,7 +476,7 @@ class GpuArrayType(Type):
         alt_inc_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '/Library/include'))
         if os.path.exists(alt_inc_dir) and os.path.isdir(alt_inc_dir):
             other_dirs.append(alt_inc_dir)
-        return [pygpu.get_include(), numpy.get_include()] + other_dirs
+        return [pygpu.get_include(), np.get_include()] + other_dirs
 
     def c_lib_dirs(self):
         alt_lib_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '/Library/lib'))

--- a/theano/gpuarray/type.py
+++ b/theano/gpuarray/type.py
@@ -472,17 +472,15 @@ class GpuArrayType(Type):
 
     def c_header_dirs(self):
         other_dirs = []
-        if sys.platform == 'win32':
-            alt_inc_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '\Library\include'))
-            if os.path.exists(alt_inc_dir) and os.path.isdir(alt_inc_dir):
-                other_dirs.append(alt_inc_dir)
+        alt_inc_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '/Library/include'))
+        if os.path.exists(alt_inc_dir) and os.path.isdir(alt_inc_dir):
+            other_dirs.append(alt_inc_dir)
         return [pygpu.get_include(), numpy.get_include()] + other_dirs
 
     def c_lib_dirs(self):
-        if sys.platform == 'win32':
-            alt_lib_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '\Library\lib'))
-            if os.path.exists(alt_lib_dir) and os.path.isdir(alt_lib_dir):
-                return [alt_lib_dir]
+        alt_lib_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '/Library/lib'))
+        if os.path.exists(alt_lib_dir) and os.path.isdir(alt_lib_dir):
+            return [alt_lib_dir]
         return []
 
     def c_libraries(self):

--- a/theano/gpuarray/type.py
+++ b/theano/gpuarray/type.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function, division
-import sys, os
+import sys
+import os
 import numpy as np
 import six.moves.copyreg as copyreg
 from six import iteritems

--- a/theano/gpuarray/type.py
+++ b/theano/gpuarray/type.py
@@ -473,16 +473,19 @@ class GpuArrayType(Type):
 
     def c_header_dirs(self):
         other_dirs = []
-        alt_inc_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '/Library/include'))
-        if os.path.exists(alt_inc_dir) and os.path.isdir(alt_inc_dir):
-            other_dirs.append(alt_inc_dir)
+        for dir_to_add in ['Library/include', 'include']:
+            alt_inc_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '/' + dir_to_add))
+            if os.path.exists(alt_inc_dir) and os.path.isdir(alt_inc_dir):
+                other_dirs.append(alt_inc_dir)
         return [pygpu.get_include(), np.get_include()] + other_dirs
 
     def c_lib_dirs(self):
-        alt_lib_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '/Library/lib'))
-        if os.path.exists(alt_lib_dir) and os.path.isdir(alt_lib_dir):
-            return [alt_lib_dir]
-        return []
+        dirs = []
+        for dir_to_add in ['Library/lib', 'lib']:
+            alt_lib_dir = os.path.abspath(os.path.normpath(sys.exec_prefix + '/' + dir_to_add))
+            if os.path.exists(alt_lib_dir) and os.path.isdir(alt_lib_dir):
+                dirs.append(alt_lib_dir)
+        return dirs
 
     def c_libraries(self):
         return ['gpuarray']


### PR DESCRIPTION
( this is related to windows documentation PR #5433 )

Theano uses `distutils.sysconfig.get_python_inc()` to get Python headers folder (and a similar function for libraries folder), and on Windows it returns the `include` folder located inside the environment folder (e.g. `C:\donnees\programmes\Anaconda3\envs\python2\include` (PS: same value is returned when calling ` distutils.sysconfig.get_python_inc(plat_specific=True)`)).

But conda installs the `libgpuarray` package under a folder named `Library` inside the environment folder (e.g. `C:\donnees\programmes\Anaconda3\envs\python2\Library\include\gpuarray`). It seems this `Library` folder is specific to Windows, so that it is impossible to get it directly from Python.

This fix ensures that the `Library` folder on Windows is used to find libgpuarray headers and static libraries automatically, so that user has nothing more to do when installing libgpuarray through conda.

Then the windows documentation will not need anything related to "configure libgpuarray" or something like that.

@abergeron 




![gpuarray](https://cloud.githubusercontent.com/assets/3467054/22560439/9985e302-e942-11e6-9afd-8ee9874dc3f6.png)
