### PR TITLE
(small fix) Add new internal config flag `cuda.disable` to help disable compilation in old backend

### DIFF
--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -671,6 +671,14 @@ import theano and print the config variable, as in:
 
     A directory with bin/, lib/, include/ folders containing cuda utilities.
 
+.. attribute:: config.cuda.enabled
+
+    Bool value: either ``True`` of ``False``
+
+    Default: ``True``
+
+    If set to `False`, C code in old backend is not compiled.
+
 .. attribute:: config.dnn.enabled
 
     String value: ``'auto'``, ``'True'``, ``'False'``

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -199,7 +199,6 @@ AddConfigVar(
     StrParam(default_cuda_root),
     in_c_key=False)
 
-# To be used as an internal config or for developers (i.e. not to be put in documentation)
 AddConfigVar(
     'cuda.enabled',
     'If false, C code in old backend is not compiled.',

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -199,6 +199,13 @@ AddConfigVar(
     StrParam(default_cuda_root),
     in_c_key=False)
 
+# To be used as an internal config or for developers (i.e. not to be put in documentation)
+AddConfigVar(
+    'cuda.disable',
+    'If true, C code in old backend is not compiled.',
+    BoolParam(False),
+    in_c_key=False)
+
 
 def filter_nvcc_flags(s):
     assert isinstance(s, str)

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -201,9 +201,9 @@ AddConfigVar(
 
 # To be used as an internal config or for developers (i.e. not to be put in documentation)
 AddConfigVar(
-    'cuda.disable',
-    'If true, C code in old backend is not compiled.',
-    BoolParam(False),
+    'cuda.enabled',
+    'If false, C code in old backend is not compiled.',
+    BoolParam(True),
     in_c_key=False)
 
 

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -24,7 +24,7 @@ nvcc_version = None
 
 def is_nvcc_available():
     """
-    Return True if the nvcc compiler is found.
+    Return True iff the nvcc compiler is found.
 
     """
     if config.cuda.disable:

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -27,7 +27,7 @@ def is_nvcc_available():
     Return True iff the nvcc compiler is found.
 
     """
-    if config.cuda.disable:
+    if not config.cuda.enabled:
         return False
 
     def set_version():

--- a/theano/sandbox/cuda/nvcc_compiler.py
+++ b/theano/sandbox/cuda/nvcc_compiler.py
@@ -24,9 +24,12 @@ nvcc_version = None
 
 def is_nvcc_available():
     """
-    Return True iff the nvcc compiler is found.
+    Return True if the nvcc compiler is found.
 
     """
+    if config.cuda.disable:
+        return False
+
     def set_version():
         p_out = output_subprocess_Popen([nvcc_path, '--version'])
         ver_line = decode(p_out[0]).strip().split('\n')[-1]


### PR DESCRIPTION
Currently the old backend is imported sometimes just to do some type checking, but when imported, it will try to compile some C code if it finds `nvcc`, and the compilation in old backend also needs the Microsoft Visual C++ compiler (`cl.exe`).

On Windows, the CUDA_ROOT contains both `nvcc` and CUDA DLL files that are required for the new backend, so that `nvcc` will be always visible in the environment, but `cl.exe` will not be always installed or visible (and the new Windows Installation documentation will not tell to install Visual C++).

Then, on Windows, this can lead to an useless compilation error, which is non-blocking, but prints about 5000 lines of C code + some annoying error messages.

This PR suggests a new flag `cuda.disable` which may be used to disable compilation in old backend. I use it in the function `is_nvcc_available()`, which now immediately returns false when `cuda.disable` is set to `true`.

@nouiz @abergeron @lamblin 

```
(python2) C:\Users\HPPC\mila\dev\git\theano>set THEANO_FLAGS=device=cuda

(python2) C:\Users\HPPC\mila\dev\git\theano>nosetests -vs theano\tensor\tests\test_basic.py:T_Join_a
nd_Split.test_stack_hessian > error1.log.txt 2>&1

(python2) C:\Users\HPPC\mila\dev\git\theano>set THEANO_FLAGS=device=cuda,cuda.disable=true

(python2) C:\Users\HPPC\mila\dev\git\theano>nosetests -vs theano\tensor\tests\test_basic.py:T_Join_a
nd_Split.test_stack_hessian > error2.log.txt 2>&1
```

[error1.log.txt](https://github.com/Theano/Theano/files/748576/error1.log.txt)

[error2.log.txt](https://github.com/Theano/Theano/files/748577/error2.log.txt)
