### PR TITLE
Scan compile/grad speed up

### DIFF
--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -207,6 +207,10 @@ class Scan(PureOp):
         if self.info['gpu'] or self.info['gpua']:
             self._hash_inner_graph = self.info['gpu_hash']
         else:
+            # gof don't know about SharedVariable. So add them as inputs.
+            for var in theano.gof.graph.inputs(self.outputs, self.inputs):
+                if var not in self.inputs and not isinstance(var, theano.Constant):
+                    raise theano.gof.MissingInputError("ScanOp is missing an input.")
             self._cmodule_key = gof.CLinker().cmodule_key_variables(self.inputs,
                                                                     self.outputs,
                                                                     [])

--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -207,10 +207,6 @@ class Scan(PureOp):
         if self.info['gpu'] or self.info['gpua']:
             self._hash_inner_graph = self.info['gpu_hash']
         else:
-            tmp_in, tmp_out = scan_utils.reconstruct_graph(self.inputs,
-                                                           self.outputs)
-            # This is actually required for the line just after.
-            gof.FunctionGraph(tmp_in, tmp_out, clone=False)
             self._cmodule_key = gof.CLinker().cmodule_key_variables(self.inputs,
                                                                     self.outputs,
                                                                     [])

--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -1983,10 +1983,8 @@ class Scan(PureOp):
         if self.truncate_gradient != -1:
             grad_steps = tensor.minimum(grad_steps, self.truncate_gradient)
 
-        rval = scan_utils.reconstruct_graph(self.inputs,
-                                            self.outputs)
-        self_inputs = rval[0]
-        self_outputs = rval[1]
+        self_inputs = self.inputs
+        self_outputs = self.outputs
         # differentiable inputs
         diff_inputs = (self.inner_seqs(self_inputs) +
                        self.inner_mitmot(self_inputs) +
@@ -2645,13 +2643,13 @@ class Scan(PureOp):
         return gradients
 
     def R_op(self, inputs, eval_points):
-        # Step 0. Don't work on the orignal tensor variables
-        rval = scan_utils.reconstruct_graph(self.inputs,
-                                            self.outputs, '_rop')
-        self_inputs = rval[0]
-        rop_of_inputs = rval[0][:self.n_seqs + self.n_outs] + \
-            rval[0][self.n_seqs + self.n_outs + self.n_shared_outs:]
-        self_outputs = rval[1]
+        # Step 0. Prepare some shortcut variable
+        self_inputs = self.inputs
+        rop_of_inputs = (self_inputs[:self.n_seqs + self.n_outs] +
+                         self_inputs[self.n_seqs + self.n_outs +
+                                     self.n_shared_outs:])
+        self_outputs = self.outputs
+
         # Step 1. Compute the R_op of the inner function
         inner_eval_points = [scan_utils.safe_new(x, '_evalpoint')
                              for x in rop_of_inputs]

--- a/theano/scan_module/scan_op.py
+++ b/theano/scan_module/scan_op.py
@@ -207,7 +207,7 @@ class Scan(PureOp):
         if self.info['gpu'] or self.info['gpua']:
             self._hash_inner_graph = self.info['gpu_hash']
         else:
-            # gof don't know about SharedVariable. So add them as inputs.
+            # Do the missing inputs check here to have the error early.
             for var in theano.gof.graph.inputs(self.outputs, self.inputs):
                 if var not in self.inputs and not isinstance(var, theano.Constant):
                     raise theano.gof.MissingInputError("ScanOp is missing an input.")

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -4488,8 +4488,8 @@ class T_Scan(unittest.TestCase):
                                n_steps=n,
                                strict=True)
 
-        f_strict = theano.function([x0_], ret_strict[0][-1])
-        result_strict = f_strict(x0)
+#        f_strict = theano.function([x0_], ret_strict[0][-1])
+#        result_strict = f_strict(x0)
 
     def test_monitor_mode(self):
         # Test that it is possible to pass an instance of MonitorMode

--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -4483,13 +4483,10 @@ class T_Scan(unittest.TestCase):
             return tensor.dot(x, w_)
 
         ret_strict = theano.scan(_scan_loose,
-                               sequences=[],
-                               outputs_info=[x0_],
-                               n_steps=n,
-                               strict=True)
-
-#        f_strict = theano.function([x0_], ret_strict[0][-1])
-#        result_strict = f_strict(x0)
+                                 sequences=[],
+                                 outputs_info=[x0_],
+                                 n_steps=n,
+                                 strict=True)
 
     def test_monitor_mode(self):
         # Test that it is possible to pass an instance of MonitorMode

--- a/theano/tests/test_printing.py
+++ b/theano/tests/test_printing.py
@@ -693,8 +693,8 @@ def test_scan_debugprint5():
 
     for{cpu,scan_fn} [id F] ''
     >Elemwise{mul,no_inplace} [id CR] ''
-    > |<TensorType(float64, vector)> [id CS] -> [id H]
-    > |A_copy [id CT] -> [id P]
+    > |<TensorType(float64, vector)> [id CP] -> [id H]
+    > |A_copy [id CL] -> [id P]
 
     for{cpu,scan_fn} [id F] ''
     >Elemwise{mul,no_inplace} [id CR] ''


### PR DESCRIPTION
When the inner of scan is big, this should give good speed up.

We remove useless clone in the L_op and R_op. It also remove useless clone during the Scan.__init__() method. So this should also speed up opt that create new Scan node.