### PR TITLE
Allow for pooling of empty batch (like for conv in #3715).

### DIFF
--- a/theano/gpuarray/dnn_pool.c
+++ b/theano/gpuarray/dnn_pool.c
@@ -52,9 +52,6 @@ int APPLY_SPECIFIC(dnn_pool)(PyGpuArrayObject *img,
     return 1;
   }
 
-  if (c_set_tensorNd(img, APPLY_SPECIFIC(input)) != 0)
-    return 1;
-
   cudnnPoolingMode_t mode;
   int w[3];
   int p[3];
@@ -71,12 +68,6 @@ int APPLY_SPECIFIC(dnn_pool)(PyGpuArrayObject *img,
      s[i] = *((npy_intp*)PyArray_GETPTR1(stride, i));
   }
 
-  err = cudnnSetPoolingNdDescriptor(APPLY_SPECIFIC(pool), MODE_FLAG, CUDNN_PROPAGATE_NAN, ndims, w, p, s);
-
-  if (err != CUDNN_STATUS_SUCCESS) {
-    PyErr_Format(PyExc_RuntimeError, "could not set op descriptor %s", cudnnGetErrorString(err));
-  }
-
   dims[0] = PyGpuArray_DIM(img, 0);
   dims[1] = PyGpuArray_DIM(img, 1);
   dims[2] = (PyGpuArray_DIM(img, 2) + (p[0]*2) - w[0]) / s[0] + 1;
@@ -88,8 +79,22 @@ int APPLY_SPECIFIC(dnn_pool)(PyGpuArrayObject *img,
                          GA_C_ORDER, c) != 0)
     return 1;
 
+  // if input batch is empty, we return the empty output without calling cuDNN
+  // (which will fail on zero batch size).
+  if (PyGpuArray_DIM(*out, 0) == 0)
+    return 0;
+
+  if (c_set_tensorNd(img, APPLY_SPECIFIC(input)) != 0)
+    return 1;
+
   if (c_set_tensorNd(*out, APPLY_SPECIFIC(output)) != 0)
     return 1;
+
+  err = cudnnSetPoolingNdDescriptor(APPLY_SPECIFIC(pool), MODE_FLAG, CUDNN_PROPAGATE_NAN, ndims, w, p, s);
+
+  if (err != CUDNN_STATUS_SUCCESS) {
+    PyErr_Format(PyExc_RuntimeError, "could not set op descriptor %s", cudnnGetErrorString(err));
+  }
 
   {
     const float alphaf = 1;

--- a/theano/gpuarray/dnn_pool_grad.c
+++ b/theano/gpuarray/dnn_pool_grad.c
@@ -83,18 +83,23 @@ int APPLY_SPECIFIC(dnn_pool_grad)(PyGpuArrayObject *inp,
     return 1;
   }
 
+  if (theano_prep_output(inp_grad, PyGpuArray_NDIM(inp),
+                         PyGpuArray_DIMS(inp), inp->ga.typecode,
+                         GA_C_ORDER, c) != 0) {
+    return 1;
+  }
+
+  // if input batch is empty, we return the empty output without calling cuDNN
+  // (which will fail on zero batch size).
+  if (PyGpuArray_DIM(*inp_grad, 0) == 0)
+    return 0;
+
   if (c_set_tensorNd(inp, APPLY_SPECIFIC(input)) != 0)
     return 1;
   if (c_set_tensorNd(out_grad, APPLY_SPECIFIC(output_grad)) != 0)
     return 1;
   if (c_set_tensorNd(out, APPLY_SPECIFIC(output)) != 0)
     return 1;
-
-  if (theano_prep_output(inp_grad, PyGpuArray_NDIM(inp),
-                         PyGpuArray_DIMS(inp), inp->ga.typecode,
-                         GA_C_ORDER, c) != 0) {
-    return 1;
-  }
 
   int w[3];
   int p[3];

--- a/theano/gpuarray/tests/test_dnn.py
+++ b/theano/gpuarray/tests/test_dnn.py
@@ -502,6 +502,22 @@ def test_pooling_opt_arbitrary_dimensions():
                 utt.assert_allclose(res_gpu[1], res_cpu[1])
 
 
+def test_pooling_empty_batch():
+    img_shp = (0, 5, 6, 8)
+    img = T.ftensor4('img')
+
+    o = dnn.dnn_pool(img, (2, 2), (2, 2))
+    f = theano.function([img], o, mode=mode_with_gpu)
+    d = f(np.random.rand(*img_shp).astype('float32'))
+    assert d.shape == (0, 5, 3, 4)
+
+    g = T.grad(T.sum(o), wrt=img)
+    f = theano.function([img], g, mode=mode_with_gpu)
+    d = f(np.random.rand(*img_shp).astype('float32'))
+    # Not sure what to assert, it should just pass, that's all.
+    assert d.shape == (0, 5, 6, 8)
+
+
 def test_dnn_tag():
     """
     Test that if cudnn isn't avail we crash and that if it is avail, we use it.

--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -1709,19 +1709,10 @@ if (CudaNdarray_prep_output(&%(out)s, %(nd)s+2, %(out)s_dims) != 0)
 }
 
 // if input batch is empty, we return the empty output without calling cuDNN
-// (which will fail on zero batch size)
-if (CudaNdarray_DIMS(%(input)s)[0] == 0) {
-  cudaError_t err2 = cudaMemset((%(out)s)->devdata, 0,
-                                CudaNdarray_SIZE(%(out)s) * sizeof(real));
-  if (err2 != cudaSuccess) {
-    PyErr_Format(PyExc_RuntimeError,
-                 "GpuDnnConv could not fill the output with zeros: %%s",
-                 cudaGetErrorString(err2));
-    %(fail)s
-  }
-
-  // Ideally, "return success" here, but we don't have a %%(done)s
-} else {
+// (which will fail on zero batch size).
+// Ideally, "return success" here, but we don't have a %%(done)s, so just skip the call.
+if (CudaNdarray_DIMS(%(input)s)[0] > 0) {
+// Don't indent for keeping history
 
 if (c_set_tensorNd(%(input)s, %(input_desc)s) != 0)
   %(fail)s
@@ -1748,7 +1739,7 @@ if (err != CUDNN_STATUS_SUCCESS) {
   %(fail)s
 }
 
-}
+} // Closes the batchdim > 0 check.
 """ % dict(out=out, fail=sub['fail'],
            name=name, input=inputs[0],
            ws=ws, pad=pad, str=stride,
@@ -1963,19 +1954,10 @@ if (CudaNdarray_prep_output(&%(output_grad)s,
 }
 
 // if input batch is empty, we return the empty output without calling cuDNN
-// (which will fail on zero batch size)
-if (CudaNdarray_DIMS(%(input)s)[0] == 0) {
-  cudaError_t err2 = cudaMemset((%(output)s)->devdata, 0,
-                                CudaNdarray_SIZE(%(output)s) * sizeof(real));
-  if (err2 != cudaSuccess) {
-    PyErr_Format(PyExc_RuntimeError,
-                 "GpuDnnConv could not fill the output with zeros: %%s",
-                 cudaGetErrorString(err2));
-    %(fail)s
-  }
-
-  // Ideally, "return success" here, but we don't have a %%(done)s, so do else.
-} else {
+// (which will fail on zero batch size).
+// Ideally, "return success" here, but we don't have a %%(done)s, so just skip the call.
+if (CudaNdarray_DIMS(%(input)s)[0] > 0) {
+// Don't indent for keeping history
 
 if (c_set_tensorNd(%(input)s, %(input_desc)s) != 0)
   %(fail)s
@@ -2031,7 +2013,7 @@ if (err%(name)s != CUDNN_STATUS_SUCCESS) {
  %(fail)s
 }
 
-}
+} // Closes the batchdim > 0 check.
 """ % dict(output_grad=out_grad,
            fail=sub['fail'], name=name,
            input=inp, input_grad=inp_grad, output=out,

--- a/theano/sandbox/cuda/tests/test_dnn.py
+++ b/theano/sandbox/cuda/tests/test_dnn.py
@@ -546,6 +546,22 @@ def test_pooling_opt_arbitrary_dimensions():
                 utt.assert_allclose(res_gpu[1], res_cpu[1])
 
 
+def test_pooling_empty_batch():
+    img_shp = (0, 5, 6, 8)
+    img = T.ftensor4('img')
+
+    o = dnn.dnn_pool(img, (2, 2), (2, 2))
+    f = theano.function([img], o, mode=mode_with_gpu)
+    d = f(numpy.random.rand(*img_shp).astype('float32'))
+    assert d.shape == (0, 5, 3, 4)
+
+    g = T.grad(T.sum(o), wrt=img)
+    f = theano.function([img], g, mode=mode_with_gpu)
+    d = f(numpy.random.rand(*img_shp).astype('float32'))
+    # Not sure what to assert, it should just pass, that's all.
+    assert d.shape == (0, 5, 6, 8)
+
+
 class test_DnnSoftMax(test_nnet.test_SoftMax):
     gpu_op = dnn.GpuDnnSoftmax
     gpu_grad_op = dnn.GpuDnnSoftmaxGrad


### PR DESCRIPTION
Similarly to #3715 allowing size-zero batches to be sent through cuDNN conv (essentially bypassing the call to cuDNN and allocating a size-zero batch output of the correct size), this allows size-zero batches to be sent through cuDNN pooling.

Comes with unit-tests and I have used this change in a real-world application for a couple weeks already.