### PR TITLE
Consistently use '\n' in outputted code

### DIFF
--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -1216,7 +1216,7 @@ def apply_meth(tag):
             code = self.code_sections[tag]
 
             define_macros, undef_macros = self.get_c_macros(node, name)
-            return os.linesep.join(['', define_macros, code,
+            return '\n'.join(['', define_macros, code,
                                     undef_macros])
         else:
             raise utils.MethodNotDefined(
@@ -1458,7 +1458,7 @@ class COp(Op):
             define_macros.append(define_template % (n, v))
             undef_macros.append(undef_template % (n,))
 
-        return os.linesep.join(define_macros), os.linesep.join(undef_macros)
+        return '\n'.join(define_macros), '\n'.join(undef_macros)
 
     def _lquote_macro(self, txt):
         res = []
@@ -1466,7 +1466,7 @@ class COp(Op):
         for l in spl[:-1]:
             res.append(l + ' \\')
         res.append(spl[-1])
-        return os.linesep.join(res)
+        return '\n'.join(res)
 
     def get_sub_macros(self, sub):
         define_macros = []
@@ -1478,7 +1478,7 @@ class COp(Op):
             define_macros.append("#define PARAMS %s" % (sub['params'],))
             undef_macros.append("#undef PARAMS")
 
-        return os.linesep.join(define_macros), os.linesep.join(undef_macros)
+        return '\n'.join(define_macros), '\n'.join(undef_macros)
 
     def get_io_macros(self, inputs, outputs):
         define_macros = []
@@ -1503,7 +1503,7 @@ class COp(Op):
             def_macros, undef_macros = self.get_c_macros(node, name)
             def_sub, undef_sub = self.get_sub_macros(sub)
 
-            return os.linesep.join(['', def_macros, def_sub,
+            return '\n'.join(['', def_macros, def_sub,
                                     op_code,
                                     undef_sub, undef_macros])
         else:
@@ -1543,7 +1543,7 @@ class COp(Op):
                 def_sub, undef_sub = self.get_sub_macros(sub)
                 def_io, undef_io = self.get_io_macros(inp, out)
 
-                return os.linesep.join([def_macros, def_sub, def_io,
+                return '\n'.join([def_macros, def_sub, def_io,
                                         op_code,
                                         undef_io, undef_sub, undef_macros])
             else:
@@ -1561,7 +1561,7 @@ class COp(Op):
             def_sub, undef_sub = self.get_sub_macros(sub)
             def_io, undef_io = self.get_io_macros(inputs, outputs)
 
-            return os.linesep.join([def_macros, def_sub, def_io,
+            return '\n'.join([def_macros, def_sub, def_io,
                                     op_code,
                                     undef_io, undef_sub, undef_macros])
         else:

--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -1217,7 +1217,7 @@ def apply_meth(tag):
 
             define_macros, undef_macros = self.get_c_macros(node, name)
             return '\n'.join(['', define_macros, code,
-                                    undef_macros])
+                              undef_macros])
         else:
             raise utils.MethodNotDefined(
                 'c_' + tag, type(self), type(self).__name__)
@@ -1504,8 +1504,8 @@ class COp(Op):
             def_sub, undef_sub = self.get_sub_macros(sub)
 
             return '\n'.join(['', def_macros, def_sub,
-                                    op_code,
-                                    undef_sub, undef_macros])
+                              op_code,
+                              undef_sub, undef_macros])
         else:
             raise utils.MethodNotDefined(
                 'c_init_code_struct', type(self), type(self).__name__)
@@ -1544,8 +1544,8 @@ class COp(Op):
                 def_io, undef_io = self.get_io_macros(inp, out)
 
                 return '\n'.join([def_macros, def_sub, def_io,
-                                        op_code,
-                                        undef_io, undef_sub, undef_macros])
+                                  op_code,
+                                  undef_io, undef_sub, undef_macros])
             else:
                 raise utils.MethodNotDefined(
                     'c_code', type(self), type(self).__name__)
@@ -1562,8 +1562,8 @@ class COp(Op):
             def_io, undef_io = self.get_io_macros(inputs, outputs)
 
             return '\n'.join([def_macros, def_sub, def_io,
-                                    op_code,
-                                    undef_io, undef_sub, undef_macros])
+                              op_code,
+                              undef_io, undef_sub, undef_macros])
         else:
             raise utils.MethodNotDefined(
                 'c_code_cleanup', type(self), type(self).__name__)


### PR DESCRIPTION
All generated C code uses `\n` line separators, except some in `gof/op.py` when on Windows. This fixes it.

Strangely, this also fixes the issue I described in [#5463](/Theano/Theano/issues/5463#issuecomment-279826487).