### PR TITLE
Fix invalid pointer casts and negative stride handling in sparse

### DIFF
--- a/theano/sparse/tests/test_basic.py
+++ b/theano/sparse/tests/test_basic.py
@@ -3172,6 +3172,20 @@ class SamplingDotTester(utt.InferShapeTester):
         assert tested.format == 'csr'
         assert tested.dtype == expected.dtype
 
+    def test_negative_stride(self):
+        f = theano.function(
+            self.x,
+            sampling_dot(*self.x))
+
+        a2 = [self.a[0][::-1,:], self.a[1][:,::-1], self.a[2]]
+        tested = f(*a2)
+        x, y, p = a2
+        expected = p.multiply(np.dot(x, y.T))
+
+        utt.assert_allclose(as_ndarray(expected), tested.toarray())
+        assert tested.format == 'csr'
+        assert tested.dtype == expected.dtype
+
     def test_infer_shape(self):
         self._compile_and_check(self.x,
                                 [sampling_dot(*self.x)],


### PR DESCRIPTION
SamplingDotCsr is [broken on negative-stride arrays](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=855102) because it passes a first-in-index-order pointer to a BLAS interface that expects first-in-memory-order.  Fix this and add a negative stride test case.

Both it and UsmmCscDense also cast npy_intp* (usually int64*) to int32*, which is a strict aliasing violation (i.e. technically undefined behaviour: it currently appears to work, but might not in future compilers).  (It's also broken on big-endian systems, which is [how Debian discovered the problem](https://bugs.debian.org/831541), but those are now rare.)  Fix this by casting values instead of pointers.

(These have been tested by running sparse/tests/test_basic.py from the source tree, but *not* in a full build.)