### PR TITLE
Fix crash due to excessive decref of 1

### DIFF
--- a/theano/gpuarray/reduction.py
+++ b/theano/gpuarray/reduction.py
@@ -66,7 +66,6 @@ class GpuMaxAndArgmax(Op):
         for (unsigned i = 0; i < %(name)s_redux_len; ++i) {
             PyObject* axis_object = PyTuple_GET_ITEM(%(axes)s, i);
             %(name)s_axes_to_reduce[i] = (unsigned) PyInt_AS_LONG(axis_object);
-            Py_XDECREF(axis_object);
         }
 
         size_t  %(name)s_input_ndim = PyGpuArray_NDIM(%(X)s);
@@ -136,3 +135,6 @@ class GpuMaxAndArgmax(Op):
         free(%(name)s_output_dims);
         free(%(name)s_axes_to_reduce);
         """ % {'name': name, 'X': inputs[0]}
+
+    def c_code_cache_version(self):
+        return (1,)

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -1259,7 +1259,6 @@ class MaxAndArgmax(Op):
         } else if(PyTuple_GET_SIZE(%(axis)s) == 1) {
             PyObject* axis_object = PyTuple_GET_ITEM(%(axis)s, 0);
             axis = (int)PyInt_AS_LONG(axis_object);
-            Py_XDECREF(axis_object);
             if (axis > PyArray_NDIM(%(x)s)-1 || axis < -PyArray_NDIM(%(x)s)) {
                 PyErr_SetString(PyExc_ValueError,
                 "MaxAndArgmax: bad axis argument");
@@ -1308,7 +1307,7 @@ class MaxAndArgmax(Op):
         return ret % locals()
 
     def c_code_cache_version(self):
-        return (4,)
+        return (5,)
 
     def infer_shape(self, node, shapes):
         ishape = shapes[0]


### PR DESCRIPTION
Do not decref borrowed references.

This should close #5535.