### PR TITLE
Speed merge optimizer and allow partial optimizer profile

### DIFF
--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -885,7 +885,13 @@ class MergeOptimizer(Optimizer):
                         pairs = [(pairs[0][1], pairs[0][0])]
 
                 try:
-                    fgraph.replace_all_validate(pairs, 'MergeOptimizer')
+                    # If all Constants, no need to call validate.
+                    # Only need to check one of the var of each pairs.
+                    # If it is a Constant, the other must also be a Constant as we merge them.
+                    if all([isinstance(old, graph.Constant) for old, new in pairs]):
+                        fgraph.replace_all(pairs, 'MergeOptimizer')
+                    else:
+                        fgraph.replace_all_validate(pairs, 'MergeOptimizer')
                 except InconsistencyError:
                     success = False
                     nb_fail += 1

--- a/theano/gof/tests/test_graph.py
+++ b/theano/gof/tests/test_graph.py
@@ -361,7 +361,7 @@ class TestAutoName:
         r3 = tensor.constant(1.6)
         # The cache still create a new object that we don't return.
         # This is why we must increase by 2 and not 1.
-        assert r3.auto_name == "auto_" + str(autoname_id + 2)
+        assert r3.auto_name == "auto_" + str(autoname_id + 1)
 
     def test_tensorvariable(self):
         # Get counter value

--- a/theano/gof/tests/test_graph.py
+++ b/theano/gof/tests/test_graph.py
@@ -359,8 +359,6 @@ class TestAutoName:
         assert r1 is r2
 
         r3 = tensor.constant(1.6)
-        # The cache still create a new object that we don't return.
-        # This is why we must increase by 2 and not 1.
         assert r3.auto_name == "auto_" + str(autoname_id + 1)
 
     def test_tensorvariable(self):

--- a/theano/scan_module/scan_utils.py
+++ b/theano/scan_module/scan_utils.py
@@ -876,19 +876,20 @@ class Validator(object):
 
             if out.owner is None:
                 if isinstance(out, tensor.TensorConstant):
-                    # This might be a constant from the outer graph or a constant
-                    # from the inner graph. In all cases, we can clone it to be
-                    # certain we have a valid constant
-
-                    # TODO: FRED I think the clone is not needed.
-                    cloned_out = out.clone()
-                    self.valid.add(cloned_out)
-                    self.invalid.add(out)
-                    self.valid_equivalent[out] = cloned_out
+                    if hasattr(out, 'fgraph'):
+                        # If out have an fgraph, we aren't sure if it
+                        # is from the inner graph or outer graph, so
+                        # clone it.
+                        cloned_out = out.clone()
+                        self.valid.add(cloned_out)
+                        self.invalid.add(out)
+                        self.valid_equivalent[out] = cloned_out
+                    else:
+                        self.valid.add(out)
                     continue
                 else:
-                    # This is an input node and it has not been explicitly marked
-                    # as invalid so we can use it
+                    # This is an input node and it has not been
+                    # explicitly marked as invalid so we can use it
                     self.valid.add(out)
                     continue
 

--- a/theano/scan_module/scan_utils.py
+++ b/theano/scan_module/scan_utils.py
@@ -855,50 +855,76 @@ class Validator(object):
         If out is not valid and has no equivalent, None is returned.
 
         """
-        if out in self.valid:
-            return out, True
-        elif out in self.valid_equivalent:
-            return self.valid_equivalent[out], False
-        elif out in self.invalid:
-            return None
 
-        if out.owner is None:
-            if isinstance(out, tensor.TensorConstant):
-                # This might be a constant from the outer graph or a constant
-                # from the inner graph. In all cases, we can clone it to be
-                # certain we have a valid constant
-                cloned_out = out.clone()
-                self.valid.add(cloned_out)
-                self.invalid.add(out)
-                self.valid_equivalent[out] = cloned_out
-                return cloned_out, False
-            else:
-                # This is an input node and it has not been explicitly marked
-                # as invalid so we can use it
+        def get_value(out):
+            if out in self.valid:
                 return out, True
+            elif out in self.valid_equivalent:
+                return self.valid_equivalent[out], False
+            elif out in self.invalid:
+                return None
+            else:
+                raise RuntimeError("This should not happen")
 
-        # Recurse over inputs
-        inputs = [self.check(i) for i in out.owner.inputs]
+        q = [out]
+        while q:
+            out = q.pop()
+            if out in self.valid:
+                continue
+            elif out in self.invalid:
+                continue
 
-        # If some inputs are invalid without equivalent, so is out
-        if None in inputs:
-            self.invalid.add(out)
-            return None
+            if out.owner is None:
+                if isinstance(out, tensor.TensorConstant):
+                    # This might be a constant from the outer graph or a constant
+                    # from the inner graph. In all cases, we can clone it to be
+                    # certain we have a valid constant
 
-        # If some inputs are invalid with equivalent,
-        # an equivalent out should be built and returned
-        all_inputs = [inp for (inp, is_valid) in inputs]
-        equiv_inputs = [inp for (inp, is_valid) in inputs if not is_valid]
-        if equiv_inputs:
-            cloned_node = out.owner.clone_with_new_inputs(all_inputs)
-            cloned_out = cloned_node.outputs[out.index]
-            self.invalid.add(out)
-            self.valid.add(cloned_out)
-            self.valid_equivalent[out] = cloned_out
-            return cloned_out, False
+                    # TODO: FRED I think the clone is not needed.
+                    cloned_out = out.clone()
+                    self.valid.add(cloned_out)
+                    self.invalid.add(out)
+                    self.valid_equivalent[out] = cloned_out
+                    continue
+                else:
+                    # This is an input node and it has not been explicitly marked
+                    # as invalid so we can use it
+                    self.valid.add(out)
+                    continue
 
-        # All inputs are valid, so is out
-        return out, True
+            # Process the input if needed
+            continue_while = False
+            for inp in out.owner.inputs:
+                if inp not in self.valid and inp not in self.invalid:
+                    q.append(out)
+                    q.extend(out.owner.inputs)
+                    continue_while = True
+                    break
+            if continue_while:
+                continue
+            inputs = [get_value(i) for i in out.owner.inputs]
+
+            # If some inputs are invalid without equivalent, so is out
+            if None in inputs:
+                self.invalid.add(out)
+                continue
+
+            # If some inputs are invalid with equivalent,
+            # an equivalent out should be built and returned
+            all_inputs = [inp for (inp, is_valid) in inputs]
+            equiv_inputs = [inp for (inp, is_valid) in inputs if not is_valid]
+            if equiv_inputs:
+                cloned_node = out.owner.clone_with_new_inputs(all_inputs)
+                cloned_out = cloned_node.outputs[out.index]
+                self.invalid.add(out)
+                self.valid.add(cloned_out)
+                self.valid_equivalent[out] = cloned_out
+                continue
+
+            # All inputs are valid, so is out
+            self.valid.add(out)
+
+        return get_value(out)
 
 
 def scan_can_remove_outs(op, out_idxs):

--- a/theano/scan_module/tests/test_scan_opt.py
+++ b/theano/scan_module/tests/test_scan_opt.py
@@ -113,10 +113,7 @@ class TestGaussNewton(unittest.TestCase):
     def test_nobatch(self):
         # This used to give an error due to optimization "scan_merge_inouts".
         # The batch size is set to 1 and the data is represented by a matrix.
-        # As of 2013-10-24, it still triggers an optimization error due to
-        # "remove_constants_and_unused_inputs_scan".
-        mode_exc = mode.excluding("remove_constants_and_unused_inputs_scan")
-        self._run(100, 10, batch_size=1, mode=mode_exc)
+        self._run(100, 10, batch_size=1, mode=mode)
 
 
 class GaussNewtonMatrix(object):

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -246,15 +246,11 @@ def constant_or_value(x, rtype, name=None, ndim=None, dtype=None):
 
     try:
         if rtype is TensorConstant:
-            rval = rtype(
-                TensorType(dtype=x_.dtype, broadcastable=bcastable),
-                x_.copy(),
-                name=name)
-            return rval
-        else:
-            # leave the shape out of the type
-            return rtype(TensorType(dtype=x_.dtype, broadcastable=bcastable),
-                         x_, name=name)
+            x_ = x_.copy()
+        rval = rtype(
+            TensorType(dtype=x_.dtype, broadcastable=bcastable),
+            x_, name=name)
+        return rval
     except Exception:
         raise TypeError("Could not convert %s to TensorType" % x, type(x))
 

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -255,15 +255,15 @@ def constant(x, name=None, ndim=None, dtype=None):
         assert len(bcastable) == ndim
 
     try:
-        type = TensorType(dtype=x_.dtype, broadcastable=bcastable)
+        ttype = TensorType(dtype=x_.dtype, broadcastable=bcastable)
         if not constant.enable:
-            return TensorConstant(type, x_, name=name)
+            return TensorConstant(ttype, x_, name=name)
 
-        sig = TensorConstantSignature((type, x_))
+        sig = TensorConstantSignature((ttype, x_))
         if sig in constant_cache:
             return constant_cache[sig]
 
-        ret = TensorConstant(type, x_, name=name)
+        ret = TensorConstant(ttype, x_, name=name)
         if (x_.size == 1 and
             (-10) <= x_ <= 10 and
             (x_.dtype in int_dtypes or x_.dtype in uint_dtypes or

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -3251,12 +3251,15 @@ def local_IncSubtensor_serialize(node):
         if movable_inputs:
             new_inputs = ([i for i in node.inputs if not movable(i)] +
                           [mi.owner.inputs[0] for mi in movable_inputs])
-            new_add = T.add(*new_inputs)
+            if len(new_inputs) == 0:
+                new_add = new_inputs[0]
+            else:
+                new_add = T.add(*new_inputs)
 
-            # Copy over stacktrace from original output, as an error
-            # (e.g. an index error) in this add operation should
-            # correspond to an error in the original add operation.
-            copy_stack_trace(node.outputs[0], new_add)
+                # Copy over stacktrace from original output, as an error
+                # (e.g. an index error) in this add operation should
+                # correspond to an error in the original add operation.
+                copy_stack_trace(node.outputs[0], new_add)
 
             # stack up the new incsubtensors
             tip = new_add


### PR DESCRIPTION
- MergeOptimizer don't call validate when merging constant
- SequenceOptimizer still print the partial profile.
- tensor.constant() don't create intermediate TensorConstant when it won't be used. (code clean up and help find where in the code constant are created)