### PR TITLE
Adding scipy.special modified Bessel function ops

### DIFF
--- a/theano/scalar/basic_scipy.py
+++ b/theano/scalar/basic_scipy.py
@@ -449,13 +449,6 @@ class I1(UnaryScalarOp):
     def grad(self, inp, grads):
         raise NotImplementedError()
 
-    def c_code(self, node, name, inp, out, sub):
-        x, = inp
-        z, = out
-        if node.inputs[0].type in float_types:
-            return """%(z)s =
-                i1(%(x)s);""" % locals()
-        raise NotImplementedError('only floating point is implemented')
 i1 = I1(upgrade_to_float, name='i1')
 
 
@@ -479,11 +472,4 @@ class I0(UnaryScalarOp):
         gz, = grads
         return [gz * i1(x)]
 
-    def c_code(self, node, name, inp, out, sub):
-        x, = inp
-        z, = out
-        if node.inputs[0].type in float_types:
-            return """%(z)s =
-                i0(%(x)s);""" % locals()
-        raise NotImplementedError('only floating point is implemented')
 i0 = I0(upgrade_to_float, name='i0')

--- a/theano/scalar/basic_scipy.py
+++ b/theano/scalar/basic_scipy.py
@@ -429,3 +429,61 @@ class J0(UnaryScalarOp):
                 j0(%(x)s);""" % locals()
         raise NotImplementedError('only floating point is implemented')
 j0 = J0(upgrade_to_float, name='j0')
+
+
+class I1(UnaryScalarOp):
+    """
+    Modified Bessel function of order 1.
+    """
+
+    @staticmethod
+    def st_impl(x):
+        return scipy.special.i1(x)
+
+    def impl(self, x):
+        if imported_scipy_special:
+            return self.st_impl(x)
+        else:
+            super(I1, self).impl(x)
+
+    def grad(self, inp, grads):
+        raise NotImplementedError()
+
+    def c_code(self, node, name, inp, out, sub):
+        x, = inp
+        z, = out
+        if node.inputs[0].type in float_types:
+            return """%(z)s =
+                i1(%(x)s);""" % locals()
+        raise NotImplementedError('only floating point is implemented')
+i1 = I1(upgrade_to_float, name='i1')
+
+
+class I0(UnaryScalarOp):
+    """
+    Modified Bessel function of order 0.
+    """
+
+    @staticmethod
+    def st_impl(x):
+        return scipy.special.i0(x)
+
+    def impl(self, x):
+        if imported_scipy_special:
+            return self.st_impl(x)
+        else:
+            super(I0, self).impl(x)
+
+    def grad(self, inp, grads):
+        x, = inp
+        gz, = grads
+        return [gz * i1(x)]
+
+    def c_code(self, node, name, inp, out, sub):
+        x, = inp
+        z, = out
+        if node.inputs[0].type in float_types:
+            return """%(z)s =
+                i0(%(x)s);""" % locals()
+        raise NotImplementedError('only floating point is implemented')
+i0 = I0(upgrade_to_float, name='i0')

--- a/theano/scalar/basic_scipy.py
+++ b/theano/scalar/basic_scipy.py
@@ -391,13 +391,10 @@ class Jv(BinaryScalarOp):
             super(Jv, self).impl(v, x)
 
     def grad(self, inputs, grads):
-        if imported_scipy_special:
-            v, x = inputs
-            gz, = grads
-            return [grad_not_implemented(self, 0, v),
-                    gz * (jv(v - 1, x) - jv(v + 1, x)) / 2.]
-        else:
-            super(Jv, self).grad(v, x)
+        v, x = inputs
+        gz, = grads
+        return [grad_not_implemented(self, 0, v),
+                gz * (jv(v - 1, x) - jv(v + 1, x)) / 2.]
 
 jv = Jv(upgrade_to_float, name='jv')
 
@@ -418,12 +415,9 @@ class J1(UnaryScalarOp):
             super(J1, self).impl(x)
 
     def grad(self, inputs, grads):
-        if imported_scipy_special:
-            x, = inputs
-            gz, = grads
-            return [gz * (j0(x) - jv(2, x)) / 2.]
-        else:
-            super(J1, self).grad(x)
+        x, = inputs
+        gz, = grads
+        return [gz * (j0(x) - jv(2, x)) / 2.]
 
     def c_code(self, node, name, inp, out, sub):
         x, = inp
@@ -483,13 +477,10 @@ class Iv(BinaryScalarOp):
             super(Iv, self).impl(v, x)
 
     def grad(self, inputs, grads):
-        if imported_scipy_special:
-            v, x = inputs
-            gz, = grads
-            return [grad_not_implemented(self, 0, v),
-                    gz * (iv(v - 1, x) + iv(v + 1, x)) / 2.]
-        else:
-            super(Iv, self).grad(v, x)
+        v, x = inputs
+        gz, = grads
+        return [grad_not_implemented(self, 0, v),
+                gz * (iv(v - 1, x) + iv(v + 1, x)) / 2.]
 
 iv = Iv(upgrade_to_float, name='iv')
 
@@ -510,12 +501,9 @@ class I1(UnaryScalarOp):
             super(I1, self).impl(x)
 
     def grad(self, inputs, grads):
-        if imported_scipy_special:
-            x, = inputs
-            gz, = grads
-            return [gz * (i0(x) + iv(2, x)) / 2.]
-        else:
-            super(I1, self).grad(x)
+        x, = inputs
+        gz, = grads
+        return [gz * (i0(x) + iv(2, x)) / 2.]
 
 i1 = I1(upgrade_to_float, name='i1')
 

--- a/theano/scalar/basic_scipy.py
+++ b/theano/scalar/basic_scipy.py
@@ -423,7 +423,7 @@ class J1(UnaryScalarOp):
             gz, = grads
             return [gz * (j0(x) - jv(2, x)) / 2.]
         else:
-            super(J1, self).grad(v, x)
+            super(J1, self).grad(x)
 
     def c_code(self, node, name, inp, out, sub):
         x, = inp
@@ -515,7 +515,7 @@ class I1(UnaryScalarOp):
             gz, = grads
             return [gz * (i0(x) + iv(2, x)) / 2.]
         else:
-            super(I1, self).grad(v, x)
+            super(I1, self).grad(x)
 
 i1 = I1(upgrade_to_float, name='i1')
 

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2300,23 +2300,33 @@ def chi2sf(x, k):
 
 
 @_scal_elemwise
-def j0(a):
-    """Bessel function of the 0'th kind"""
+def j0(x):
+    """Bessel function of the first kind of order 0."""
 
 
 @_scal_elemwise
-def j1(a):
-    """Bessel function of the 1'th kind"""
+def j1(x):
+    """Bessel function of the first kind of order 1."""
 
 
 @_scal_elemwise
-def i0(a):
-    """Modified Bessel function of order 0."""
+def jv(v, x):
+    """Bessel function of the first kind of order v (real)."""
 
 
 @_scal_elemwise
-def i1(a):
-    "Modified Bessel function of order 1."
+def i0(x):
+    """Modified Bessel function of the first kind of order 0."""
+
+
+@_scal_elemwise
+def i1(x):
+    """Modified Bessel function of the first kind of order 1."""
+
+
+@_scal_elemwise
+def iv(v, x):
+    """Modified Bessel function of the first kind of order v (real)."""
 
 
 @_scal_elemwise

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2309,12 +2309,12 @@ def j1(a):
     """Bessel function of the 1'th kind"""
 
 
-@scal_elemwise
+@_scal_elemwise
 def i0(a):
     """Modified Bessel function of order 0."""
 
 
-@scal_elemwise
+@_scal_elemwise
 def i1(a):
     "Modified Bessel function of order 1."
 

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2309,6 +2309,16 @@ def j1(a):
     """Bessel function of the 1'th kind"""
 
 
+@scal_elemwise
+def i0(a):
+    """Modified Bessel function of order 0."""
+
+
+@scal_elemwise
+def i1(a):
+    "Modified Bessel function of order 1."
+
+
 @_scal_elemwise
 def real(z):
     """Return real component of complex-valued tensor `z`"""

--- a/theano/tensor/inplace.py
+++ b/theano/tensor/inplace.py
@@ -291,6 +291,16 @@ def j1_inplace(a):
 
 
 @_scal_inplace
+def i0_inplace(a):
+    """Modified Bessel function of order 0."""
+
+
+@_scal_inplace
+def i1_inplace(a):
+    "Modified Bessel function of order 1."
+
+
+@_scal_inplace
 def second_inplace(a):
     """Fill `a` with `b`"""
 

--- a/theano/tensor/inplace.py
+++ b/theano/tensor/inplace.py
@@ -281,23 +281,33 @@ def chi2sf_inplace(x, k):
 
 
 @_scal_inplace
-def j0_inplace(a):
-    """Bessel function of the 0'th kind"""
+def j0_inplace(x):
+    """Bessel function of the first kind of order 0."""
 
 
 @_scal_inplace
-def j1_inplace(a):
-    """Bessel function of the 0'th kind"""
+def j1_inplace(x):
+    """Bessel function of the first kind of order 1."""
 
 
 @_scal_inplace
-def i0_inplace(a):
-    """Modified Bessel function of order 0."""
+def jv_inplace(v, x):
+    """Bessel function of the first kind of order v (real)."""
 
 
 @_scal_inplace
-def i1_inplace(a):
-    "Modified Bessel function of order 1."
+def i0_inplace(x):
+    """Modified Bessel function of the first kind of order 0."""
+
+
+@_scal_inplace
+def i1_inplace(x):
+    """Modified Bessel function of the first kind of order 1."""
+
+
+@_scal_inplace
+def iv_inplace(v, x):
+    """Modified Bessel function of the first kind of order v (real)."""
 
 
 @_scal_inplace

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -1921,14 +1921,33 @@ Chi2SFInplaceTester = makeBroadcastTester(
     skip=skip_scipy,
     name='Chi2SF')
 
-_good_broadcast_unary_j = dict(
-    normal=(rand_ranged(0.1, 8, (2, 3)),),)
+_good_broadcast_unary_bessel = dict(
+    normal=(rand_ranged(-10, 10, (2, 3)),),
+    empty=(numpy.asarray([], dtype=config.floatX),),
+    int=(randint_ranged(-10, 10, (2, 3)),),
+    uint8=(randint_ranged(0, 10, (2, 3)).astype('uint8'),),
+    uint16=(randint_ranged(0, 10, (2, 3)).astype('uint16'),))
+
+_grad_broadcast_unary_bessel = dict(
+    normal=(rand_ranged(-10., 10., (2, 3)),),)
+
+_good_broadcast_binary_bessel = dict(
+    normal=(rand_ranged(-5, 5, (2, 3)),
+            rand_ranged(0, 10, (2, 3))),
+    empty=(numpy.asarray([], dtype=config.floatX),
+           numpy.asarray([], dtype=config.floatX)),
+    integers=(randint_ranged(-5, 5, (2, 3)),
+              randint_ranged(-10, 10, (2, 3))),
+    uint8=(randint_ranged(0, 5, (2, 3)).astype('uint8'),
+           randint_ranged(0, 10, (2, 3)).astype('uint8')),
+    uint16=(randint_ranged(0, 5, (2, 3)).astype('uint16'),
+            randint_ranged(0, 10, (2, 3)).astype('uint16')))
 
 J0Tester = makeBroadcastTester(
     op=tensor.j0,
     expected=expected_j0,
-    good=_good_broadcast_unary_j,
-    grad=_good_broadcast_unary_j,
+    good=_good_broadcast_unary_bessel,
+    grad=_grad_broadcast_unary_bessel,
     eps=2e-10,
     mode=mode_no_scipy,
     skip=skip_scipy)
@@ -1936,8 +1955,8 @@ J0Tester = makeBroadcastTester(
 J0InplaceTester = makeBroadcastTester(
     op=inplace.j0_inplace,
     expected=expected_j0,
-    good=_good_broadcast_unary_j,
-    grad=_good_broadcast_unary_j,
+    good=_good_broadcast_unary_bessel,
+    grad=_grad_broadcast_unary_bessel,
     eps=2e-10,
     mode=mode_no_scipy,
     inplace=True,
@@ -1946,7 +1965,8 @@ J0InplaceTester = makeBroadcastTester(
 J1Tester = makeBroadcastTester(
     op=tensor.j1,
     expected=expected_j1,
-    good=_good_broadcast_unary_j,
+    good=_good_broadcast_unary_bessel,
+    grad=_grad_broadcast_unary_bessel,
     eps=2e-10,
     mode=mode_no_scipy,
     skip=skip_scipy)
@@ -1954,28 +1974,17 @@ J1Tester = makeBroadcastTester(
 J1InplaceTester = makeBroadcastTester(
     op=inplace.j1_inplace,
     expected=expected_j1,
-    good=_good_broadcast_unary_j,
+    good=_good_broadcast_unary_bessel,
+    grad=_grad_broadcast_unary_bessel,
     eps=2e-10,
     mode=mode_no_scipy,
     inplace=True,
     skip=skip_scipy)
 
-_good_broadcast_binary_jv = dict(
-    normal=(rand_ranged(-5, 5, (2, 3)),
-            rand_ranged(0.1, 8, (2, 3))),
-    empty=(numpy.asarray([], dtype=config.floatX),
-           numpy.asarray([], dtype=config.floatX)),
-    integers=(randint_ranged(-5, 5, (2, 3)),
-              randint_ranged(1, 8, (2, 3))),
-    uint8=(randint_ranged(-5, 5, (2, 3)).astype('uint8'),
-           randint_ranged(1, 8, (2, 3)).astype('uint8')),
-    uint16=(randint_ranged(-5, 5, (2, 3)).astype('uint16'),
-            randint_ranged(1, 8, (2, 3)).astype('uint16')))
-
 JvTester = makeBroadcastTester(
     op=tensor.jv,
     expected=expected_jv,
-    good=_good_broadcast_binary_jv,
+    good=_good_broadcast_binary_bessel,
     eps=2e-10,
     mode=mode_no_scipy,
     skip=skip_scipy)
@@ -1983,24 +1992,17 @@ JvTester = makeBroadcastTester(
 JvInplaceTester = makeBroadcastTester(
     op=inplace.jv_inplace,
     expected=expected_jv,
-    good=_good_broadcast_binary_jv,
+    good=_good_broadcast_binary_bessel,
     eps=2e-10,
     mode=mode_no_scipy,
     inplace=True,
     skip=skip_scipy)
 
-_good_broadcast_unary_i = dict(
-    normal=(rand_ranged(-10, 10, (2, 3)),),
-    empty=(numpy.asarray([], dtype=config.floatX),),
-    int=(randint_ranged(-10, 10, (2, 3)),),
-    uint8=(randint_ranged(0, 10, (2, 3)).astype('uint8'),),
-    uint16=(randint_ranged(0, 10, (2, 3)).astype('uint16'),))
-
 I0Tester = makeBroadcastTester(
     op=tensor.i0,
     expected=expected_i0,
-    good=_good_broadcast_unary_i,
-    grad=_good_broadcast_unary_i,
+    good=_good_broadcast_unary_bessel,
+    grad=_grad_broadcast_unary_bessel,
     eps=2e-10,
     mode=mode_no_scipy,
     skip=skip_scipy)
@@ -2008,8 +2010,8 @@ I0Tester = makeBroadcastTester(
 I0InplaceTester = makeBroadcastTester(
     op=inplace.i0_inplace,
     expected=expected_i0,
-    good=_good_broadcast_unary_i,
-    grad=_good_broadcast_unary_i,
+    good=_good_broadcast_unary_bessel,
+    grad=_grad_broadcast_unary_bessel,
     eps=2e-10,
     mode=mode_no_scipy,
     inplace=True,
@@ -2018,7 +2020,8 @@ I0InplaceTester = makeBroadcastTester(
 I1Tester = makeBroadcastTester(
     op=tensor.i1,
     expected=expected_i1,
-    good=_good_broadcast_unary_i,
+    good=_good_broadcast_unary_bessel,
+    grad=_grad_broadcast_unary_bessel,
     eps=2e-10,
     mode=mode_no_scipy,
     skip=skip_scipy)
@@ -2026,28 +2029,17 @@ I1Tester = makeBroadcastTester(
 I1InplaceTester = makeBroadcastTester(
     op=inplace.i1_inplace,
     expected=expected_i1,
-    good=_good_broadcast_unary_i,
+    good=_good_broadcast_unary_bessel,
+    grad=_grad_broadcast_unary_bessel,
     eps=2e-10,
     mode=mode_no_scipy,
     inplace=True,
     skip=skip_scipy)
 
-_good_broadcast_binary_iv = dict(
-    normal=(rand_ranged(-5, 5, (2, 3)),
-            rand_ranged(-10, 10, (2, 3))),
-    empty=(numpy.asarray([], dtype=config.floatX),
-           numpy.asarray([], dtype=config.floatX)),
-    integers=(randint_ranged(-5, 5, (2, 3)),
-              randint_ranged(-10, 10, (2, 3))),
-    uint8=(randint_ranged(-5, 5, (2, 3)).astype('uint8'),
-           randint_ranged(-10, 10, (2, 3)).astype('uint8')),
-    uint16=(randint_ranged(-5, 5, (2, 3)).astype('uint16'),
-            randint_ranged(-10, 10, (2, 3)).astype('uint16')))
-
 IvTester = makeBroadcastTester(
     op=tensor.iv,
     expected=expected_iv,
-    good=_good_broadcast_binary_iv,
+    good=_good_broadcast_binary_bessel,
     eps=2e-10,
     mode=mode_no_scipy,
     skip=skip_scipy)
@@ -2055,7 +2047,7 @@ IvTester = makeBroadcastTester(
 IvInplaceTester = makeBroadcastTester(
     op=inplace.iv_inplace,
     expected=expected_iv,
-    good=_good_broadcast_binary_iv,
+    good=_good_broadcast_binary_bessel,
     eps=2e-10,
     mode=mode_no_scipy,
     inplace=True,

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -1721,8 +1721,10 @@ if imported_scipy_special:
     expected_chi2sf = scipy.stats.chi2.sf
     expected_j0 = scipy.special.j0
     expected_j1 = scipy.special.j1
+    expected_jv = scipy.special.jv
     expected_i0 = scipy.special.i0
     expected_i1 = scipy.special.i1
+    expected_iv = scipy.special.iv
     skip_scipy = False
     expected_erfcx = scipy.special.erfcx
 else:
@@ -1737,8 +1739,10 @@ else:
     expected_chi2sf = []
     expected_j0 = []
     expected_j1 = []
+    expected_jv = []
     expected_i0 = []
     expected_i1 = []
+    expected_iv = []
     skip_scipy = "scipy is not present"
 
 ErfTester = makeBroadcastTester(
@@ -1928,6 +1932,7 @@ J0Tester = makeBroadcastTester(
     eps=2e-10,
     mode=mode_no_scipy,
     skip=skip_scipy)
+
 J0InplaceTester = makeBroadcastTester(
     op=inplace.j0_inplace,
     expected=expected_j0,
@@ -1945,10 +1950,40 @@ J1Tester = makeBroadcastTester(
     eps=2e-10,
     mode=mode_no_scipy,
     skip=skip_scipy)
+
 J1InplaceTester = makeBroadcastTester(
     op=inplace.j1_inplace,
     expected=expected_j1,
     good=_good_broadcast_unary_j,
+    eps=2e-10,
+    mode=mode_no_scipy,
+    inplace=True,
+    skip=skip_scipy)
+
+_good_broadcast_binary_jv = dict(
+    normal=(rand_ranged(-5, 5, (2, 3)),
+            rand_ranged(0.1, 8, (2, 3))),
+    empty=(numpy.asarray([], dtype=config.floatX),
+           numpy.asarray([], dtype=config.floatX)),
+    integers=(randint_ranged(-5, 5, (2, 3)),
+              randint_ranged(1, 8, (2, 3))),
+    uint8=(randint_ranged(-5, 5, (2, 3)).astype('uint8'),
+           randint_ranged(1, 8, (2, 3)).astype('uint8')),
+    uint16=(randint_ranged(-5, 5, (2, 3)).astype('uint16'),
+            randint_ranged(1, 8, (2, 3)).astype('uint16')))
+
+JvTester = makeBroadcastTester(
+    op=tensor.jv,
+    expected=expected_jv,
+    good=_good_broadcast_binary_jv,
+    eps=2e-10,
+    mode=mode_no_scipy,
+    skip=skip_scipy)
+
+JvInplaceTester = makeBroadcastTester(
+    op=inplace.jv_inplace,
+    expected=expected_jv,
+    good=_good_broadcast_binary_jv,
     eps=2e-10,
     mode=mode_no_scipy,
     inplace=True,
@@ -1959,8 +1994,7 @@ _good_broadcast_unary_i = dict(
     empty=(numpy.asarray([], dtype=config.floatX),),
     int=(randint_ranged(-10, 10, (2, 3)),),
     uint8=(randint_ranged(0, 10, (2, 3)).astype('uint8'),),
-    uint16=(randint_ranged(0, 10, (2, 3)).astype('uint16'),)
-)
+    uint16=(randint_ranged(0, 10, (2, 3)).astype('uint16'),))
 
 I0Tester = makeBroadcastTester(
     op=tensor.i0,
@@ -1973,7 +2007,7 @@ I0Tester = makeBroadcastTester(
 
 I0InplaceTester = makeBroadcastTester(
     op=inplace.i0_inplace,
-    expected=expected_j0,
+    expected=expected_i0,
     good=_good_broadcast_unary_i,
     grad=_good_broadcast_unary_i,
     eps=2e-10,
@@ -1993,6 +2027,35 @@ I1InplaceTester = makeBroadcastTester(
     op=inplace.i1_inplace,
     expected=expected_i1,
     good=_good_broadcast_unary_i,
+    eps=2e-10,
+    mode=mode_no_scipy,
+    inplace=True,
+    skip=skip_scipy)
+
+_good_broadcast_binary_iv = dict(
+    normal=(rand_ranged(-5, 5, (2, 3)),
+            rand_ranged(-10, 10, (2, 3))),
+    empty=(numpy.asarray([], dtype=config.floatX),
+           numpy.asarray([], dtype=config.floatX)),
+    integers=(randint_ranged(-5, 5, (2, 3)),
+              randint_ranged(-10, 10, (2, 3))),
+    uint8=(randint_ranged(-5, 5, (2, 3)).astype('uint8'),
+           randint_ranged(-10, 10, (2, 3)).astype('uint8')),
+    uint16=(randint_ranged(-5, 5, (2, 3)).astype('uint16'),
+            randint_ranged(-10, 10, (2, 3)).astype('uint16')))
+
+IvTester = makeBroadcastTester(
+    op=tensor.iv,
+    expected=expected_iv,
+    good=_good_broadcast_binary_iv,
+    eps=2e-10,
+    mode=mode_no_scipy,
+    skip=skip_scipy)
+
+IvInplaceTester = makeBroadcastTester(
+    op=inplace.iv_inplace,
+    expected=expected_iv,
+    good=_good_broadcast_binary_iv,
     eps=2e-10,
     mode=mode_no_scipy,
     inplace=True,

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -1721,6 +1721,8 @@ if imported_scipy_special:
     expected_chi2sf = scipy.stats.chi2.sf
     expected_j0 = scipy.special.j0
     expected_j1 = scipy.special.j1
+    expected_i0 = scipy.special.i0
+    expected_i1 = scipy.special.i1
     skip_scipy = False
     expected_erfcx = scipy.special.erfcx
 else:
@@ -1735,6 +1737,8 @@ else:
     expected_chi2sf = []
     expected_j0 = []
     expected_j1 = []
+    expected_i0 = []
+    expected_i1 = []
     skip_scipy = "scipy is not present"
 
 ErfTester = makeBroadcastTester(

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -1943,6 +1943,10 @@ _good_broadcast_binary_bessel = dict(
     uint16=(randint_ranged(0, 5, (2, 3)).astype('uint16'),
             randint_ranged(0, 10, (2, 3)).astype('uint16')))
 
+_grad_broadcast_binary_bessel = dict(
+    normal=(rand_ranged(1, 5, (2, 3)),
+            rand_ranged(0, 10, (2, 3))))
+
 J0Tester = makeBroadcastTester(
     op=tensor.j0,
     expected=expected_j0,
@@ -1998,6 +2002,21 @@ JvInplaceTester = makeBroadcastTester(
     inplace=True,
     skip=skip_scipy)
 
+
+def test_verify_jv_grad():
+    """Verify Jv gradient.
+
+    Implemented separately due to need to fix first input for which grad is
+    not defined.
+    """
+    v_val, x_val = _grad_broadcast_binary_bessel['normal']
+
+    def fixed_first_input_jv(x):
+        return tensor.jv(v_val, x)
+
+    utt.verify_grad(fixed_first_input_jv, [x_val])
+
+
 I0Tester = makeBroadcastTester(
     op=tensor.i0,
     expected=expected_i0,
@@ -2052,6 +2071,21 @@ IvInplaceTester = makeBroadcastTester(
     mode=mode_no_scipy,
     inplace=True,
     skip=skip_scipy)
+
+
+def test_verify_iv_grad():
+    """Verify Iv gradient.
+
+    Implemented separately due to need to fix first input for which grad is
+    not defined.
+    """
+    v_val, x_val = _grad_broadcast_binary_bessel['normal']
+
+    def fixed_first_input_iv(x):
+        return tensor.iv(v_val, x)
+
+    utt.verify_grad(fixed_first_input_iv, [x_val])
+
 
 ZerosLikeTester = makeBroadcastTester(
         op=tensor.zeros_like,

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -1954,6 +1954,50 @@ J1InplaceTester = makeBroadcastTester(
     inplace=True,
     skip=skip_scipy)
 
+_good_broadcast_unary_i = dict(
+    normal=(rand_ranged(-10, 10, (2, 3)),),
+    empty=(numpy.asarray([], dtype=config.floatX),),
+    int=(randint_ranged(-10, 10, (2, 3)),),
+    uint8=(randint_ranged(0, 10, (2, 3)).astype('uint8'),),
+    uint16=(randint_ranged(0, 10, (2, 3)).astype('uint16'),)
+)
+
+I0Tester = makeBroadcastTester(
+    op=tensor.i0,
+    expected=expected_i0,
+    good=_good_broadcast_unary_i,
+    grad=_good_broadcast_unary_i,
+    eps=2e-10,
+    mode=mode_no_scipy,
+    skip=skip_scipy)
+
+I0InplaceTester = makeBroadcastTester(
+    op=inplace.i0_inplace,
+    expected=expected_j0,
+    good=_good_broadcast_unary_i,
+    grad=_good_broadcast_unary_i,
+    eps=2e-10,
+    mode=mode_no_scipy,
+    inplace=True,
+    skip=skip_scipy)
+
+I1Tester = makeBroadcastTester(
+    op=tensor.i1,
+    expected=expected_i1,
+    good=_good_broadcast_unary_i,
+    eps=2e-10,
+    mode=mode_no_scipy,
+    skip=skip_scipy)
+
+I1InplaceTester = makeBroadcastTester(
+    op=inplace.i1_inplace,
+    expected=expected_i1,
+    good=_good_broadcast_unary_i,
+    eps=2e-10,
+    mode=mode_no_scipy,
+    inplace=True,
+    skip=skip_scipy)
+
 ZerosLikeTester = makeBroadcastTester(
         op=tensor.zeros_like,
         expected=numpy.zeros_like,


### PR DESCRIPTION
Adding scalar and elemwise ops for modified Bessel function of order 0 and 1 from `scipy.special`. I've tried to follow the format and naming conventions as used for the Bessel function of first kind ops added in #3883. 

