### PR TITLE
Clarify error message related to expected kern_shape specs (1D, int64) in GpuDnnConvDesc

### DIFF
--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -386,7 +386,7 @@ class GpuDnnConvDesc(COp):
 
     def make_node(self, kern_shape):
         if kern_shape.type.ndim != 1 or kern_shape.type.dtype != 'int64':
-            raise TypeError('kern must be 1D shape tensor')
+            raise TypeError('kern must be an int64 1D shape tensor')
 
         node = Apply(self, [kern_shape],
                      [CDataType("cudnnConvolutionDescriptor_t",

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -385,6 +385,7 @@ class GpuDnnConvDesc(COp):
         self.precision = precision
 
     def make_node(self, kern_shape):
+        kern_shape = as_tensor_variable(kern_shape)
         if kern_shape.type.ndim != 1 or kern_shape.dtype not in theano.tensor.basic.int_dtypes:
             raise TypeError('kern must be an int64 1D shape tensor')
         kern_shape = theano.tensor.basic.cast(kern_shape, 'int64')

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -385,8 +385,9 @@ class GpuDnnConvDesc(COp):
         self.precision = precision
 
     def make_node(self, kern_shape):
-        if kern_shape.type.ndim != 1 or kern_shape.type.dtype != 'int64':
+        if kern_shape.type.ndim != 1 or kern_shape.dtype not in theano.tensor.basic.int_dtypes:
             raise TypeError('kern must be an int64 1D shape tensor')
+        kern_shape = theano.tensor.basic.cast(kern_shape, 'int64')
 
         node = Apply(self, [kern_shape],
                      [CDataType("cudnnConvolutionDescriptor_t",

--- a/theano/gpuarray/tests/test_dnn.py
+++ b/theano/gpuarray/tests/test_dnn.py
@@ -657,7 +657,7 @@ class TestDnnInferShapes(utt.InferShapeTester):
         )
 
         kerns_vals = np.zeros(kerns_shape, dtype=theano.config.floatX)
-        kerns_shape = theano.shared(np.asarray(kerns_shape))
+        kerns_shape = theano.shared(np.asarray(kerns_shape, dtype=np.int64))
         desc = dnn.GpuDnnConvDesc(
             border_mode=border_mode,
             subsample=subsample,

--- a/theano/gpuarray/tests/test_dnn.py
+++ b/theano/gpuarray/tests/test_dnn.py
@@ -657,7 +657,7 @@ class TestDnnInferShapes(utt.InferShapeTester):
         )
 
         kerns_vals = np.zeros(kerns_shape, dtype=theano.config.floatX)
-        kerns_shape = theano.shared(np.asarray(kerns_shape, dtype=np.int64))
+        kerns_shape = theano.shared(np.asarray(kerns_shape))
         desc = dnn.GpuDnnConvDesc(
             border_mode=border_mode,
             subsample=subsample,


### PR DESCRIPTION
In new back-end, method `GpuDnnConvDesc.make_node()` expects its input `kern_shape` to be an int64 1D tensor, but on Windows machines it seems that integers are created as int32 by default. This kind of error has already been encountered, for example here: https://github.com/pymc-devs/pymc3/pull/1550 .

On Windows it make crash this test:

```
nosetests -vs theano/gpuarray/tests/test_dnn.py:TestDnnInferShapes.test_conv_gradw_full_conv
```

For the moment, I suggest to:
* modify a line in `test_dnn` so that kern_shape is always casted to `int64`,
* clarify error message in GpuDnnConvDesc.

@nouiz @abergeron 