### PR TITLE
Prevent pkl_utils from stomping higher sys recursion limits

### DIFF
--- a/theano/misc/pkl_utils.py
+++ b/theano/misc/pkl_utils.py
@@ -40,7 +40,7 @@ __license__ = "3-clause BSD"
 
 min_recursion = 3000
 if sys.getrecursionlimit() < min_recursion:
-  sys.setrecursionlimit(min_recursion)
+    sys.setrecursionlimit(min_recursion)
 
 Pickler = pickle.Pickler
 

--- a/theano/misc/pkl_utils.py
+++ b/theano/misc/pkl_utils.py
@@ -37,7 +37,11 @@ __authors__ = "Pascal Lamblin"
 __copyright__ = "Copyright 2013, Universite de Montreal"
 __license__ = "3-clause BSD"
 
-sys.setrecursionlimit(3000)
+
+min_recursion = 3000
+if sys.getrecursionlimit() < min_recursion:
+  sys.setrecursionlimit(min_recursion)
+
 Pickler = pickle.Pickler
 
 


### PR DESCRIPTION
As a stop gap for pickling large recursive structures - this should allow the user to set higher sys recursion limits outside of the library.