### PR TITLE
Fix GPU test_pool on Windows.

### DIFF
--- a/theano/gpuarray/pool.c
+++ b/theano/gpuarray/pool.c
@@ -241,9 +241,9 @@ int APPLY_SPECIFIC(pool)(PyGpuArrayObject *x,
   size_t p[3]; z_dims[0] = x_dims[0]; z_dims[1] = x_dims[1];
   int nonzero_padding = 0;
   for (int i = 0; i < ndims; i++) {
-    w[i] = *((npy_intp*)PyArray_GETPTR1(ws, i));
-    s[i] = *((npy_intp*)PyArray_GETPTR1(stride, i));
-    p[i] = *((npy_intp*)PyArray_GETPTR1(pad, i));
+    w[i] = *((npy_int64*)PyArray_GETPTR1(ws, i));
+    s[i] = *((npy_int64*)PyArray_GETPTR1(stride, i));
+    p[i] = *((npy_int64*)PyArray_GETPTR1(pad, i));
     z_dims[2 + i] = OUTPUT_DIMS(x_dims[2 + i] + 2*p[i], w[i], s[i]);
     if (p[i] > 0) {
       nonzero_padding = 1;

--- a/theano/gpuarray/pool.py
+++ b/theano/gpuarray/pool.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 import os.path
 
 import theano
+import numpy as np
 from theano import Apply
 from theano.tensor.basic import as_tensor_variable
 from theano.tensor.signal.pool import Pool
@@ -67,6 +68,12 @@ class GpuPool(CGpuKernelBase):
             raise TypeError('Stride parameters must be ints.')
         if pad.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
+        # I can't assume that npy_intp is 64 bits, as it can be 32 bits on some computers (according to NumPy doc),
+        # so I prefer to use the "bit-width name for this data-type" for casting.
+        dtype_name_for_casting = np.dtype(np.intp).name
+        ws = theano.tensor.cast(ws, dtype_name_for_casting)
+        stride = theano.tensor.cast(stride, dtype_name_for_casting)
+        pad = theano.tensor.cast(pad, dtype_name_for_casting)
 
         return Apply(self, [inp, ws, stride, pad], [inp.type()])
 
@@ -183,6 +190,12 @@ class GpuMaxPoolGrad(CGpuKernelBase):
             raise TypeError('Stride parameters must be ints.')
         if pad.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
+
+        dtype_name_for_casting = np.dtype(np.intp).name
+        ws = theano.tensor.cast(ws, dtype_name_for_casting)
+        stride = theano.tensor.cast(stride, dtype_name_for_casting)
+        pad = theano.tensor.cast(pad, dtype_name_for_casting)
+
         return Apply(self, [inp, out, out_grad, ws, stride, pad], [inp.type()])
 
     def get_params(self, node):
@@ -257,6 +270,12 @@ class GpuAveragePoolGrad(CGpuKernelBase):
             raise TypeError('Stride parameters must be ints.')
         if pad.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
+
+        dtype_name_for_casting = np.dtype(np.intp).name
+        ws = theano.tensor.cast(ws, dtype_name_for_casting)
+        stride = theano.tensor.cast(stride, dtype_name_for_casting)
+        pad = theano.tensor.cast(pad, dtype_name_for_casting)
+
         return Apply(self, [inp, out_grad, ws, stride, pad], [inp.type()])
 
     def get_params(self, node):

--- a/theano/gpuarray/pool.py
+++ b/theano/gpuarray/pool.py
@@ -15,8 +15,6 @@ except ImportError as e:
     # To make sure theano is importable
     pass
 
-dtype_name_for_casting = 'int64'
-
 
 class GpuPool(CGpuKernelBase):
     """
@@ -70,9 +68,9 @@ class GpuPool(CGpuKernelBase):
         if pad.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
 
-        ws = theano.tensor.cast(ws, dtype_name_for_casting)
-        stride = theano.tensor.cast(stride, dtype_name_for_casting)
-        pad = theano.tensor.cast(pad, dtype_name_for_casting)
+        ws = theano.tensor.cast(ws, 'int64')
+        stride = theano.tensor.cast(stride, 'int64')
+        pad = theano.tensor.cast(pad, 'int64')
 
         return Apply(self, [inp, ws, stride, pad], [inp.type()])
 
@@ -190,9 +188,9 @@ class GpuMaxPoolGrad(CGpuKernelBase):
         if pad.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
 
-        ws = theano.tensor.cast(ws, dtype_name_for_casting)
-        stride = theano.tensor.cast(stride, dtype_name_for_casting)
-        pad = theano.tensor.cast(pad, dtype_name_for_casting)
+        ws = theano.tensor.cast(ws, 'int64')
+        stride = theano.tensor.cast(stride, 'int64')
+        pad = theano.tensor.cast(pad, 'int64')
 
         return Apply(self, [inp, out, out_grad, ws, stride, pad], [inp.type()])
 
@@ -269,9 +267,9 @@ class GpuAveragePoolGrad(CGpuKernelBase):
         if pad.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
 
-        ws = theano.tensor.cast(ws, dtype_name_for_casting)
-        stride = theano.tensor.cast(stride, dtype_name_for_casting)
-        pad = theano.tensor.cast(pad, dtype_name_for_casting)
+        ws = theano.tensor.cast(ws, 'int64')
+        stride = theano.tensor.cast(stride, 'int64')
+        pad = theano.tensor.cast(pad, 'int64')
 
         return Apply(self, [inp, out_grad, ws, stride, pad], [inp.type()])
 
@@ -351,9 +349,9 @@ class GpuDownsampleFactorMaxGradGrad(CGpuKernelBase):
         if pad.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
 
-        ws = theano.tensor.cast(ws, dtype_name_for_casting)
-        stride = theano.tensor.cast(stride, dtype_name_for_casting)
-        pad = theano.tensor.cast(pad, dtype_name_for_casting)
+        ws = theano.tensor.cast(ws, 'int64')
+        stride = theano.tensor.cast(stride, 'int64')
+        pad = theano.tensor.cast(pad, 'int64')
 
         return Apply(self, [inp, out, out_grad, ws, stride, pad], [inp.type()])
 
@@ -430,9 +428,9 @@ class GpuMaxPoolRop(CGpuKernelBase):
         if pad.dtype not in theano.tensor.int_dtypes:
             raise TypeError('Padding parameters must be ints.')
 
-        ws = theano.tensor.cast(ws, dtype_name_for_casting)
-        stride = theano.tensor.cast(stride, dtype_name_for_casting)
-        pad = theano.tensor.cast(pad, dtype_name_for_casting)
+        ws = theano.tensor.cast(ws, 'int64')
+        stride = theano.tensor.cast(stride, 'int64')
+        pad = theano.tensor.cast(pad, 'int64')
 
         return Apply(self, [inp, eval_point, ws, stride, pad], [eval_point.type()])
 

--- a/theano/gpuarray/pool_ave_grad.c
+++ b/theano/gpuarray/pool_ave_grad.c
@@ -138,9 +138,9 @@ int APPLY_SPECIFIC(ave_pool_grad)(PyGpuArrayObject *x,
     size_t s[3];
     size_t p[3];
     for(int i = 0; i < ndims; i++) {
-      w[i] = *((npy_intp*)PyArray_GETPTR1(ws, i));
-      s[i] = *((npy_intp*)PyArray_GETPTR1(stride, i));
-      p[i] = *((npy_intp*)PyArray_GETPTR1(pad, i));
+      w[i] = *((npy_int64*)PyArray_GETPTR1(ws, i));
+      s[i] = *((npy_int64*)PyArray_GETPTR1(stride, i));
+      p[i] = *((npy_int64*)PyArray_GETPTR1(pad, i));
     }
 
     int err;

--- a/theano/gpuarray/pool_grad_grad.c
+++ b/theano/gpuarray/pool_grad_grad.c
@@ -132,9 +132,9 @@ int APPLY_SPECIFIC(pool_grad_grad)(PyGpuArrayObject *x,
     size_t s[3];
     size_t p[3];
     for(int i = 0; i < ndims; i++) {
-      w[i] = *((npy_intp*)PyArray_GETPTR1(ws, i));
-      s[i] = *((npy_intp*)PyArray_GETPTR1(stride, i));
-      p[i] = *((npy_intp*)PyArray_GETPTR1(pad, i));
+      w[i] = *((npy_int64*)PyArray_GETPTR1(ws, i));
+      s[i] = *((npy_int64*)PyArray_GETPTR1(stride, i));
+      p[i] = *((npy_int64*)PyArray_GETPTR1(pad, i));
     }
 
     int err;

--- a/theano/gpuarray/pool_max_grad.c
+++ b/theano/gpuarray/pool_max_grad.c
@@ -124,9 +124,9 @@ int APPLY_SPECIFIC(max_pool_grad)(PyGpuArrayObject *x,
     size_t s[3];
     size_t p[3];
     for(int i = 0; i < ndims; i++) {
-      w[i] = *((npy_intp*)PyArray_GETPTR1(ws, i));
-      s[i] = *((npy_intp*)PyArray_GETPTR1(stride, i));
-      p[i] = *((npy_intp*)PyArray_GETPTR1(pad, i));
+      w[i] = *((npy_int64*)PyArray_GETPTR1(ws, i));
+      s[i] = *((npy_int64*)PyArray_GETPTR1(stride, i));
+      p[i] = *((npy_int64*)PyArray_GETPTR1(pad, i));
     }
 
     int err;

--- a/theano/gpuarray/pool_max_rop.c
+++ b/theano/gpuarray/pool_max_rop.c
@@ -137,9 +137,9 @@ int APPLY_SPECIFIC(max_pool_rop)(PyGpuArrayObject *x,
   size_t p[3]; z_dims[0] = x_dims[0]; z_dims[1] = x_dims[1];
   int nonzero_padding = 0;
   for (int i = 0; i < ndims; i++) {
-    w[i] = *((npy_intp*)PyArray_GETPTR1(ws, i));
-    s[i] = *((npy_intp*)PyArray_GETPTR1(stride, i));
-    p[i] = *((npy_intp*)PyArray_GETPTR1(pad, i));
+    w[i] = *((npy_int64*)PyArray_GETPTR1(ws, i));
+    s[i] = *((npy_int64*)PyArray_GETPTR1(stride, i));
+    p[i] = *((npy_int64*)PyArray_GETPTR1(pad, i));
     z_dims[2 + i] = OUTPUT_DIMS(x_dims[2 + i] + 2*p[i], w[i], s[i]);
     if (p[i] > 0) {
       nonzero_padding = 1;


### PR DESCRIPTION
fix #5582 . On Windows the test:
```
nosetests -vs theano/gpuarray/tests/test_pool.py:test_pool2d
```
fails with the following output:
```
Using cuDNN version 5110 on context None
Mapped name None to device cuda: GeForce 840M (0000:0A:00.0)
theano.gpuarray.tests.test_pool.test_pool2d ... FAIL

======================================================================
FAIL: theano.gpuarray.tests.test_pool.test_pool2d
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\donnees\programmes\Anaconda3\envs\python2\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "C:\Users\HPPC\mila\dev\git\theano\theano\gpuarray\tests\test_pool.py", line 116, in test_pool2d
    assert np.allclose(f(), f2()), (shp, ws, st, pad, mode, ignore_border)
AssertionError: ((30, 2, 24, 24), (2, 2), (2, 2), (1, 1), 'max', True)

----------------------------------------------------------------------
Ran 1 test in 0.183s

FAILED (failures=1)
```
That's because the C code for `gpuarray/pool` expects ws, strides and pads to be convertible to `npy_intp`. But `npy_intp` can be either 32 or 64 bits depending on the machine, and these inputs generally contain default integers that are also either 32 or 64 bits.

This PR makes sure these inputs are casted to `int64` in Python code and used as `int64` in all related C codes.

@abergeron @lamblin @nouiz .