### PR TITLE
Fix various GPU unit tests on Windows

### DIFF
--- a/theano/gpuarray/reduction.py
+++ b/theano/gpuarray/reduction.py
@@ -141,4 +141,4 @@ class GpuMaxAndArgmax(Op):
         """ % {'name': name, 'X': inputs[0]}
 
     def c_code_cache_version(self):
-        return (1,1)
+        return (1, 1)

--- a/theano/gpuarray/reduction.py
+++ b/theano/gpuarray/reduction.py
@@ -61,6 +61,8 @@ class GpuMaxAndArgmax(Op):
             #endif
         #endif
 
+        int err = 0;
+
         unsigned  %(name)s_redux_len = PyTuple_GET_SIZE(%(axes)s);
         unsigned* %(name)s_axes_to_reduce = (unsigned*)malloc(%(name)s_redux_len * sizeof(unsigned));
         for (unsigned i = 0; i < %(name)s_redux_len; ++i) {
@@ -114,10 +116,12 @@ class GpuMaxAndArgmax(Op):
                 PyErr_SetString(PyExc_RuntimeError, "GpuMaxAndArgmax: unable to set argmax to 0 when input is a scalar.");
                 %(fail)s
             }
-        } else if (GA_NO_ERROR !=
+        } else if (GA_NO_ERROR != (err =
             GpuArray_maxandargmax(&%(max)s->ga, &%(argmax)s->ga, &%(X)s->ga, %(name)s_redux_len, %(name)s_axes_to_reduce)
-        ) {
-            PyErr_SetString(PyExc_RuntimeError, "GpuMaxAndArgmax: unable to compute gpuarray maxandargmax.");
+        )) {
+            PyErr_Format(PyExc_RuntimeError,
+                "GpuMaxAndArgmax: unable to compute gpuarray maxandargmax: error %%d: %%s (%%s).",
+                err, gpuarray_error_str(err), GpuArray_error(&%(X)s->ga, err));
             %(fail)s
         }
         """
@@ -137,4 +141,4 @@ class GpuMaxAndArgmax(Op):
         """ % {'name': name, 'X': inputs[0]}
 
     def c_code_cache_version(self):
-        return (1,)
+        return (1,1)

--- a/theano/gpuarray/tests/test_reduction.py
+++ b/theano/gpuarray/tests/test_reduction.py
@@ -14,7 +14,7 @@ from .. import GpuArrayType
 import math
 
 # Number of values to be used in test tensors (except with 0-D tensors!).
-test_size = 10000000
+test_size = 10000
 
 # NB: This order of "unsorted axes" is arbitrary and is here
 # just to have the same informations on profile output

--- a/theano/gpuarray/tests/test_reduction.py
+++ b/theano/gpuarray/tests/test_reduction.py
@@ -14,7 +14,7 @@ from .. import GpuArrayType
 import math
 
 # Number of values to be used in test tensors (except with 0-D tensors!).
-test_size = 10000
+test_size = 10000000
 
 # NB: This order of "unsorted axes" is arbitrary and is here
 # just to have the same informations on profile output

--- a/theano/tensor/tests/test_subtensor.py
+++ b/theano/tensor/tests/test_subtensor.py
@@ -533,7 +533,7 @@ class T_subtensor(unittest.TestCase, utt.TestOptimizationMixin):
         data = rand(4, 2, 3)
         idx = [2, 2, 0, 0, 1, 1]
         n = self.shared(data)
-        t = n[self.shared(numpy.asarray(idx))[::2]]
+        t = n[self.shared(numpy.asarray(idx).astype('int64'))[::2]]
         self.assertTrue(isinstance(t.owner.op, tensor.AdvancedSubtensor1))
         val = self.eval_output_and_check(t, op_type=self.adv_sub1, length=2)
         utt.assert_allclose(data[idx[::2]], val)


### PR DESCRIPTION
This PR fixes some unit tests that fail on GPU on Windows.
___
### GPU test_reduction makes NVIDIA driver crash.

![image](https://cloud.githubusercontent.com/assets/3467054/23184909/816f70be-f84f-11e6-9a4a-cb2da15f93c2.png)

I resolved it by reducing the size of test values from 10 000 000 to 10 000. We initially use a big size to check if GPU is faster than CPU on big data, but I think it is not really useful for simple unit testing.

PS: But it is quite strange, as this test does not fail on my Ubuntu partition.

___

### test_noncontiguous_idx fails for subtensor on GPU.
This test;
```
nosetests -vs theano/gpuarray/tests/test_subtensor.py:G_subtensor.test_noncontiguous_idx
```
fails with this output:
```
Using cuDNN version 5110 on context None
Mapped name None to device cuda: GeForce 840M (0000:0A:00.0)
test_noncontiguous_idx (theano.gpuarray.tests.test_subtensor.G_subtensor) ... FAIL

======================================================================
FAIL: test_noncontiguous_idx (theano.gpuarray.tests.test_subtensor.G_subtensor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\HPPC\mila\dev\git\theano\theano\tensor\tests\test_subtensor.py", line 538, in test_noncontiguous_idx
    val = self.eval_output_and_check(t, op_type=self.adv_sub1, length=2)
  File "C:\Users\HPPC\mila\dev\git\theano\theano\tensor\tests\test_subtensor.py", line 114, in eval_output_and_check
    assert_equal(len(topo_), length)
AssertionError: 3 != 2

----------------------------------------------------------------------
Ran 1 test in 3.889s

FAILED (failures=1)
```
This test checks that the length of the function graph is exactly 2 when ignoring a list of operations. On GPU the ignored operations are `HostFromGpu, GpuFromHost, DeepCopyOp, GpuContiguous` ( https://github.com/Theano/Theano/blob/master/theano/gpuarray/tests/test_subtensor.py#L39 ). But the function graph (defined here: https://github.com/Theano/Theano/blob/master/theano/tensor/tests/test_subtensor.py#L110 ) looks like this on my computer:
```
HostFromGpu(gpuarray) [id A] ''   4
 |GpuAdvancedSubtensor1 [id B] ''   3
   |<GpuArrayType<None>(float64, (False, False, False))> [id C]
   |GpuContiguous [id D] ''   2
     |GpuElemwise{Cast{int64}}[]<gpuarray> [id E] ''   1
       |GpuSubtensor{::int64} [id F] ''   0
         |<GpuArrayType<None>(int32, (False,))> [id G]
         |Constant{2} [id H]
```
So there are 3 operations counted when we let the ignored ones: `GpuAdvancedSubtensor1`, `GpuElemwise{Cast{int64}}` and `GpuSubtensor{::int64}`. Then, it is the cast{int64} op that seems extra. Indeed, it seems it is created here: https://github.com/Theano/Theano/blob/master/theano/gpuarray/subtensor.py#L414 :
```
        if ilist__.type.dtype != 'int64':
            ilist__ = tensor.cast(ilist__, 'int64')
```
So it is certainly (again) because index list is `int32` on Windows.

To fix it, I have just updated the creation of index list in the test, by casting it to `int64` before it is passed to `make_node()`, as it is the test only that checks the number of ops (it should not be a real use-case).

___

I'm looking for some last other bugs, so I will update this PR tomorrow (unit tests take much time to run on my computer!).

@abergeron @nouiz @lamblin 