### PR TITLE
Remove a warning. It happen frequently enough that people need to wor…

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1885,11 +1885,6 @@ class GCC_compiler(Compiler):
             for f in cxxflags:
                 # If the user give an -march=X parameter, don't add one ourself
                 if ((f.startswith("--march=") or f.startswith("-march="))):
-                    _logger.warn(
-                        "WARNING: your Theano flags `gcc.cxxflags` specify"
-                        " an `-march=X` flags.\n"
-                        "         It is better to let Theano/g++ find it"
-                        " automatically, but we don't do it now")
                     detect_march = False
                     GCC_compiler.march_flags = []
                     break


### PR DESCRIPTION
…k around g++ bugs or strange installation environment that it is more annoing then useful. Also people don't set it if they don't have problem, so it don't really help.