### PR TITLE
Faster compilation and import with cuda backend

### DIFF
--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -239,6 +239,16 @@ AddConfigVar('nvcc.fastmath',
              # if theano.sandbox.cuda is loaded or not.
              in_c_key=False)
 
+AddConfigVar('nvcc.cudafe',
+             "If 'always' (the default), cudafe will be called for every GPU"
+             " Op compilation. If 'heuristic', it will only be called if the"
+             " source code appears to contain CUDA code. This can speed up"
+             " compilation and importing theano, but might fail to compile"
+             " some custom GPU Ops.",
+             EnumStr('always', 'heuristic'),
+             # Not needed in c key, does not affect the compilation result.
+             in_c_key=False)
+
 AddConfigVar('gpuarray.sync',
              """If True, every op will make sure its work is done before
                 returning.  Setting this to True will slow down execution,


### PR DESCRIPTION
This partly solves the problem identified in https://github.com/Theano/Theano/issues/1681#issuecomment-283022286 of GPU Ops taking much longer to compile than CPU Ops.

The problem is that a `mod.cu` file goes through `cudafe` and `cudafe++`, which takes a whopping 1.5 seconds of compile time even for an empty file. Many GPU Ops don't actually need that: If an Op doesn't require compiling any kernels, there's no point in calling `cudafe`. The simple solution is to rename such files to `mod.cpp` instead, and manually add the `cuda.h` and `cuda_runtime_api.h` headers.

This PR is a proof of concept. I'm not sure the distinction code catches all cases, but it works for me.
On my machine, `import theano` takes 2.5s before this PR, and 0.7s after (with an existing compile directory, not from scratch).
Compiling the Lasagne MNIST example with the CNN architecture from an empty compile directory takes 2m45s before this PR, and 1m38s after. Before this PR, it produces 34 `mod.cpp` files and 70 `mod.cu` files. After this PR, it produces 71 `mod.cpp` files and 33 `mod.cu` files.

Now what do we do with this? I know the backend is meant to be dropped any time soon (before or after releasing 0.9?), so it's probably more of a "why didn't we do this 5 years ago" suggestion, but maybe there is a chance to backport this to Theano 0.8.2 and have a final maintenance release with it, for people who need to use the old backend for some reason? Finally, is any of this relevant for the new backend? On my machine, it takes even longer to import than the old backend, but I don't see any nvcc process involved.