### PR TITLE
Change the default of conv.assert_shape flags to speed up compilation time

### DIFF
--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -695,10 +695,9 @@ import theano and print the config variable, as in:
 
 .. attribute:: config.conv.assert_shape
 
-    If False, AbstractConv* ops won't add assert that verify that
-    the user provided shapes are also the one at run time.
-
-    This can speed up compilation time and/or execution time.
+    If True, AbstractConv* ops will verify that user-provided
+    shapes match the runtime shapes (debugging option,
+    may slow down compilation)
 
 .. attribute:: config.dnn.conv.workmem
 

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -130,7 +130,7 @@ AddConfigVar(
     'conv.assert_shape',
     "If False, AbstractConv* ops won't add assert that verify that"
     " the user provided shapes are also the one at run time",
-    BoolParam(True),
+    BoolParam(False),
     in_c_key=False)
 
 AddConfigVar(

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -128,8 +128,9 @@ AddConfigVar(
 
 AddConfigVar(
     'conv.assert_shape',
-    "If False, AbstractConv* ops won't add assert that verify that"
-    " the user provided shapes are also the one at run time",
+    "If True, AbstractConv* ops will verify that user-provided"
+    " shapes match the runtime shapes (debugging option,"
+    " may slow down compilation)",
     BoolParam(False),
     in_c_key=False)
 

--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -98,15 +98,17 @@ class change_flags(object):
 
     Useful during tests.
     """
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
         confs = dict()
-        for k in kwargs:
+        args = dict(*args)
+        args.update(kwargs)
+        for k in args:
             l = [v for v in theano.configparser._config_var_list
                  if v.fullname == k]
             assert len(l) == 1
             confs[k] = l[0]
         self.confs = confs
-        self.new_vals = kwargs
+        self.new_vals = args
 
     def __call__(self, f):
         @wraps(f)

--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -98,9 +98,9 @@ class change_flags(object):
 
     Useful during tests.
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, args=[], **kwargs):
         confs = dict()
-        args = dict(*args)
+        args = dict(args)
         args.update(kwargs)
         for k in args:
             l = [v for v in theano.configparser._config_var_list

--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -98,7 +98,7 @@ class change_flags(object):
 
     Useful during tests.
     """
-    def __init__(self, args=[], **kwargs):
+    def __init__(self, args=(), **kwargs):
         confs = dict()
         args = dict(args)
         args.update(kwargs)

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -217,7 +217,8 @@ def op_lifter(OP, cuda_only=False):
                 if (not replace or
                         (cuda_only and
                          get_context(context_name).kind != b'cuda') or
-                        any(["complex" in i.dtype for i in node.inputs])):
+                        any(["complex" in getattr(i, 'dtype', "")
+                             for i in node.inputs])):
                     return False
 
                 # tag the inputs with the context in case

--- a/theano/tensor/nnet/tests/test_abstract_conv.py
+++ b/theano/tensor/nnet/tests/test_abstract_conv.py
@@ -230,7 +230,7 @@ class TestAssertConvShape(unittest.TestCase):
 
 
 class TestAssertShape(unittest.TestCase):
-    @change_flags([("conv.assert_shape",True)])
+    @change_flags([("conv.assert_shape", True)])
     def test_basic(self):
         x = tensor.tensor4()
         s1 = tensor.iscalar()
@@ -246,7 +246,7 @@ class TestAssertShape(unittest.TestCase):
         assert_raises(AssertionError, f, v, 0, 7)
         assert_raises(AssertionError, f, v, 7, 7)
 
-    @change_flags([("conv.assert_shape",True)])
+    @change_flags([("conv.assert_shape", True)])
     def test_shape_check_conv2d(self):
         input = tensor.tensor4()
         filters = tensor.tensor4()
@@ -264,7 +264,7 @@ class TestAssertShape(unittest.TestCase):
                       numpy.zeros((3, 5, 7, 11), dtype='float32'),
                       numpy.zeros((7, 5, 2, 2), dtype='float32'))
 
-    @change_flags([("conv.assert_shape",True)])
+    @change_flags([("conv.assert_shape", True)])
     def test_shape_check_conv3d(self):
         input = tensor.tensor5()
         filters = tensor.tensor5()
@@ -282,7 +282,7 @@ class TestAssertShape(unittest.TestCase):
                       numpy.zeros((3, 5, 7, 11, 13), dtype='float32'),
                       numpy.zeros((7, 5, 2, 2, 2), dtype='float32'))
 
-    @change_flags([("conv.assert_shape",True)])
+    @change_flags([("conv.assert_shape", True)])
     def test_shape_check_conv2d_grad_wrt_inputs(self):
         output_grad = tensor.tensor4()
         filters = tensor.tensor4()
@@ -296,7 +296,7 @@ class TestAssertShape(unittest.TestCase):
                       numpy.zeros((3, 6, 5, 9), dtype='float32'),
                       numpy.zeros((7, 6, 3, 3), dtype='float32'))
 
-    @change_flags([("conv.assert_shape",True)])
+    @change_flags([("conv.assert_shape", True)])
     def test_shape_check_conv3d_grad_wrt_inputs(self):
         output_grad = tensor.tensor5()
         filters = tensor.tensor5()
@@ -310,7 +310,7 @@ class TestAssertShape(unittest.TestCase):
                       numpy.zeros((3, 6, 5, 9, 11), dtype='float32'),
                       numpy.zeros((7, 6, 3, 3, 3), dtype='float32'))
 
-    @change_flags([("conv.assert_shape",True)])
+    @change_flags([("conv.assert_shape", True)])
     def test_shape_check_conv2d_grad_wrt_weights(self):
         input = tensor.tensor4()
         output_grad = tensor.tensor4()
@@ -324,7 +324,7 @@ class TestAssertShape(unittest.TestCase):
                       numpy.zeros((3, 6, 7, 11), dtype='float32'),
                       numpy.zeros((3, 7, 5, 9), dtype='float32'))
 
-    @change_flags([("conv.assert_shape",True)])
+    @change_flags([("conv.assert_shape", True)])
     def test_shape_check_conv3d_grad_wrt_weights(self):
         input = tensor.tensor5()
         output_grad = tensor.tensor5()

--- a/theano/tensor/nnet/tests/test_abstract_conv.py
+++ b/theano/tensor/nnet/tests/test_abstract_conv.py
@@ -7,6 +7,7 @@ from nose.tools import assert_raises, assert_true
 
 import theano
 from theano import tensor
+from theano.configparser import change_flags
 from theano.gof.opt import check_stack_trace
 from theano.tests import unittest_tools as utt
 from theano.tensor.nnet import (corr, corr3d, conv2d_transpose,
@@ -229,6 +230,7 @@ class TestAssertConvShape(unittest.TestCase):
 
 
 class TestAssertShape(unittest.TestCase):
+    @change_flags([("conv.assert_shape",True)])
     def test_basic(self):
         x = tensor.tensor4()
         s1 = tensor.iscalar()
@@ -244,6 +246,7 @@ class TestAssertShape(unittest.TestCase):
         assert_raises(AssertionError, f, v, 0, 7)
         assert_raises(AssertionError, f, v, 7, 7)
 
+    @change_flags([("conv.assert_shape",True)])
     def test_shape_check_conv2d(self):
         input = tensor.tensor4()
         filters = tensor.tensor4()
@@ -261,6 +264,7 @@ class TestAssertShape(unittest.TestCase):
                       numpy.zeros((3, 5, 7, 11), dtype='float32'),
                       numpy.zeros((7, 5, 2, 2), dtype='float32'))
 
+    @change_flags([("conv.assert_shape",True)])
     def test_shape_check_conv3d(self):
         input = tensor.tensor5()
         filters = tensor.tensor5()
@@ -278,6 +282,7 @@ class TestAssertShape(unittest.TestCase):
                       numpy.zeros((3, 5, 7, 11, 13), dtype='float32'),
                       numpy.zeros((7, 5, 2, 2, 2), dtype='float32'))
 
+    @change_flags([("conv.assert_shape",True)])
     def test_shape_check_conv2d_grad_wrt_inputs(self):
         output_grad = tensor.tensor4()
         filters = tensor.tensor4()
@@ -291,6 +296,7 @@ class TestAssertShape(unittest.TestCase):
                       numpy.zeros((3, 6, 5, 9), dtype='float32'),
                       numpy.zeros((7, 6, 3, 3), dtype='float32'))
 
+    @change_flags([("conv.assert_shape",True)])
     def test_shape_check_conv3d_grad_wrt_inputs(self):
         output_grad = tensor.tensor5()
         filters = tensor.tensor5()
@@ -304,6 +310,7 @@ class TestAssertShape(unittest.TestCase):
                       numpy.zeros((3, 6, 5, 9, 11), dtype='float32'),
                       numpy.zeros((7, 6, 3, 3, 3), dtype='float32'))
 
+    @change_flags([("conv.assert_shape",True)])
     def test_shape_check_conv2d_grad_wrt_weights(self):
         input = tensor.tensor4()
         output_grad = tensor.tensor4()
@@ -317,6 +324,7 @@ class TestAssertShape(unittest.TestCase):
                       numpy.zeros((3, 6, 7, 11), dtype='float32'),
                       numpy.zeros((3, 7, 5, 9), dtype='float32'))
 
+    @change_flags([("conv.assert_shape",True)])
     def test_shape_check_conv3d_grad_wrt_weights(self):
         input = tensor.tensor5()
         output_grad = tensor.tensor5()


### PR DESCRIPTION
This happen in corner cases with scan from 20m to 1m.

@f0k How bad you think that we don't assert user shape by default? @abergeron point of view is that this is more for debugging purpose. We won't generate bad results. It would just put back the user shape as compiler hint as it was done in some of the ops (while others was enforcing it). We will be consistent between all ops.

see gh-5642