### PR TITLE
Fix problems in daily buildbot (debug mode)

### DIFF
--- a/theano/scan_module/tests/test_scan.py
+++ b/theano/scan_module/tests/test_scan.py
@@ -1838,20 +1838,20 @@ class T_Scan(unittest.TestCase):
         n_in = 1
         n_out = 1
 
-        W_hh_v = asarrayX(rng.uniform(size=(n_hid, n_hid), low=-.01, high=.01))
-        h0_v = asarrayX(rng.uniform(size=(2, n_hid), low=-.01, high=.01))
+        W_hh_v = asarrayX(rng.uniform(size=(n_hid, n_hid), low=-1, high=1))
+        h0_v = asarrayX(rng.uniform(size=(2, n_hid), low=-1, high=1))
         b_h_v = asarrayX(rng.uniform(size=(n_hid), low=-.01, high=.01))
-        W_ih_v = asarrayX(rng.uniform(size=(n_in, n_hid), low=-.01, high=.01))
-        W_ho_v = asarrayX(rng.uniform(size=(n_hid, n_out), low=-.01, high=.01))
+        W_ih_v = asarrayX(rng.uniform(size=(n_in, n_hid), low=-1, high=1))
+        W_ho_v = asarrayX(rng.uniform(size=(n_hid, n_out), low=-1, high=1))
         b_o_v = asarrayX(rng.uniform(size=(n_out), low=-.01, high=.01))
 
         # parameters of the rnn
-        b_h = theano.shared(b_h_v)
-        h0 = theano.shared(h0_v)
-        W_ih = theano.shared(W_ih_v)
-        W_hh = theano.shared(W_hh_v)
-        W_ho = theano.shared(W_ho_v)
-        b_o = theano.shared(b_o_v)
+        b_h = theano.shared(b_h_v, name='b_h')
+        h0 = theano.shared(h0_v, name='h0')
+        W_ih = theano.shared(W_ih_v, name='W_ih')
+        W_hh = theano.shared(W_hh_v, name='W_hh')
+        W_ho = theano.shared(W_ho_v, name='W_ho')
+        b_o = theano.shared(b_o_v, name='b_o')
         params = [W_ih, W_hh, b_h, W_ho, b_o, h0]
 
         # first dimension is time

--- a/theano/tensor/tests/test_nlinalg.py
+++ b/theano/tensor/tests/test_nlinalg.py
@@ -404,7 +404,7 @@ class test_Eig(utt.InferShapeTester):
         self.rng = numpy.random.RandomState(utt.fetch_seed())
         self.A = theano.tensor.matrix(dtype=self.dtype)
         self.X = numpy.asarray(self.rng.rand(5, 5),
-                          dtype=self.dtype)
+                               dtype=self.dtype)
         self.S = self.X.dot(self.X.T)
 
     def test_infer_shape(self):
@@ -440,6 +440,8 @@ class test_Eigh(test_Eig):
 
     def test_grad(self):
         X = self.X
+        # We need to do the dot inside the graph because Eigh needs a
+        # matrix that is hermitian
         utt.verify_grad(lambda x: self.op(x.dot(x.T))[0], [X], rng=self.rng)
         utt.verify_grad(lambda x: self.op(x.dot(x.T))[1], [X], rng=self.rng)
         utt.verify_grad(lambda x: self.op(x.dot(x.T), 'U')[0], [X], rng=self.rng)

--- a/theano/tensor/tests/test_nlinalg.py
+++ b/theano/tensor/tests/test_nlinalg.py
@@ -15,33 +15,12 @@ from theano.tests.test_rop import break_op
 from theano.tests import unittest_tools as utt
 from theano import config
 
-from theano.tensor.nlinalg import ( MatrixInverse,
-                                    matrix_inverse,
-                                    MatrixPinv,
-                                    pinv,
-                                    AllocDiag,
-                                    alloc_diag,
-                                    ExtractDiag,
-                                    extract_diag,
-                                    diag,
-                                    trace,
-                                    Det,
-                                    det,
-                                    Eig,
-                                    eig,
-                                    Eigh,
-                                    EighGrad,
-                                    eigh,
-                                    matrix_dot,
-                                    _zero_disconnected,
-                                    qr,
-                                    matrix_power,
-                                    norm,
-                                    svd,
-                                    TensorInv,
-                                    tensorinv,
-                                    tensorsolve
-                                    )
+from theano.tensor.nlinalg import (
+    MatrixInverse, matrix_inverse, MatrixPinv, pinv,
+    AllocDiag, alloc_diag, ExtractDiag, extract_diag, diag,
+    trace, Det, det, Eig, eig, Eigh, EighGrad, eigh,
+    matrix_dot, _zero_disconnected, qr, matrix_power,
+    norm, svd, TensorInv, tensorinv, tensorsolve)
 from nose.plugins.attrib import attr
 
 from nose.plugins.skip import SkipTest
@@ -462,9 +441,9 @@ class test_Eigh(test_Eig):
     def test_grad(self):
         S = self.S
         utt.verify_grad(lambda x: self.op(x)[0], [S], rng=self.rng)
-        utt.verify_grad(lambda x: self.op(x)[1], [S], rng=self.rng)
+        utt.verify_grad(lambda x: self.op(x)[1], [S], rng=self.rng, eps=1e-4)
         utt.verify_grad(lambda x: self.op(x, 'U')[0], [S], rng=self.rng)
-        utt.verify_grad(lambda x: self.op(x, 'U')[1], [S], rng=self.rng)
+        utt.verify_grad(lambda x: self.op(x, 'U')[1], [S], rng=self.rng, eps=1e-4)
 
 
 class test_Eigh_float32(test_Eigh):

--- a/theano/tensor/tests/test_nlinalg.py
+++ b/theano/tensor/tests/test_nlinalg.py
@@ -403,9 +403,9 @@ class test_Eig(utt.InferShapeTester):
         super(test_Eig, self).setUp()
         self.rng = numpy.random.RandomState(utt.fetch_seed())
         self.A = theano.tensor.matrix(dtype=self.dtype)
-        X = numpy.asarray(self.rng.rand(5, 5),
+        self.X = numpy.asarray(self.rng.rand(5, 5),
                           dtype=self.dtype)
-        self.S = X.dot(X.T)
+        self.S = self.X.dot(self.X.T)
 
     def test_infer_shape(self):
         A = self.A
@@ -439,21 +439,19 @@ class test_Eigh(test_Eig):
                                   vl * numpy.sign(vl[0, :]))
 
     def test_grad(self):
-        S = self.S
-        utt.verify_grad(lambda x: self.op(x)[0], [S], rng=self.rng)
-        utt.verify_grad(lambda x: self.op(x)[1], [S], rng=self.rng, eps=1e-4)
-        utt.verify_grad(lambda x: self.op(x, 'U')[0], [S], rng=self.rng)
-        utt.verify_grad(lambda x: self.op(x, 'U')[1], [S], rng=self.rng, eps=1e-4)
+        X = self.X
+        utt.verify_grad(lambda x: self.op(x.dot(x.T))[0], [X], rng=self.rng)
+        utt.verify_grad(lambda x: self.op(x.dot(x.T))[1], [X], rng=self.rng)
+        utt.verify_grad(lambda x: self.op(x.dot(x.T), 'U')[0], [X], rng=self.rng)
+        utt.verify_grad(lambda x: self.op(x.dot(x.T), 'U')[1], [X], rng=self.rng)
 
 
 class test_Eigh_float32(test_Eigh):
     dtype = 'float32'
 
-    @utt.AttemptManyTimes(n_attempts=3, n_req_successes=2)
     def test_uplo(self):
         super(test_Eigh_float32, self).test_uplo()
 
-    @utt.AttemptManyTimes(n_attempts=3, n_req_successes=2)
     def test_grad(self):
         super(test_Eigh_float32, self).test_grad()
 

--- a/theano/tensor/tests/test_slinalg.py
+++ b/theano/tensor/tests/test_slinalg.py
@@ -80,7 +80,7 @@ def test_cholesky_grad():
     if not imported_scipy:
         raise SkipTest("Scipy needed for the Cholesky op.")
     rng = numpy.random.RandomState(utt.fetch_seed())
-    r = rng.randn(5, 5).astype(config.floatX)
+    r = rng.rand(5, 5).astype(config.floatX)
     pd = numpy.dot(r, r.T)
     eps = None
     if config.floatX == "float64":

--- a/theano/tensor/tests/test_slinalg.py
+++ b/theano/tensor/tests/test_slinalg.py
@@ -15,16 +15,9 @@ from theano.tensor.basic import _allclose
 from theano.tests.test_rop import break_op
 from theano.tests import unittest_tools as utt
 from theano import config
-from theano.tensor.slinalg import ( Cholesky,
-                                    cholesky,
-                                    CholeskyGrad,
-                                    Solve,
-                                    solve,
-                                    Eigvalsh,
-                                    EigvalshGrad,
-                                    eigvalsh,
-                                    expm,
-                                    kron)
+from theano.tensor.slinalg import (
+    Cholesky, cholesky, CholeskyGrad, Solve, solve,
+    Eigvalsh, EigvalshGrad, eigvalsh, expm, kron)
 from theano.tests.unittest_tools import attr
 
 from nose.plugins.skip import SkipTest
@@ -80,19 +73,16 @@ def test_cholesky_grad():
     if not imported_scipy:
         raise SkipTest("Scipy needed for the Cholesky op.")
     rng = numpy.random.RandomState(utt.fetch_seed())
-    r = rng.rand(5, 5).astype(config.floatX)
-    pd = numpy.dot(r, r.T)
-    eps = None
-    if config.floatX == "float64":
-        eps = 2e-8
+    r = rng.randn(5, 5).astype(config.floatX)
     # Check the default.
-    yield (lambda: utt.verify_grad(cholesky, [pd], 3, rng, eps=eps))
+    yield (lambda: utt.verify_grad(lambda r: cholesky(r.dot(r.T)),
+                                   [r], 3, rng))
     # Explicit lower-triangular.
-    yield (lambda: utt.verify_grad(Cholesky(lower=True), [pd], 3,
-                                   rng, eps=eps))
+    yield (lambda: utt.verify_grad(lambda r: Cholesky(lower=True)(r.dot(r.T)),
+                                   [r], 3, rng))
     # Explicit upper-triangular.
-    yield (lambda: utt.verify_grad(Cholesky(lower=False), [pd], 3,
-                                   rng, eps=eps))
+    yield (lambda: utt.verify_grad(lambda r: Cholesky(lower=False)(r.dot(r.T)),
+                                   [r], 3, rng))
 
 
 @attr('slow')

--- a/theano/tensor/tests/test_slinalg.py
+++ b/theano/tensor/tests/test_slinalg.py
@@ -74,6 +74,9 @@ def test_cholesky_grad():
         raise SkipTest("Scipy needed for the Cholesky op.")
     rng = numpy.random.RandomState(utt.fetch_seed())
     r = rng.randn(5, 5).astype(config.floatX)
+
+    # The dots are inside the graph since Cholesky needs separable matrices
+
     # Check the default.
     yield (lambda: utt.verify_grad(lambda r: cholesky(r.dot(r.T)),
                                    [r], 3, rng))


### PR DESCRIPTION
Some failures are not addressed:
- ModTester.test_grad will fail if the two inputs are really close to one another because then you wrap around and numeric_grad is super large.  This happens pretty rarely.
- test_dnn_batchnorm_train in the old backend failed once.  It seems to be a random fluke and we are about to delete the backend so I didn't want to investigate further.