### PR TITLE
 To fix the precision of GpuDnnConvDesc in #5555

### DIFF
--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -345,6 +345,9 @@ def version(raises=True):
 version.v = None
 
 
+
+
+
 class GpuDnnConvDesc(COp):
 
     """
@@ -357,6 +360,9 @@ class GpuDnnConvDesc(COp):
 
     __props__ = ('border_mode', 'subsample', 'conv_mode', 'precision')
 
+    prec_GpuDnn = get_precision(precision, [img, kerns])
+    
+    
     def c_headers(self):
         return ['cudnn.h', 'cudnn_helper.h']
 
@@ -373,7 +379,7 @@ class GpuDnnConvDesc(COp):
         return False
 
     def __init__(self, border_mode, subsample=(1, 1), conv_mode='conv',
-                 precision="float32"):
+                 precision=prec_GpuDnn):
         COp.__init__(self, ["conv_desc.c"], "APPLY_SPECIFIC(conv_desc)")
 
         if isinstance(border_mode, integer_types):
@@ -464,7 +470,7 @@ class GpuDnnConvDesc(COp):
 
 
 def gpu_dnn_conv_desc(border_mode, subsample=(1, 1), conv_mode='conv',
-                      precision="float32"):
+                      precision=prec_GpuDnn):
     key = (border_mode, subsample, conv_mode, precision)
     if key not in gpu_dnn_conv_desc.cache:
         gpu_dnn_conv_desc.cache[key] = GpuDnnConvDesc(border_mode,


### PR DESCRIPTION
Made changes in class GpuDnnConvDesc and gpu_dnn_conv_desc to enable handling of float64 values by using get_precision function