### PR TITLE
Prepare release 0.9.0rc3.

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -10,15 +10,15 @@ This release extends the 0.9.0rc2 and announces the upcoming final release 0.9.
 
 Highlights (since 0.9.0rc2):
  - Graph clean up and faster compilation
- - Removed warp-synchronous programming
  - New Theano flag conv.assert_shape
- - Fix precision in cuDNN
  - Fix overflow in pooling
- - Test fixes
- - Some useless optimizations are now marked as unsafe
  - Warn if taking softmax over broadcastable dimension
  - Removed old files not used anymore
+ - Test fixes and crash fixes
 
+ - New GPU back-end:
+
+   - Removed warp-synchronous programming, to get good results with newer CUDA drivers
 
 A total of 5 people contributed to this release since 0.9.0rc2 and 122 since 0.8.0, see the lists below.
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -3,6 +3,34 @@ Release Notes
 =============
 
 
+Theano 0.9.0rc3 (6th of March, 2017)
+====================================
+
+This release extends the 0.9.0rc2 and announces the upcoming final release 0.9.
+
+Highlights (since 0.9.0rc2):
+ - Graph clean up and faster compilation
+ - Removed warp-synchronous programming
+ - New Theano flag conv.assert_shape
+ - Fix precision in cuDNN
+ - Fix overflow in pooling
+ - Test fixes
+ - Some useless optimizations are now marked as unsafe
+ - Warn if taking softmax over broadcastable dimension
+ - Removed old files not used anymore
+
+
+A total of 5 people contributed to this release since 0.9.0rc2 and 122 since 0.8.0, see the lists below.
+
+
+Committers since 0.9.0rc2:
+ - Frederic Bastien
+ - Arnaud Bergeron
+ - Pascal Lamblin
+ - Florian Bordes
+ - Jan Schlüter
+
+
 Theano 0.9.0rc2 (27th of February, 2017)
 ========================================
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -10,7 +10,7 @@ This release extends the 0.9.0rc2 and announces the upcoming final release 0.9.
 
 Highlights (since 0.9.0rc2):
  - Graph clean up and faster compilation
- - New Theano flag conv.assert_shape to speed up compilation when we are not debugging
+ - New Theano flag conv.assert_shape to check user-provided shapes at runtime (for debugging)
  - Fix overflow in pooling
  - Warn if taking softmax over broadcastable dimension
  - Removed old files not used anymore

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -10,7 +10,7 @@ This release extends the 0.9.0rc2 and announces the upcoming final release 0.9.
 
 Highlights (since 0.9.0rc2):
  - Graph clean up and faster compilation
- - New Theano flag conv.assert_shape
+ - New Theano flag conv.assert_shape to speed up compilation when we are not debugging
  - Fix overflow in pooling
  - Warn if taking softmax over broadcastable dimension
  - Removed old files not used anymore

--- a/NEWS_DEV.txt
+++ b/NEWS_DEV.txt
@@ -45,6 +45,7 @@ Highlights:
    - better mapping between theano device number and nvidia-smi number, using the PCI bus ID of graphic cards
    - More pooling support on GPU when cuDNN isn't there
    - ignore_border=False is now implemented for pooling
+   - Removed warp-synchronous programming
 
 Interface changes:
  - In MRG, replaced method `multinomial_wo_replacement()` with new method `choice()`
@@ -78,6 +79,7 @@ GPU:
    for convolution backward filter operations
 
 New features:
+ - Added new Theano flag conv.assert_shape
  - OpFromGraph now allows gradient overriding for every input
  - Added Abstract Ops for batch normalization that use cuDNN when available and pure Theano CPU/GPU alternatives otherwise
  - Added new Theano flag cuda.enabled
@@ -102,9 +104,11 @@ Others:
  - More stack trace in error message
  - Speed up cholesky grad
  - log(sum(exp(...))) now get stability optimized
+ - Some useless optimizations are now marked as unsafe
 
 
 Other more detailed changes:
+ - Faster compilation and import with old CUDA backend
  - Use of 64-bit indexing in sparse ops to allow matrix with more then 2\ :sup:`31`\ -1 elements.
  - Allow more then one output to be an destructive inplace
  - Add flag profiling.ignore_first_call, useful to profile the new gpu back-end
@@ -119,6 +123,15 @@ Other more detailed changes:
 
 
 ALL THE PR BELLOW HAVE BEEN CHECKED
+* https://github.com/Theano/Theano/pull/5631
+* https://github.com/Theano/Theano/pull/5651
+* https://github.com/Theano/Theano/pull/5652
+* https://github.com/Theano/Theano/pull/5646
+* https://github.com/Theano/Theano/pull/5634
+* https://github.com/Theano/Theano/pull/5650
+* https://github.com/Theano/Theano/pull/5636
+* https://github.com/Theano/Theano/pull/5635
+* https://github.com/Theano/Theano/pull/5632
 * https://github.com/Theano/Theano/pull/5626
 * https://github.com/Theano/Theano/pull/5625
 * https://github.com/Theano/Theano/pull/5616

--- a/NEWS_DEV.txt
+++ b/NEWS_DEV.txt
@@ -122,6 +122,7 @@ Other more detailed changes:
 
 
 ALL THE PR BELLOW HAVE BEEN CHECKED
+* https://github.com/Theano/Theano/pull/5666
 * https://github.com/Theano/Theano/pull/5643
 * https://github.com/Theano/Theano/pull/5631
 * https://github.com/Theano/Theano/pull/5651

--- a/NEWS_DEV.txt
+++ b/NEWS_DEV.txt
@@ -122,6 +122,7 @@ Other more detailed changes:
 
 
 ALL THE PR BELLOW HAVE BEEN CHECKED
+* https://github.com/Theano/Theano/pull/5643
 * https://github.com/Theano/Theano/pull/5631
 * https://github.com/Theano/Theano/pull/5651
 * https://github.com/Theano/Theano/pull/5652

--- a/NEWS_DEV.txt
+++ b/NEWS_DEV.txt
@@ -104,11 +104,10 @@ Others:
  - More stack trace in error message
  - Speed up cholesky grad
  - log(sum(exp(...))) now get stability optimized
- - Some useless optimizations are now marked as unsafe
 
 
 Other more detailed changes:
- - Faster compilation and import with old CUDA backend
+ - Added new Theano flag nvcc.cudafe to enable faster compilation and import with old CUDA back-end
  - Use of 64-bit indexing in sparse ops to allow matrix with more then 2\ :sup:`31`\ -1 elements.
  - Allow more then one output to be an destructive inplace
  - Add flag profiling.ignore_first_call, useful to profile the new gpu back-end

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -74,7 +74,7 @@ copyright = '2008--2017, LISA lab'
 # The short X.Y version.
 version = '0.9'
 # The full version, including alpha/beta/rc tags.
-release = '0.9.0rc2'
+release = '0.9.0rc3'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/doc/index.txt
+++ b/doc/index.txt
@@ -21,6 +21,8 @@ learning/machine learning <https://mila.umontreal.ca/en/cours/>`_ classes).
 News
 ====
 
+* 2017/03/06: Release of Theano 0.9.0rc3, with crash fixes, bug fixes and improvements.
+
 * 2017/02/27: Release of Theano 0.9.0rc2, with crash fixes, bug fixes and improvements.
 
 * 2017/02/20: Release of Theano 0.9.0rc1, many improvements and bugfixes, final release to coming.

--- a/doc/introduction.txt
+++ b/doc/introduction.txt
@@ -165,7 +165,7 @@ Note: There is no short term plan to support multi-node computation.
 Theano Vision State
 ===================
 
-Here is the state of that vision as of February 27th, 2017 (after Theano 0.9.0rc2):
+Here is the state of that vision as of March 6th, 2017 (after Theano 0.9.0rc3):
 
 * We support tensors using the `numpy.ndarray` object and we support many operations on them.
 * We support sparse types by using the `scipy.{csc,csr,bsr}_matrix` object and support some operations on them.

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ PLATFORMS           = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"]
 MAJOR               = 0
 MINOR               = 9
 MICRO               = 0
-SUFFIX              = "rc2"  # Should be blank except for rc's, betas, etc.
+SUFFIX              = "rc3"  # Should be blank except for rc's, betas, etc.
 ISRELEASED          = False
 
 VERSION             = '%d.%d.%d%s' % (MAJOR, MINOR, MICRO, SUFFIX)


### PR DESCRIPTION
PR to prepare release `0.9.0rc3`.

**NB**: I have not added one of the last PRs ( about old backend: https://github.com/Theano/Theano/pull/5631 ) into the highlights, as we don't want anymore to put old backend forth. But I have added it into `NEWS_DEV.txt`.

I'll update the PR if needed.

@nouiz 