### PR TITLE
Optimization to remove upcast in local_cast_cast

### DIFF
--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -2225,7 +2225,7 @@ def local_cast_cast(node):
         # We don't need to copy over any stack traces here
         return [x]
 
-    if(upcast(base.dtype, type1.dtype)):
+    if(is_an_upcast(base.dtype, type1.dtype)):
         # Checking for further redundancy. Eg: int8 -> int32 -> int8
         if(type2.dtype == base.dtype):
             return x.owner.inputs
@@ -2237,17 +2237,23 @@ def local_cast_cast(node):
             return [v]
 
 
-def upcast(type1, type2):
+def is_an_upcast(type1, type2):
     """Given two data types (as strings), check if converting to
     type2 from type1 constitutes an upcast.
+    Differs from theano.scalar.upcast
 
     """
     category = {
-        # Pair of numbers : the 'super-index' and 'sub-index'
-        'uint8': (0, 0), 'uint16': (0, 1), 'uint32': (0, 2), 'uint64': (0, 3),
-        'int8': (1, 0), 'int16': (1, 1), 'int32': (1, 2), 'int64': (1, 3),
-        'float16': (2, 0.5), 'float32': (2, 1.5), 'float64': (2, 2.5),
-        'complex64': (3, 2), 'complex128': (3, 3)
+        # The first number in the pair is the dtype (bool, uint, int, float,
+        # complex). Conversion from higher to lower is never an upcast.
+        # The second number roughly indicates the precision. Again, conversion
+        # from higher to lower is never an upcast.
+
+        'bool': (0, 0),
+        'uint8': (1, 1), 'uint16': (1, 2), 'uint32': (1, 3), 'uint64': (1, 4),
+        'int8': (2, 1), 'int16': (2, 2), 'int32': (2, 3), 'int64': (2, 4),
+        'float16': (3, 1.5), 'float32': (3, 2.5), 'float64': (3, 3.5),
+        'complex64': (4, 3), 'complex128': (4, 4)
     }
 
     cat1 = category[type1]

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -2234,33 +2234,46 @@ def local_cast_cast(node):
             v = node.op(base)
             return [v]
 
+
 def upcast(type1, type2):
-    '''
-    Given two data types (as strings), check if converting to 
+    """Given two data types (as strings), check if converting to
     type2 from type1 constitutes an upcast.
-    '''
+
+    """
     upcast_pairs = (
-        ('int8','int16'),('int8','int32'),('int8','int64'),('int16','int32'),('int16','int64'),('int32','int64'),
-        ('uint8','uint16'),('uint8','uint32'),('uint8','uint64'),('uint16','uint32'),('uint16','uint64'),('uint32','uint64'),
-        ('float16','float32'),('float16','float32'),('float16','float64'),('float32','float64'),
-        ('complex64','complex128'),
+        ('int8', 'int16'), ('int8', 'int32'), ('int8', 'int64'),
+        ('int16', 'int32'), ('int16', 'int64'),
+        ('int32', 'int64'),
+        ('uint8', 'uint16'), ('uint8', 'uint32'), ('uint8', 'uint64'),
+        ('uint16', 'uint32'), ('uint16', 'uint64'),
+        ('uint32', 'uint64'),
+        ('float16', 'float32'), ('float16', 'float32'), ('float16', 'float64'),
+        ('float32', 'float64'),
+        ('complex64', 'complex128'),
 
-        ('uint8','int16'),('uint8','int32'),('uint8','int64'),('uint16','int32'),('uint16','int64'),('uint32','int64'),
-        ('int8','float16'),('int8','float32'),('int8','float64'),('int16','float32'),('int16','float64'),('int32','float64'),
-        ('uint8','float16'),('uint8','float32'),('uint8','float64'),('uint16','float32'),('uint16','float64'),('uint32','float64'),
+        ('uint8', 'int16'), ('uint8', 'int32'), ('uint8', 'int64'),
+        ('uint16', 'int32'), ('uint16', 'int64'),
+        ('uint32', 'int64'),
+        ('int8', 'float16'), ('int8', 'float32'), ('int8', 'float64'),
+        ('int16', 'float32'), ('int16', 'float64'),
+        ('int32', 'float64'),
+        ('uint8', 'float16'), ('uint8', 'float32'), ('uint8', 'float64'),
+        ('uint16', 'float32'), ('uint16', 'float64'),
+        ('uint32', 'float64'),
 
-        ('int8','complex64'),('int16','complex64'),
-        ('uint8','complex64'),('uint16','complex64'),
-        ('float32','complex64'),
-        ('int8','complex128'),('int16','complex128'),('int32','complex128'),
-        ('uint8','complex128'),('uint16','complex128'),('uint32','complex128'),
-        ('float32','complex128'),('float64','complex128')
+        ('int8', 'complex64'), ('int16', 'complex64'),
+        ('uint8', 'complex64'), ('uint16', 'complex64'),
+        ('float32', 'complex64'),
+        ('int8', 'complex128'), ('int16', 'complex128'), ('int32', 'complex128'),
+        ('uint8', 'complex128'), ('uint16', 'complex128'), ('uint32', 'complex128'),
+        ('float32', 'complex128'), ('float64', 'complex128')
     )
 
     for pair in upcast_pairs:
         if(type1 == pair[0] and type2 == pair[1]):
             return True
     return False
+
 
 @register_canonicalize
 @register_specialize

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -4658,7 +4658,7 @@ class T_cast_cast(unittest.TestCase):
         f(dx)
         topo = f.maker.fgraph.toposort()
         assert len(topo) == 1
-        assert isinstance(topo[0].op.scalar_op, scal.basic.Cast)
+        assert isinstance(topo[0].op, T.Elemwise)
 
         x = T.dmatrix()
         o = T.Elemwise(scal.Cast(scal.Scalar("float32")))(x.astype("float32"))
@@ -4667,7 +4667,7 @@ class T_cast_cast(unittest.TestCase):
         f(dx)
         topo = f.maker.fgraph.toposort()
         assert len(topo) == 1
-        assert isinstance(topo[0].op.scalar_op, scal.basic.Cast)
+        assert isinstance(topo[0].op, T.Elemwise)
 
     def test_upcast(self):
         # Upcast followed by any other cast
@@ -4691,14 +4691,14 @@ class T_cast_cast(unittest.TestCase):
         assert isinstance(topo[0].op, DeepCopyOp)
 
         # Downcast followed by an upcast back to the base type
+        # Optimization shouldn't be applied
         x = T.dmatrix()
         o = T.Elemwise(scal.Cast(scal.Scalar("float64")))(x.astype("float32"))
         f = theano.function([x], o, mode=self.mode)
         dx = numpy.random.rand(5, 4)
         f(dx)
         topo = f.maker.fgraph.toposort()
-        assert len(topo) == 1
-        assert isinstance(topo[0].op.scalar_op, scal.basic.Composite)
+        assert (len(topo) == 1 and isinstance(topo[0].op.scalar_op, scal.basic.Composite)) or (len(topo) > 1)
 
 
 class T_func_inverse(unittest.TestCase):

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -4658,7 +4658,7 @@ class T_cast_cast(unittest.TestCase):
         f(dx)
         topo = f.maker.fgraph.toposort()
         assert len(topo) == 1
-       assert isinstance(topo[0].op.scalar_op, scal.basic.Cast)
+        assert isinstance(topo[0].op.scalar_op, scal.basic.Cast)
 
         x = T.dmatrix()
         o = T.Elemwise(scal.Cast(scal.Scalar("float32")))(x.astype("float32"))

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -4650,7 +4650,7 @@ class T_cast_cast(unittest.TestCase):
         mode = theano.compile.get_default_mode()
         self.mode = mode.including('local_cast_cast')
 
-    def test(self):
+    def test_consecutive(self):
         x = T.fmatrix()
         o = T.Elemwise(scal.Cast(scal.Scalar("float64")))(x.astype("float64"))
         f = theano.function([x], o, mode=self.mode)
@@ -4658,7 +4658,7 @@ class T_cast_cast(unittest.TestCase):
         f(dx)
         topo = f.maker.fgraph.toposort()
         assert len(topo) == 1
-        assert isinstance(topo[0].op, T.Elemwise)
+        assert isinstance(topo[0].op.scalar_op, scal.basic.Cast)
 
         x = T.dmatrix()
         o = T.Elemwise(scal.Cast(scal.Scalar("float32")))(x.astype("float32"))
@@ -4667,7 +4667,38 @@ class T_cast_cast(unittest.TestCase):
         f(dx)
         topo = f.maker.fgraph.toposort()
         assert len(topo) == 1
-        assert isinstance(topo[0].op, T.Elemwise)
+        assert isinstance(topo[0].op.scalar_op, scal.basic.Cast)
+
+    def test_upcast(self):
+        # Upcast followed by any other cast
+        x = T.fmatrix()
+        o = T.Elemwise(scal.Cast(scal.Scalar("complex128")))(x.astype("complex64"))
+        f = theano.function([x], o, mode=self.mode)
+        dx = numpy.random.rand(5, 4).astype("float32")
+        f(dx)
+        topo = f.maker.fgraph.toposort()
+        assert len(topo) == 1
+        assert isinstance(topo[0].op.scalar_op, scal.basic.Cast)
+
+        # Upcast followed by a downcast back to the base type
+        x = T.fmatrix()
+        o = T.Elemwise(scal.Cast(scal.Scalar("float32")))(x.astype("float64"))
+        f = theano.function([x], o, mode=self.mode)
+        dx = numpy.random.rand(5, 4).astype('float32')
+        f(dx)
+        topo = f.maker.fgraph.toposort()
+        assert len(topo) == 1
+        assert isinstance(topo[0].op, DeepCopyOp)
+
+        # Downcast followed by an upcast back to the base type
+        x = T.dmatrix()
+        o = T.Elemwise(scal.Cast(scal.Scalar("float64")))(x.astype("float32"))
+        f = theano.function([x], o, mode=self.mode)
+        dx = numpy.random.rand(5, 4)
+        f(dx)
+        topo = f.maker.fgraph.toposort()
+        assert len(topo) == 1
+        assert isinstance(topo[0].op.scalar_op, scal.basic.Composite)
 
 
 class T_func_inverse(unittest.TestCase):

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -4658,7 +4658,7 @@ class T_cast_cast(unittest.TestCase):
         f(dx)
         topo = f.maker.fgraph.toposort()
         assert len(topo) == 1
-        assert isinstance(topo[0].op, T.Elemwise)
+       assert isinstance(topo[0].op.scalar_op, scal.basic.Cast)
 
         x = T.dmatrix()
         o = T.Elemwise(scal.Cast(scal.Scalar("float32")))(x.astype("float32"))
@@ -4667,7 +4667,7 @@ class T_cast_cast(unittest.TestCase):
         f(dx)
         topo = f.maker.fgraph.toposort()
         assert len(topo) == 1
-        assert isinstance(topo[0].op, T.Elemwise)
+        assert isinstance(topo[0].op.scalar_op, scal.basic.Cast)
 
     def test_upcast(self):
         # Upcast followed by any other cast


### PR DESCRIPTION
fix #949
I've made a list of pairs of data types that would constitute an upcast, in **opt.py** in the function _upcast_
Function _local_cast_cast_ has been updated accordingly.