### PR TITLE
docs: Fix openmp config section

### DIFF
--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -253,13 +253,12 @@ import theano and print the config variable, as in:
 
     Bool value: either ``True`` or ``False``
 
-    Default: ``True`` if the environment variable OMP_NUM_THREADS!=1 or
-             if we detect more than 1 CPU core. Otherwise ``False``.
+    Default: ``False``
 
-    Enable or not parallel computation on the CPU with OpenMP.
-    It is the default value used when creating an Op that support it.
-    The best is to define it via Theano configuration
-    file or with the environment variable THEANO_FLAGS.
+    Enable or disable parallel computation on the CPU with OpenMP.
+    It is the default value used when creating an Op that supports it.
+    It is best to define it in .theanorc
+    or in the environment variable THEANO_FLAGS.
 
 .. attribute:: openmp_elemwise_minsize
 


### PR DESCRIPTION
- openmp has been disabled by default since https://github.com/Theano/Theano/commit/f1f06bb960f63e098a7ce32de50c8547d2fb7713.
- grammar improvements