### PR TITLE
Implement new op param type `EnumType`

### DIFF
--- a/theano/gof/__init__.py
+++ b/theano/gof/__init__.py
@@ -55,6 +55,8 @@ from theano.gof.link import \
 from theano.gof.op import \
     Op, OpenMPOp, PureOp, COp, ops_with_inner_function
 
+from theano.gof.type import EnumType, EnumList
+
 from theano.gof.opt import (
     Optimizer,
     optimizer, inplace_optimizer,

--- a/theano/gof/__init__.py
+++ b/theano/gof/__init__.py
@@ -55,7 +55,7 @@ from theano.gof.link import \
 from theano.gof.op import \
     Op, OpenMPOp, PureOp, COp, ops_with_inner_function
 
-from theano.gof.type import EnumType, EnumList
+from theano.gof.type import EnumType, EnumList, CEnumType
 
 from theano.gof.opt import (
     Optimizer,

--- a/theano/gof/tests/test_types.py
+++ b/theano/gof/tests/test_types.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, print_function, division
 import numpy as np
 
 import theano
-from theano import Op, Apply
+from theano import Op, Apply, scalar
 from theano.tensor import TensorType
-from theano.gof.type import CDataType
+from theano.gof.type import CDataType, EnumType, EnumList
 
 from nose.plugins.skip import SkipTest
 
@@ -76,3 +76,118 @@ def test_cdata():
 
     v2 = f(v)
     assert (v2 == v).all()
+
+
+class TestOpEnumList(Op):
+    __props__ = ('op_chosen',)
+    params_type = EnumList('ADD', 'SUB', 'MULTIPLY', 'DIVIDE')
+
+    def __init__(self, choose_op):
+        assert self.params_type.ADD == 0
+        assert self.params_type.SUB == 1
+        assert self.params_type.MULTIPLY == 2
+        assert self.params_type.DIVIDE == 3
+        op_to_const = {'+': self.params_type.ADD,
+                       '-': self.params_type.SUB,
+                       '*': self.params_type.MULTIPLY,
+                       '/': self.params_type.DIVIDE}
+        self.op_chosen = op_to_const[choose_op]
+
+    def get_params(self, node):
+        return self.op_chosen
+
+    def make_node(self, a, b):
+        return Apply(self, [scalar.as_scalar(a), scalar.as_scalar(b)], [scalar.float64()])
+
+    def perform(self, node, inputs, outputs, op):
+        a, b = inputs
+        o, = outputs
+        if op == self.params_type.ADD:
+            o[0] = a + b
+        elif op == self.params_type.SUB:
+            o[0] = a - b
+        elif op == self.params_type.MULTIPLY:
+            o[0] = a * b
+        elif op == self.params_type.DIVIDE:
+            o[0] = a / b
+        else:
+            raise NotImplementedError('Unknown op id ' + str(op))
+
+    def c_code_cache_version(self):
+        return (1,)
+
+    def c_code(self, node, name, inputs, outputs, sub):
+        a, b = inputs
+        o, = outputs
+        fail = sub['fail']
+        op = sub['params']
+        return """
+        switch((int)%(op)s) {
+            case ADD:
+                %(o)s = %(a)s + %(b)s;
+                break;
+            case SUB:
+                %(o)s = %(a)s - %(b)s;
+                break;
+            case MULTIPLY:
+                %(o)s = %(a)s * %(b)s;
+                break;
+            case DIVIDE:
+                %(o)s = %(a)s / %(b)s;
+                break;
+            default:
+                {%(fail)s}
+                break;
+        }
+        """ % locals()
+
+
+def test_enum():
+    # Check that invalid enum name raises exception.
+    for invalid_name in ('a', '_A', '0'):
+        try:
+            EnumList(invalid_name)
+        except AttributeError:
+            pass
+        else:
+            raise Exception('EnumList with invalid name should faild.')
+
+        try:
+            EnumType(**{invalid_name: 0})
+        except AttributeError:
+            pass
+        else:
+            raise Exception('EnumType with invalid name should fail.')
+
+    # Check that invalid enum value raises exception.
+    try:
+        EnumType(INVALID_VALUE='string is not allowe.')
+    except ValueError:
+        pass
+    else:
+        raise Exception('EnumType with invalid value should fail.')
+
+    # Check EnumType.
+    e1 = EnumType(C1=True, C2=12, C3=True, C4=-1, C5=False, C6=0.0)
+    e2 = EnumType(C1=1, C2=12, C3=1, C4=-1.0, C5=0.0, C6=0)
+    assert e1 == e2
+    assert not (e1 != e2)
+    assert hash(e1) == hash(e2)
+
+    # Test an op with EnumList.
+    a = scalar.int32()
+    b = scalar.int32()
+    c_add = TestOpEnumList('+')(a, b)
+    c_sub = TestOpEnumList('-')(a, b)
+    c_multiply = TestOpEnumList('*')(a, b)
+    c_divide = TestOpEnumList('/')(a, b)
+    f = theano.function([a, b], [c_add, c_sub, c_multiply, c_divide])
+    va = 12
+    vb = 15
+    ref_add = va + vb
+    ref_sub = va - vb
+    ref_multiply = va * vb
+    ref_divide = va // vb
+    ref = [ref_add, ref_sub, ref_multiply, ref_divide]
+    out = f(va, vb)
+    assert ref == out, (ref, out)

--- a/theano/gof/tests/test_types.py
+++ b/theano/gof/tests/test_types.py
@@ -117,7 +117,7 @@ class TestOpEnumList(Op):
             raise NotImplementedError('Unknown op id ' + str(op))
 
     def c_code_cache_version(self):
-        return None
+        return (1,)
 
     def c_code(self, node, name, inputs, outputs, sub):
         a, b = inputs
@@ -125,7 +125,7 @@ class TestOpEnumList(Op):
         fail = sub['fail']
         op = sub['params']
         return """
-        switch((int)%(op)s) {
+        switch(%(op)s) {
             case ADD:
                 %(o)s = %(a)s + %(b)s;
                 break;
@@ -175,14 +175,14 @@ class TestOpCEnumType(Op):
         return Apply(self, [], [scalar.uint32()])
 
     def c_code_cache_version(self):
-        return None
+        return (1,)
 
     def c_code(self, node, name, inputs, outputs, sub):
         o, =  outputs
-        ctype_index = sub['params']
+        # params in C code will already contains expected C constant value.
+        sizeof_ctype = sub['params']
         return """
-        /* ctype_index already contains expected C constant value. */
-        %(o)s = %(ctype_index)s;
+        %(o)s = %(sizeof_ctype)s;
         """ % locals()
 
 
@@ -205,7 +205,7 @@ def test_enum_class():
 
     # Check that invalid enum value raises exception.
     try:
-        EnumType(INVALID_VALUE='string is not allowe.')
+        EnumType(INVALID_VALUE='string is not allowed.')
     except ValueError:
         pass
     else:
@@ -220,7 +220,6 @@ def test_enum_class():
 
 
 def test_op_with_enumlist():
-    # Test an op with EnumList.
     a = scalar.int32()
     b = scalar.int32()
     c_add = TestOpEnumList('+')(a, b)
@@ -241,4 +240,4 @@ def test_op_with_cenumtype():
     sizeof_long_long = TestOpCEnumType('long long')()
     f = theano.function([], [sizeof_int, sizeof_float, sizeof_long_long])
     out = f()
-    print('(sizeof(int): ', out[0], ', sizeof(float): ', out[1], ', sizeof(long long): ', out[2], ') ', sep='', end='')
+    print('(sizeof(int): ', out[0], ', sizeof(float): ', out[1], ', sizeof(long long): ', out[2], ') ', sep='')

--- a/theano/gof/type.py
+++ b/theano/gof/type.py
@@ -920,7 +920,8 @@ class EnumType(Type, dict):
         return a == b
 
     def values_eq_approx(self, a, b):
-        return float(a) == float(b)
+        # For an enum, it does not have a meaning to be approx equal.
+        return self.values_eq(a, b)
 
     pyint_compat_code = """
     #if PY_MAJOR_VERSION >= 3

--- a/theano/gof/type.py
+++ b/theano/gof/type.py
@@ -922,22 +922,20 @@ class EnumType(Type, dict):
     def values_eq_approx(self, a, b):
         return float(a) == float(b)
 
-    @staticmethod
-    def c_support_macro_code():
-        return """
-        #if PY_MAJOR_VERSION >= 3
-            #ifndef PyInt_Check
-                #define PyInt_Check PyLong_Check
-            #endif
-            #ifndef PyInt_AsLong
-                #define PyInt_AsLong PyLong_AsLong
-            #endif
+    pyint_compat_code = """
+    #if PY_MAJOR_VERSION >= 3
+        #ifndef PyInt_Check
+            #define PyInt_Check PyLong_Check
         #endif
-        """
+        #ifndef PyInt_AsLong
+            #define PyInt_AsLong PyLong_AsLong
+        #endif
+    #endif
+    """
 
     def c_support_code(self):
         return (
-            self.c_support_macro_code() +
+            self.pyint_compat_code +
             ''.join("""
             #define %s %s
             """ % (k, str(self[k])) for k in sorted(self.keys()))
@@ -1030,7 +1028,7 @@ class CEnumType(EnumList):
     """
 
     def c_support_code(self):
-        return self.c_support_macro_code()
+        return self.pyint_compat_code
 
     def c_extract(self, name, sub, check_input=True):
         swapped_dict = dict((v, k) for (k, v) in self.items())

--- a/theano/gof/type.py
+++ b/theano/gof/type.py
@@ -813,46 +813,44 @@ CDataType.Constant = CDataTypeConstant
 
 class EnumType(Type, dict):
     """
-    Class that allows to create enumerations of constant values.
+    Op parameter class that allows to create enumerations of constant values.
 
      - Constants are available as object attributes in Python code and as macro-defined constants in C code.
      - Constants can be floating values, integers, or booleans (automatically converted to integers).
      - Constants name must start with a capital letter and contain capital letters, underscores or digits.
 
-    This type is intended to be used as op parameter type.
-
     Example::
 
-        enum = EnumType(CONSTANT_1=0, CONSTANT_2=1, CONSTANT_3=2.5, CONSTANT_4=False, CONSTANT_5=True)
-        print (enum.CONSTANT_1, enum.CONSTANT_2, enum.CONSTANT_3, enum.CONSTANT_4, enum.CONSTANT_5)
-        # will print 0 1 2.5 0 1
+        enum = EnumType(CONSTANT_1=1, CONSTANT_2=2.5, CONSTANT_3=False, CONSTANT_4=True)
+        print (enum.CONSTANT_1, enum.CONSTANT_2, enum.CONSTANT_3, enum.CONSTANT_4)
+        # will print 1 2.5 0 1
 
     In C code:
 
     .. code-block:: c
 
         int constant_1 = CONSTANT_1;
-        int constant_2 = CONSTANT_2;
-        double constant_3 = CONSTANT_3;
-        int constant_4 = CONSTANT_4; // constant_4 == 0
-        int constant_5 = CONSTANT_5; // constant_5 == 1
+        double constant_2 = CONSTANT_2;
+        int constant_3 = CONSTANT_3; // constant_3 == 0
+        int constant_4 = CONSTANT_4; // constant_4 == 1
 
-    You can also specify a C type if you want to use an op param to handle these enum values.
+    You can also specify a C type for the op param if you want to pass one of these constant values at runtime.
     Default C type is ``double``.
 
     .. code-block:: python
 
         enum = EnumType(CONSTANT_1=0, CONSTANT_2=1, CONSTANT_3=2, ctype='size_t')
+        op_param_value = enum.CONSTANT_1
 
     In C code:
 
     .. code-block:: c
 
-        size_t op_param = CONSTANT_1;
+        size_t value = op_param_value; // contains enum.CONSTANT_1, i.e 0
 
     .. note::
 
-        This Type is not complete and should never be used for regular graph operations.
+        This Type (and subclasses) is not complete and should never be used for regular graph operations.
 
     """
 
@@ -971,7 +969,7 @@ class EnumType(Type, dict):
 
 class EnumList(EnumType):
     """
-    Class that allows to create enumeration of constant values.
+    Op parameter class that allows to create enumeration of constant values.
     Same as :class:`EnumType`, but automatically gives an unique integer value for each constant in a list of
     constants names (constant at index ``i`` in the list will receive value ``i``,
     with ``i`` from ``0`` to ``len(constants) - 1``).
@@ -982,10 +980,12 @@ class EnumList(EnumType):
         print (enum.CONSTANT_1, enum.CONSTANT_2, enum.CONSTANT_3, enum.CONSTANT_4, enum.CONSTANT_5)
         # will print: 0 1 2 3 4
 
-    Like :class:`EnumType`, you can also define the C type for a variable able to handle these enum values.
+    Like :class:`EnumType`, you can also define the C type for the op param.
     Default C type is ``int``::
 
         enum = EnumList('CONSTANT_1', 'CONSTANT_2', 'CONSTANT_3', 'CONSTANT_4', ctype='unsigned int')
+
+    See test class :class:`theano.gof.tests.test_types.TestOpEnumList` for a working example.
 
     """
 
@@ -1004,7 +1004,7 @@ class EnumList(EnumType):
 
 class CEnumType(EnumList):
     """
-    Class that allows to create enumeration of constant values that represent C-defined constants.
+    Op parameter class that allows to create enumeration of constant values that represent C-defined constants.
 
      - Constant should have same names as in C.
      - In Python, constants will have arbitrary-defined values.
@@ -1012,17 +1012,19 @@ class CEnumType(EnumList):
      - In C code, the real values defined in C will be used.
        They could be used either for choices or for its real values.
 
-    Like :class:`EnumList`, you can also define the C type for a variable able to handle these enum values.
+    Like :class:`EnumList`, you can also define the C type for the op param.
     Default C type is ``int``.
 
     .. code-block:: python
 
         enum = CEnumType('CONSTANT_CNAME_1', 'CONSTANT_CNAME_2', 'CONSTANT_CNAME_3', ctype='long')
 
+    See test class :class:`theano.gof.tests.test_types.TestOpCEnumType` for a working example.
+
     .. note::
 
         Be sure C constants are available in your C code. If they come from a C header, consider implementing
-        ``c_headers()`` and ``c_header_dirs()`` in the Op class which you use CEnumType as op parameters type.
+        ``c_headers()`` and ``c_header_dirs()`` in the Op class where you use CEnumType as op parameter type.
 
     """
 


### PR DESCRIPTION
This PR suggests a new abstract attribute `enum` added into COp to define enumerations of constants that will be automatically converted into C macros by `COp.get_op_params()` method.

This should help to reduce C code of some C-ops, for example with GpuDnnSoftmax, as we could then define a fixed-list of constants (that won't change from an op instance to another), and then use an op param that takes a runtime value within this list of constants.

The PR also adds two functions to help create enums quickly, and a test for this new feature.

@nouiz @abergeron  @lamblin 