### PR TITLE
Softmax improvement

### DIFF
--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -447,7 +447,7 @@ class Softmax(gof.Op):
         # is the same as the grad
         if None in eval_points:
             return [None]
-        return self.grad(inputs, eval_points)
+        return self.L_op(inputs, [self(*inputs)], eval_points)
 
     def infer_shape(self, node, shape):
         return shape


### PR DESCRIPTION
Ref to #5712 

- Some modifications to Softmax and GradSoftmax to allow a N-dimensional array as input and apply the softmax operation on the last dimension.

For the next commits, I will need to add and change some tests in test_nnet.py. With the new implementation if the input is a vector, the output will be a vector. Currently the tests consider the fact that the softmax give a matrix if the input is a vector, so the test will crash in those cases.