### PR TITLE
Open tempfile in mode 'w' to prevent TypeError

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -2302,6 +2302,7 @@ class GCC_compiler(Compiler):
 
         if status:
             tf = tempfile.NamedTemporaryFile(
+                mode='w',
                 prefix='theano_compilation_error_',
                 delete=False
             )


### PR DESCRIPTION
For printing compilation errors, a NamedTemporaryFile object is opened in the default mode ('w+b'), and strings are written to it. This is not an issue in Python 2, but in Python 3, strings cannot be implicitly converted to bytes so a TypeError occurs on line 2310 (previously 2309). This commit explicitly opens the NamedTemporaryFile in mode 'w'.

Here's a minimal example to reproduce the error (on Python 3):
```
>>> import tempfile
>>> tf = tempfile.TemporaryFile()
>>> tf.write('=\n')
...
TypeError: a bytes-like object is required, not 'str'