### PR TITLE
Add conv2d transpose2doc

### DIFF
--- a/doc/library/tensor/nnet/conv.txt
+++ b/doc/library/tensor/nnet/conv.txt
@@ -219,13 +219,13 @@ TODO: Give examples on how to use these things! They are pretty complicated.
       It flip the kernel.
 
 .. autofunction:: theano.tensor.nnet.conv2d
+.. autofunction:: theano.tensor.nnet.conv2d_transpose
 .. autofunction:: theano.tensor.nnet.conv3d
 .. autofunction:: theano.sandbox.cuda.fftconv.conv2d_fft
 .. autofunction:: theano.tensor.nnet.Conv3D.conv3D
 .. autofunction:: theano.sandbox.cuda.fftconv.conv3d_fft
 .. autofunction:: theano.tensor.nnet.conv3d2d.conv3d
 .. autofunction:: theano.tensor.nnet.conv.conv2d
-.. autofunction:: theano.tensor.nnet.conv2d_transpose
 
 .. automodule:: theano.tensor.nnet.abstract_conv
     :members:

--- a/doc/library/tensor/nnet/conv.txt
+++ b/doc/library/tensor/nnet/conv.txt
@@ -225,6 +225,7 @@ TODO: Give examples on how to use these things! They are pretty complicated.
 .. autofunction:: theano.sandbox.cuda.fftconv.conv3d_fft
 .. autofunction:: theano.tensor.nnet.conv3d2d.conv3d
 .. autofunction:: theano.tensor.nnet.conv.conv2d
+.. autofunction:: theano.tensor.nnet.conv2d_transpose
 
 .. automodule:: theano.tensor.nnet.abstract_conv
     :members:


### PR DESCRIPTION
Fix #5663 

I have added a line to doc/library/tensor/nnet/conv.txt in order to generate documentation for conv2d_transpose.