### PR TITLE
Fix out-of-date link to sympy

### DIFF
--- a/doc/introduction.txt
+++ b/doc/introduction.txt
@@ -228,7 +228,7 @@ theano-dev_ mailing list.
 .. _numpy: http://numpy.scipy.org/
 .. _BLAS: http://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms
 
-.. _sympy: http://code.google.com/p/sympy/
+.. _sympy: http://www.sympy.org/
 .. _MATLAB: http://www.mathworks.com/products/matlab/
 .. _Mathematica: http://www.wolfram.com/products/mathematica/index.html
 


### PR DESCRIPTION
I just noticed that the current link to `sympy` in the docs is pointing to a dead Google Code site. This just updates the link to the current webpage.

Feel free to close this if you have some other way you prefer to make documentation updates.