### PR TITLE
Print compilation count for all compiled Op classes with "theano-cache list" command

### DIFF
--- a/theano/gof/compiledir.py
+++ b/theano/gof/compiledir.py
@@ -101,6 +101,7 @@ def print_compiledir_content():
 
     compiledir = theano.config.compiledir
     table = []
+    table_op_class = {}
     more_than_one_ops = 0
     zeros_op = 0
     big_key_files = []
@@ -115,6 +116,10 @@ def print_compiledir_content():
                 keydata = pickle.load(file)
                 ops = list(set([x for x in flatten(keydata.keys)
                                 if isinstance(x, theano.gof.Op)]))
+                # Whatever the case, we count compilations for OP classes.
+                for op_class in set([op.__class__ for op in ops]):
+                    table_op_class.setdefault(op_class, 0)
+                    table_op_class[op_class] += 1
                 if len(ops) == 0:
                     zeros_op += 1
                 elif len(ops) > 1:
@@ -147,14 +152,11 @@ def print_compiledir_content():
         len(table), compiledir))
     print("sub dir/compiletime/Op/set of different associated Theano types")
     table = sorted(table, key=lambda t: str(t[1]))
-    table_op_class = {}
     for dir, op, types, compile_time in table:
         print(dir, '%.3fs' % compile_time, op, types)
-        table_op_class.setdefault(op.__class__, 0)
-        table_op_class[op.__class__] += 1
 
     print()
-    print(("List of %d individual compiled Op classes and "
+    print(("List of %d compiled Op classes and "
            "the number of times they got compiled" % len(table_op_class)))
     table_op_class = sorted(iteritems(table_op_class), key=lambda t: t[1])
     for op_class, nb in table_op_class:

--- a/theano/gpuarray/type.py
+++ b/theano/gpuarray/type.py
@@ -209,8 +209,23 @@ class GpuArrayType(Type):
         return get_context(self.context_name)
 
     def __repr__(self):
-        return "GpuArrayType<%s>(%s, %s)" % (self.context_name, self.dtype,
-                                             self.broadcastable)
+        # Inspired from TensorType.
+        if self.name:
+            return self.name
+        else:
+            b = self.broadcastable
+            named_broadcastable = {tuple(): 'scalar',
+                                   (False,): 'vector',
+                                   (False, True): 'col',
+                                   (True, False): 'row',
+                                   (False, False): 'matrix'}
+            if b in named_broadcastable:
+                bcast = named_broadcastable[b]
+            elif any(b):
+                bcast = str(b)
+            else:
+                bcast = '%iD' % len(b)
+            return "GpuArrayType<%s>(%s, %s)" % (self.context_name, self.dtype, bcast)
 
     def filter(self, data, strict=False, allow_downcast=None):
         return self.filter_inplace(data, None, strict=strict,

--- a/theano/tensor/type.py
+++ b/theano/tensor/type.py
@@ -373,7 +373,6 @@ class TensorType(Type):
 
     def __repr__(self):
         return str(self)
-        # "TensorType{%s, %s}" % (str(self.dtype), str(self.broadcastable))
 
     def c_declare(self, name, sub, check_input=True):
         """


### PR DESCRIPTION
Currently, command `theano-cache list` skips modules that contains more than 1 Op. This does not help to track variations in compilation counts when we want to reduce C code procuded by Theano.

This PR updates the printing so that the number of compilations is printed for ALL compiled Op classes, and not only for individual compiled Op classes as it is currenty.

I have also updated `repr(GpuArrayType)` so that it looks more like `repr(TensorType)` (e.g. when `(False, False)` is replace with `matrix`), to help reduce length of printed lines.

@nouiz @lamblin .


**PS**: Example of printing with this PR. I am working on `GpuImages2Neibs`. As I have reduced its C code, it does not appear anymore in list of individual Ops at top of printing (because many different Op instances are associated to only 1 C module code from now). With this PR, I can see compilation count for this class in the second printed list.

```
List of 106 compiled individual ops in this theano cache /home/notoraptor/.theano/compiledir_Linux-4.4--generic-x86_64-with-debian-stretch-sid-x86_64-2.7.13-64:
sub dir/compiletime/Op/set of different associated Theano types
tmpU1Wq7g 1.644s Alloc [TensorType(float64, scalar), TensorType(int64, scalar), TensorType(int32, scalar)]
tmpcT9imo 1.572s Alloc [TensorType(float64, scalar), TensorType(int64, scalar), TensorType(int32, scalar)]
tmp2atct0 1.392s Elemwise{Add}[(0, 0)] [TensorType(int64, scalar)]
tmpy3FSoJ 1.460s Elemwise{Add}[(0, 1)] [TensorType(int64, scalar)]
tmpHZ58bV 1.332s Elemwise{Cast{int32}} [TensorType(int64, scalar)]
tmpipUT67 1.612s Elemwise{Composite{(((i0 - maximum(i1, i2)) - i3) + maximum(i4, i5))}}[(0, 0)] [TensorType(int64, scalar), TensorType(int8, scalar)]
tmpIIIQcC 1.800s Elemwise{Composite{((Cast{int64}(NEQ((i0 % i1), i2)) + (i0 // i1)) * (Cast{int64}(NEQ((i3 % i1), i2)) + (i3 // i1)) * i4 * i5)}}[(0, 0)] [TensorType(int64, scalar), TensorType(int8, scalar)]
tmpcY_TJt 2.036s Elemwise{Composite{((i0 * (i1 + ((i2 - i3) // i3)) * (i1 + ((i4 + i5) // i0)) * i3) // (-(i6 * i7 * i8 * i9)))}}[(0, 2)] [TensorType(int64, scalar), TensorType(int32, scalar)]
tmp5waLmg 2.060s Elemwise{Composite{((i0 * (i1 + ((i2 - i3) // i3)) * (i1 + ((i4 + i5) // i0)) * i3) // (i4 * i6 * i7 * i8 * i9))}}[(0, 2)] [TensorType(int64, scalar)]
tmp3e6EJm 2.728s Elemwise{Composite{((i0 + ((i1 + i2) // i3)) * (i0 + ((i1 + i4) // i3)) * i5 * i6)}}[(0, 2)] [TensorType(int64, scalar)]
tmpgGrxQg 3.056s Elemwise{Composite{((i0 + ((i1 + i2) // i3)) * (i0 + ((i4 + i5) // i6)) * i7 * i8)}}[(0, 2)] [TensorType(int64, scalar)]
tmpjTqSzs 1.776s Elemwise{Composite{((i0 + ((i1 + i2) // i3)) * (i0 + ((i4 + i5) // i6)))}}[(0, 2)] [TensorType(int64, scalar)]
tmpm9NQAt 1.792s Elemwise{Composite{((i0 + ((i1 + i2) // i3)) * i4 * i5 * i6)}}[(0, 2)] [TensorType(int64, scalar)]
tmp1QuJbS 1.600s Elemwise{Composite{((maximum(i0, i1) - Switch(LT(i2, i3), (i2 + i4), i2)) + i1)}}[(0, 2)] [TensorType(int64, scalar), TensorType(int8, scalar)]
tmpZK3Ygt 1.576s Elemwise{Composite{(Switch(EQ(i0, i1), i2, i0) + Cast{int64}(i3))}}[(0, 2)] [TensorType(int64, scalar), TensorType(int8, scalar), TensorType(int32, scalar)]
tmpmzOElP 1.512s Elemwise{Composite{(Switch(EQ(i0, i1), i2, i0) + i3)}}[(0, 0)] [TensorType(int64, scalar), TensorType(int8, scalar)]
tmpakKQF6 1.528s Elemwise{Composite{(Switch(LT(maximum(i0, i1), i2), (maximum(i0, i1) + i3), (maximum(i0, i1) - i2)) + i4)}}[(0, 0)] [TensorType(int64, scalar), TensorType(int8, scalar)]
tmpG4vL0g 1.412s Elemwise{Composite{(i0 * (i1 // i0))}} [TensorType(int64, scalar), TensorType(int32, scalar)]
tmpPAbA80 1.460s Elemwise{Composite{(i0 * (i1 // i0))}} [TensorType(int64, scalar)]
tmpW6M3Vy 1.548s Elemwise{Composite{(i0 + ((i1 + i2) // i3))}} [TensorType(int64, scalar)]
tmpBvTgpT 1.456s Elemwise{Composite{Switch(EQ(i0, i1), i2, i0)}} [TensorType(int64, scalar), TensorType(int8, scalar)]
tmpkKc4J4 1.480s Elemwise{Composite{Switch(EQ(i0, i1), i2, i0)}} [TensorType(int64, scalar), TensorType(int8, scalar), TensorType(int32, scalar)]
tmpQYpwi4 1.452s Elemwise{Composite{Switch(EQ(i0, i1), i2, i0)}}[(0, 0)] [TensorType(int64, scalar), TensorType(int8, scalar)]
tmpXX7n6H 1.696s Elemwise{Composite{Switch(LT((i0 - Composite{Switch(LT(i0, i1), i0, i1)}(i1, i2)), i3), (i4 - i0), Switch(GE((i0 - Composite{Switch(LT(i0, i1), i0, i1)}(i1, i2)), (i2 - Composite{Switch(LT(i0, i1), i0, i1)}(i1, i2))), (i5 + i0), Switch(LE((i2 - Composite{Switch(LT(i0, i1), i0, i1)}(i1, i2)), i3), (i5 + i0), i0)))}} [TensorType(int64, scalar), TensorType(int8, scalar)]
tmpNGyqix 1.716s Elemwise{Composite{Switch(LT((i0 - Composite{Switch(LT(i0, i1), i0, i1)}(i1, i2)), i3), (i4 - i0), Switch(GE((i0 - Composite{Switch(LT(i0, i1), i0, i1)}(i1, i2)), (i2 - Composite{Switch(LT(i0, i1), i0, i1)}(i1, i2))), i5, Switch(LE((i2 - Composite{Switch(LT(i0, i1), i0, i1)}(i1, i2)), i3), i5, i0)))}}[(0, 5)] [TensorType(int64, scalar), TensorType(int8, scalar)]
tmpbmOApL 1.460s Elemwise{Composite{Switch(LT(i0, i1), (i0 + i2), i0)}} [TensorType(int64, scalar), TensorType(int8, scalar)]
tmp5_PzKN 1.552s Elemwise{Composite{Switch(i0, Switch(LT((i1 + i2), i3), i3, (i1 + i2)), Switch(LT(i1, i2), i1, i2))}} [TensorType(bool, scalar), TensorType(int8, scalar), TensorType(int64, scalar)]
tmp8JFMyW 1.548s Elemwise{Composite{Switch(i0, Switch(LT((i1 + i2), i3), i3, (i1 + i2)), Switch(LT(i2, i1), i2, i1))}} [TensorType(bool, scalar), TensorType(int8, scalar), TensorType(int64, scalar)]
tmpNMJZb8 1.676s Elemwise{Composite{Switch(i0, Switch(LT(i1, i2), i2, i1), Switch(LT(i3, i4), i3, i4))}} [TensorType(bool, scalar), TensorType(int8, scalar), TensorType(int64, scalar)]
tmpqxhkak 1.524s Elemwise{Composite{Switch(i0, i1, minimum(i2, i3))}}[(0, 2)] [TensorType(bool, scalar), TensorType(int8, scalar), TensorType(int64, scalar)]
tmplN97Vx 1.528s Elemwise{Composite{minimum(((i0 + i1) - i2), i3)}}[(0, 3)] [TensorType(int64, scalar), TensorType(int8, scalar)]
tmpPhNiqk 1.396s Elemwise{IntDiv}[(0, 0)] [TensorType(int64, scalar)]
tmpI059AK 1.380s Elemwise{Maximum}[(0, 0)] [TensorType(int64, scalar)]
tmpZ0nGSp 1.372s Elemwise{Sub}[(0, 0)] [TensorType(int64, scalar)]
tmp0Rlj60 1.424s Elemwise{Sub}[(0, 1)] [TensorType(int32, scalar)]
tmphqEZfH 1.404s Elemwise{add,no_inplace} [TensorType(int64, scalar)]
tmpVvhHpp 1.400s Elemwise{int_div,no_inplace} [TensorType(int64, scalar)]
tmpIsYSgI 1.404s Elemwise{int_div,no_inplace} [TensorType(int64, scalar), TensorType(int32, scalar)]
tmpM2vgW_ 1.392s Elemwise{le,no_inplace} [TensorType(int64, scalar), TensorType(int8, scalar)]
tmpwUjwkQ 1.404s Elemwise{lt,no_inplace} [TensorType(int64, scalar), TensorType(int8, scalar)]
tmpAYZ1fu 1.396s Elemwise{minimum,no_inplace} [TensorType(int64, scalar)]
tmpjq91rE 1.404s Elemwise{mul,no_inplace} [TensorType(int64, scalar)]
tmpBSPLdE 1.384s Elemwise{sub,no_inplace} [TensorType(int32, scalar)]
tmpPGDY34 1.476s Elemwise{switch,no_inplace} [TensorType(bool, scalar), TensorType(int8, scalar), TensorType(int64, scalar)]
tmp6QemFU 1.664s GpuAlloc<None>{memset_0=True} [GpuArrayType<None>(float64, scalar), TensorType(int64, scalar)]
tmp0pmp34 1.776s GpuAlloc<None>{memset_0=True} [GpuArrayType<None>(float64, scalar), TensorType(int64, scalar), TensorType(int8, scalar)]
tmpWjgvEn 1.712s GpuAllocEmpty{dtype='float64', context_name=None} [TensorType(int64, scalar)]
tmpKFgNoq 1.720s GpuCAReduceCuda{add} [GpuArrayType<None>(float64, 4D)]
tmp4gGoRb 1.700s GpuCAReduceCuda{add} [GpuArrayType<None>(float64, matrix)]
tmpBPoO3U 1.328s GpuElemwise{Cast{float32}}[]<gpuarray> [GpuArrayType<None>(float64, matrix)]
tmpihqfMP 1.364s GpuElemwise{Cast{float32}}[]<gpuarray> [GpuArrayType<None>(float64, (True, True, False, False))]
tmpqTM02m 1.460s GpuElemwise{Composite{(i0 - (i1 * i2))}}[]<gpuarray> [GpuArrayType<None>(int64, vector), GpuArrayType<None>(int64, (True,))]
tmp7FJbhe 1.420s GpuElemwise{Mul}[(0, 0)]<gpuarray> [GpuArrayType<None>(float64, matrix), GpuArrayType<None>(float32, matrix)]
tmp2atqe7 1.412s GpuElemwise{Mul}[(0, 0)]<gpuarray> [GpuArrayType<None>(float64, 4D)]
tmpsircWc 1.316s GpuElemwise{Sqr}[(0, 0)]<gpuarray> [GpuArrayType<None>(float64, matrix)]
tmpaVi181 1.396s GpuElemwise{int_div,no_inplace} [GpuArrayType<None>(int64, vector), GpuArrayType<None>(int64, (True,))]
tmp1wPoYo 1.500s GpuFromHost<None> [TensorType(float64, scalar), TensorType(float64, 4D), TensorType(float64, matrix)]
tmpuTT2aG 1.480s GpuFromHost<None> [TensorType(int64, vector), TensorType(int64, 4D), TensorType(int64, (True,))]
tmpaoQqs0 2.288s GpuFromHost<None> [TensorType(float32, 4D)]
tmpLr40NZ 1.484s GpuIncSubtensor{InplaceSet;:int64:} [Scalar(int64), GpuArrayType<None>(float64, 5D)]
tmp7AMa5q 1.344s GpuJoin [GpuArrayType<None>(float64, 4D), GpuArrayType<None>(float32, 4D), TensorType(int8, scalar)]
tmp3pflPQ 1.376s GpuReshape{2} [GpuArrayType<None>(float64, matrix), TensorType(int64, vector), GpuArrayType<None>(float64, 4D)]
tmpq5y035 1.404s GpuReshape{4} [GpuArrayType<None>(float64, matrix), GpuArrayType<None>(float32, matrix), TensorType(int64, vector)]
tmphWh08d 1.380s GpuSubtensor{int64:int64:int8} [Scalar(int64), GpuArrayType<None>(int64, vector), Scalar(int8)]
tmpikgnwT 1.368s GpuSubtensor{int64:int64:int8} [Scalar(int64), GpuArrayType<None>(float64, matrix), Scalar(int8)]
tmpdWXCiN 1.508s GpuSubtensor{int64} [Scalar(int64), GpuArrayType<None>(float64, 5D)]
tmp1i01se 1.312s HostFromGpu(gpuarray) [GpuArrayType<None>(float64, matrix), GpuArrayType<None>(float64, scalar), GpuArrayType<None>(float64, 4D)]
tmp2aqVM1 1.348s HostFromGpu(gpuarray) [GpuArrayType<None>(int64, scalar)]
tmpkiRKDE 1.332s HostFromGpu(gpuarray) [GpuArrayType<None>(float32, matrix), GpuArrayType<None>(float32, 4D)]
tmp2FaBmo 1.380s HostFromGpu(gpuarray) [GpuArrayType<None>(float64, 4D)]
tmpqAI1ur 1.312s HostFromGpu(gpuarray) [GpuArrayType<None>(int64, matrix)]
tmppEqbpc 1.356s HostFromGpu(gpuarray) [GpuArrayType<None>(float32, vector)]
tmp9kfQMf 1.628s Images2Neibs{ignore_borders} [TensorType(int64, vector), TensorType(float64, (True, True, False, False))]
tmp_h45vp 1.512s Images2Neibs{valid} [TensorType(float64, 4D), TensorType(int64, vector), TensorType(float64, (True, True, False, False))]
tmp8wY2tU 1.532s Images2Neibs{valid} [TensorType(int64, (True, True, False, False)), TensorType(int64, vector)]
tmpMgGNwq 1.520s Images2Neibs{valid} [TensorType(float32, (True, True, False, False)), TensorType(int64, vector)]
tmpEpNj7m 1.408s IncSubtensor{InplaceInc;::, ::, int64:int64:int64, int64:int64:int64} [TensorType(float32, 4D), TensorType(float64, 4D), Scalar(int64)]
tmp36eTC9 1.212s IncSubtensor{InplaceSet;int64} [Scalar(int64), TensorType(int64, vector), TensorType(int64, scalar), TensorType(int32, vector)]
tmpMwAlcP 1.192s IncSubtensor{Set;int64} [Scalar(int64), TensorType(int64, scalar), TensorType(int32, vector)]
tmpCdp9gP 1.144s InplaceDimShuffle{x,x,0,1} [TensorType(float32, matrix), TensorType(float64, matrix), TensorType(int64, matrix)]
tmpTzs_0f 1.164s InplaceDimShuffle{x} [TensorType(int64, scalar)]
tmpQcJT4g 1.428s InplaceDimShuffle{} [TensorType(int64, scalar)]
tmprnPsri 1.224s InplaceGpuDimShuffle{1,0} [GpuArrayType<None>(float64, matrix)]
tmpTzlHx_ 1.220s InplaceGpuDimShuffle{x,x,0,1} [GpuArrayType<None>(float64, matrix)]
tmpvzRbKT 1.192s Join [TensorType(float64, 4D), TensorType(int8, scalar)]
tmpjSfhQ7 1.268s Join [TensorType(float64, 4D), TensorType(int8, scalar)]
tmpp8d5PJ 1.288s MakeVector{dtype='int64'} [TensorType(int64, scalar)]
tmp_64pst 1.484s MakeVector{dtype='int64'} [TensorType(int64, scalar)]
tmp86_0sA 2.016s MakeVector{dtype='int64'} [TensorType(int64, scalar)]
tmp7bUUA7 1.800s MakeVector{dtype='int64'} [TensorType(int64, scalar)]
tmpRzvMDg 1.200s Rebroadcast{0} [GpuArrayType<None>(float64, (True, False, False, False, False))]
tmplEJm28 1.140s Reshape{4} [TensorType(float32, vector), TensorType(int64, vector)]
tmpigBhqp 1.168s Reshape{4} [TensorType(float32, matrix), TensorType(float64, matrix), TensorType(int64, matrix), TensorType(int64, vector)]
tmpeMzO47 1.156s Reshape{4} [TensorType(float64, matrix), TensorType(int32, vector)]
tmpnTGqUP 1.144s Reshape{4} [TensorType(float64, matrix), TensorType(int32, vector)]
tmpUAuynB 1.188s ScalarFromTensor [TensorType(int8, scalar)]
tmpvIFpoq 1.480s ScalarFromTensor [TensorType(int64, scalar)]
tmpFFVrf1 1.140s Shape_i{0} [TensorType(float32, 4D), TensorType(float64, matrix), TensorType(int64, 4D), TensorType(float64, 4D)]
tmp8hRZA5 1.316s Shape_i{0} [GpuArrayType<None>(float64, 4D)]
tmpfnkb5Q 1.300s Shape_i{1} [GpuArrayType<None>(float64, 4D)]
tmpqfFkkh 1.100s Shape_i{1} [TensorType(float32, 4D), TensorType(float64, matrix), TensorType(int64, 4D), TensorType(float64, 4D)]
tmpwycaEM 1.296s Shape_i{2} [GpuArrayType<None>(float64, 4D)]
tmpjS0M1G 1.116s Shape_i{2} [TensorType(float32, 4D), TensorType(float64, 4D), TensorType(int64, 4D)]
tmpy7UZzk 1.108s Shape_i{3} [TensorType(float32, 4D), TensorType(float64, 4D), TensorType(int64, 4D)]
tmp6Q49KX 1.592s Shape_i{3} [GpuArrayType<None>(float64, 4D)]
tmp0vyF_6 1.168s Subtensor{int64} [Scalar(int64), TensorType(int64, vector), TensorType(int32, vector)]

List of 24 compiled Op classes and the number of times they got compiled
<class 'theano.tensor.subtensor.Subtensor'> 1
<class 'theano.gpuarray.subtensor.GpuIncSubtensor'> 1
<class 'theano.gpuarray.basic_ops.GpuAllocEmpty'> 1
<class 'theano.gpuarray.basic_ops.GpuJoin'> 1
<class 'theano.compile.ops.Rebroadcast'> 1
<class 'theano.gpuarray.elemwise.GpuCAReduceCuda'> 2
<class 'theano.gpuarray.basic_ops.GpuReshape'> 2
<class 'theano.tensor.basic.Alloc'> 2
<class 'theano.tensor.basic.ScalarFromTensor'> 2
<class 'theano.tensor.basic.Join'> 2
<class 'theano.gpuarray.elemwise.GpuDimShuffle'> 2
<class 'theano.gpuarray.basic_ops.GpuAlloc'> 2
<class 'theano.gpuarray.subtensor.GpuSubtensor'> 3
<class 'theano.tensor.elemwise.DimShuffle'> 3
<class 'theano.gpuarray.basic_ops.GpuFromHost'> 3
<class 'theano.tensor.subtensor.IncSubtensor'> 3
<class 'theano.tensor.basic.Reshape'> 4
<class 'theano.tensor.opt.MakeVector'> 4
<class 'theano.tensor.nnet.neighbours.Images2Neibs'> 4
<class 'theano.gpuarray.neighbours.GpuImages2Neibs'> 6
<class 'theano.gpuarray.basic_ops.HostFromGpu'> 6
<class 'theano.gpuarray.elemwise.GpuElemwise'> 7
<class 'theano.compile.ops.Shape_i'> 8
<class 'theano.tensor.elemwise.Elemwise'> 42

Number of keys for a compiled module
number of keys/number of modules with that number of keys
1 75
2 11
3 9
4 5
5 2
6 1
7 3
9 1
13 1
15 1
16 1
17 1
30 1
Skipped 6 files that contained more than 1 op (was compiled with the C linker)
Skipped 0 files that contained 0 op (are they always theano.scalar ops?)
```

