### PR TITLE
Use expm1 for elu

### DIFF
--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -2420,7 +2420,7 @@ def elu(x, alpha=1):
         "Fast and Accurate Deep Network Learning by
         Exponential Linear Units (ELUs)" <http://arxiv.org/abs/1511.07289>`.
     """
-    return tensor.switch(x > 0, x, alpha * (tensor.exp(x) - 1))
+    return tensor.switch(x > 0, x, alpha * tensor.expm1(x))
 
 
 class ScalarSoftsign(theano.scalar.UnaryScalarOp):


### PR DESCRIPTION
Just a minor optimization that @danstowell found for Lasagne: Replace `tensor.exp(x) - 1` by `tensor.expm1(x)` in the elu definition so Theano doesn't have to. (Theano has an optimization that does the same.)