### PR TITLE
Unsigned char:  fix: theano/scalar/basic.py

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -2274,8 +2274,8 @@ class GCC_compiler(Compiler):
             # improved loading times on most platforms (win32 is
             # different, as usual).
             cmd.append('-fvisibility=hidden')
-        cmd.extend(['-o', lib_filename])
-        cmd.append(cppfilename)
+        cmd.extend(['-o', '%s%s%s' % (path_wrapper, lib_filename, path_wrapper)])
+        cmd.append('%s%s%s' % (path_wrapper, cppfilename, path_wrapper))
         cmd.extend(['-l%s' % l for l in libs])
         # print >> sys.stderr, 'COMPILING W CMD', cmd
         _logger.debug('Running cmd: %s', ' '.join(cmd))

--- a/theano/gpuarray/basic_ops.py
+++ b/theano/gpuarray/basic_ops.py
@@ -319,7 +319,9 @@ class GpuKernelBase(object):
     def _generate_kernel_code(self, k):
         code = '\\n'.join(l for l in k.code.split('\n'))
         code = code.replace('"', '\\"')
-        return ("""static const char *%(cname)s = "%(code)s";""" %
+        return ("""static const char *%(cname)s_unsigned = "%(code)s";
+                static const char *%(cname)s = (char *)%(cname)s_unsigned;
+                """ %
                 dict(cname=k.codevar, code=code))
 
     def _generate_kernel_vars(self, k):

--- a/theano/gpuarray/tests/test_elemwise.py
+++ b/theano/gpuarray/tests/test_elemwise.py
@@ -45,13 +45,14 @@ def test_elemwise_pow():
 
             base = theano.tensor.vector(dtype=dtype_base)
             exp = gpuarray_shared_constructor(exp_val)
+            assert exp.dtype == dtype_exp
             output = base ** exp
             f = theano.function([base], output, mode=mode_with_gpu)
             theano.printing.debugprint(f)
             # We don't transfer to the GPU when the output dtype is int*
             n = len([n for n in f.maker.fgraph.apply_nodes
                      if isinstance(n.op, GpuElemwise)])
-            assert n == int("float" in output.dtype)
+            assert n == (output.dtype in tensor.float_dtypes)
 
             # Call the function to make sure the output is valid
             out = f(base_val)

--- a/theano/gpuarray/type.py
+++ b/theano/gpuarray/type.py
@@ -398,9 +398,6 @@ class GpuArrayType(Type):
         return pygpu.gpuarray.zeros(shape, dtype=self.typecode,
                                     context=self.context)
 
-    def make_variable(self, name=None):
-        return self.Variable(self, name=name)
-
     def __eq__(self, other):
         return (type(self) == type(other) and
                 self.typecode == other.typecode and

--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -4025,7 +4025,6 @@ class Composite(ScalarOp):
         self.prepare_node_called = set()
         self.init_fgraph()
         self.init_py_impls()
-        assert self._c_code
 
 
 class Compositef32(object):

--- a/theano/tensor/nnet/sigm.py
+++ b/theano/tensor/nnet/sigm.py
@@ -997,7 +997,7 @@ def local_1msigmoid(node):
         if sub_r.owner and sub_r.owner.op == sigmoid:
             try:
                 val_l = opt.get_scalar_constant_value(sub_l)
-            except Exception:
+            except tensor.NotScalarConstantError:
                 return
             if np.allclose(np.sum(val_l), 1):
                 out = sigmoid(-sub_r.owner.inputs[0])


### PR DESCRIPTION
Crash issue with theano/scalar/basic.py [gh-5816](https://github.com/Theano/Theano/issues/5816#issuecomment-293435358)
The diff does not crash when unpickling the batch normalization op.
Confirming what Pascal @lamblin suggested, it should be removed.

fix https://github.com/Theano/Theano/issues/5803
fix gh-5816
fix https://github.com/Theano/libgpuarray/issues/403