### PR TITLE
Consistent dtype

### DIFF
--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -2014,7 +2014,8 @@ def binary_crossentropy(output, target):
     TODO : Rewrite as a scalar, and then broadcast to tensor.
 
     """
-    return -(target * tensor.log(output) + (1.0 - target) * tensor.log(1.0 - output))
+    one = np.asarray(1.0).astype(theano.config.floatX)
+    return -(target * tensor.log(output) + (one - target) * tensor.log(one - output))
 
 
 def categorical_crossentropy(coding_dist, true_dist):


### PR DESCRIPTION
In `binary_crossentropy`, we have been using a python float(which is `float64` by default). When we use the `binary_crossentropy` with two `float32`s  the resulting output is a `float64`, which is resulting mismatch in dtype error. The similar change, I would like to apply to other places where we use pythonic floats.
Edit : I will post the detailed error in a short while(As it is on the computer in my lab)