### PR TITLE
Update Windows (and other generic) installation instructions

### DIFF
--- a/doc/install_centos6.txt
+++ b/doc/install_centos6.txt
@@ -11,6 +11,7 @@ CentOS 6 Installation Instructions
     from GitHub, please make sure you are reading `the latest version of this
     page <http://deeplearning.net/software/theano_versions/dev/install_centos6.html>`_.
 
+.. |PythonDistRecommended| replace:: The development package (python-dev or python-devel on most Linux distributions) is recommended (see just below)
 .. |PlatformCompiler| replace:: ``python-dev``, ``g++`` >= 4.2
 .. |CompilerName| replace:: ``g++``
 

--- a/doc/install_generic.inc
+++ b/doc/install_generic.inc
@@ -19,6 +19,11 @@ will be automatically installed as a dependency.
 
     conda install theano pygpu
 
+.. warning::
+
+    Last conda packages for theano (0.9) and pygpu (0.6*) currently don't support
+    Python 3.4 branch.
+
 With ``pip``
 ^^^^^^^^^^^^
 

--- a/doc/install_macos.txt
+++ b/doc/install_macos.txt
@@ -19,6 +19,7 @@ alternative instructions here.
 
 .. _theano-users: http://groups.google.com/group/theano-users?pli=1
 
+.. |PythonDistRecommended| replace:: The conda distribution is highly recommended
 .. |PlatformCompiler| replace:: ``clang`` (the system version)
 .. |CompilerName| replace:: ``Clang``
 

--- a/doc/install_ubuntu.txt
+++ b/doc/install_ubuntu.txt
@@ -13,6 +13,7 @@ Ubuntu Installation Instructions
 
 .. _gpu_linux:
 
+.. |PythonDistRecommended| replace:: The development package (python-dev or python-devel on most Linux distributions) is recommended (see just below)
 .. |PlatformCompiler| replace:: ``python-dev``, ``g++`` >= 4.2
 .. |CompilerName| replace:: ``g++``
 

--- a/doc/install_windows.txt
+++ b/doc/install_windows.txt
@@ -11,7 +11,8 @@ Windows Installation Instructions
     from GitHub, please make sure you are reading `the latest version of this
     page <http://deeplearning.net/software/theano_versions/dev/install_windows.html>`_.
 
-.. |PlatformCompiler| replace:: ``python-dev``, ``g++`` >= 4.2
+.. |PythonDistRecommended| replace:: The conda distribution is highly recommended
+.. |PlatformCompiler| replace:: GCC compiler with ``g++`` (version >= ``4.2.*``), and Python development files
 .. |CompilerName| replace:: ``g++``
 
 .. List of requirements, optional requirements, and installation of miniconda.

--- a/doc/requirements.inc
+++ b/doc/requirements.inc
@@ -14,10 +14,8 @@ Requirements
 .. _pycuda: https://mathema.tician.de/software/pycuda/
 .. _skcuda: http://scikit-cuda.readthedocs.io/en/latest/
 
-    Python_ == 2.7 or ( >= 3.3 and <= 3.5 )
-        The development package (python-dev or
-        python-devel on most Linux distributions) is recommended (see
-        just below). Python 2.4 was supported up to and including the
+    Python_ < 3.6
+        |PythonDistRecommended|. Python 2.4 was supported up to and including the
         release 0.6. Python 2.6 was supported up to and including the
         release 0.8.2. Python 3 is supported past the 3.3 release.
 
@@ -28,7 +26,7 @@ Requirements
         Only currently required for sparse matrix and special functions support, but highly recommended. SciPy >=0.8 could work, but earlier versions have known bugs with sparse matrices.
 
     `BLAS`_ installation (with Level 3 functionality)
-        * **Recommended**: MKL, which is free through Conda.
+        * **Recommended**: MKL, which is free through Conda with ``mkl-service`` package.
         * Alternatively, we suggest to install OpenBLAS, with the development headers (``-dev``, ``-devel``, depending on your Linux distribution).
 
 **Optional requirements**

--- a/doc/requirements.inc
+++ b/doc/requirements.inc
@@ -14,7 +14,7 @@ Requirements
 .. _pycuda: https://mathema.tician.de/software/pycuda/
 .. _skcuda: http://scikit-cuda.readthedocs.io/en/latest/
 
-    Python_ < 3.6
+    Python_ == 2.7* or ( >= 3.3 and < 3.6 )
         |PythonDistRecommended|. Python 2.4 was supported up to and including the
         release 0.6. Python 2.6 was supported up to and including the
         release 0.8.2. Python 3 is supported past the 3.3 release.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+.. |PythonDistRecommended| replace:: The development package (python-dev or python-devel on most Linux distributions) is recommended (see just below)
 .. |PlatformCompiler| replace:: ``g++`` (Linux and Windows), ``clang`` (OS X)
 
 .. |CompilerName| replace:: ``g++`` (Windows/Linux) or ``Clang`` (OS X)


### PR DESCRIPTION
This PR adds some recommendations from this discussion: https://groups.google.com/forum/#!topic/theano-dev/3VQ08whW-5Q

**Notes**:
 * For Python requirements, the first sentence is now adapted to the OS. It recommends python-dev(el) packages for Linux/CentOS, and conda distribution for Windows and Mac (I don't know if python-dev(el) packages exist on Mac).
 * BLAS requirements now recommend `mkl-service` conda package, but OpenBLAS "dev" packages are still mentionned for all OS. I currently don't know how to add/remove conditionnally a list entry in a reST file.
 * "sudo" terms are still present. It may be hard to make them appear only in Linux documentations.
 * I have added a warning about conda installation for last versions of theano and pygpu, to tell that these packages currently don't support Python 3.4 branch. I had made the remark in the previous PR: https://github.com/Theano/Theano/pull/5433#issuecomment-288792237 . It seems it is related to limitations of libgpuarray package, which is available only for Python 2.7, 3.5 and 3.6.

Doc rendering is available here: http://notoraptor.net/theano/html-doc-update/install_windows.html

@nouiz 