### PR TITLE
Use ParamsType for other ops

### DIFF
--- a/theano/gof/compiledir.py
+++ b/theano/gof/compiledir.py
@@ -146,7 +146,16 @@ def print_compiledir_content():
                     if len(ops) == 1:
                         table.append((dir, ops[0], types, compile_time))
                     else:
-                        ops_to_str = '[%s]' % ', '.join(sorted(str(op) for op in ops))
+                        # Instead of printing all Ops (which can result in very long lines),
+                        # we will just print every Op class name with the number of times
+                        # this op class is present in current Ops list (e.g. "54*GpuDnnConvDesc").
+                        ops_counts = {}
+                        for op in ops:
+                            op_name = type(op).__name__
+                            ops_counts.setdefault(op_name, 0)
+                            ops_counts[op_name] += 1
+                        ops_to_str = '[%s]' % ', '.join('%s*%s' % (ops_counts[k], k)
+                                                        for k in sorted(ops_counts.keys()))
                         types_to_str = '[%s]' % ', '.join(sorted(str(t) for t in types))
                         table_multiple_ops.append((dir, ops_to_str, types_to_str, compile_time))
 

--- a/theano/gof/compiledir.py
+++ b/theano/gof/compiledir.py
@@ -148,13 +148,46 @@ def print_compiledir_content():
                     else:
                         # Instead of printing all Ops (which can result in very long lines),
                         # we will just print every Op class name with the number of times
-                        # this op class is present in current Ops list (e.g. "54*GpuDnnConvDesc").
+                        # this op class is present in current Ops list, and the value or list
+                        # of values passed to each prop of this op.
+                        # Examples:
+                        # "54*GpuDnnConvDesc" (no props).
+                        # "54*GpuDnnConvDesc{a=1, b=2}" (props a and b have received only 1 and 2 in this entire ops list).
+                        # "54*GpuDnnConvDesc{a=1, b:(1, 2, 3)}" (a receives 1 and b either 1 or 2 or 3 in this entire ops list).
                         ops_counts = {}
+                        ops_props = {}
                         for op in ops:
                             op_name = type(op).__name__
                             ops_counts.setdefault(op_name, 0)
                             ops_counts[op_name] += 1
-                        ops_to_str = '[%s]' % ', '.join('%s*%s' % (ops_counts[k], k)
+
+                            if hasattr(op, '__props__'):
+                                ops_props.setdefault(op_name, {})
+                                try:
+                                    for prop_name in op.__props__:
+                                        prop_value = getattr(op, prop_name)
+                                        ops_props[op_name].setdefault(prop_name, set())
+                                        ops_props[op_name][prop_name].add(prop_value)
+                                except Exception:
+                                    pass
+
+                        def props_to_str(op_name):
+                            r = ''
+                            if op_name in ops_props:
+                                props_strings = []
+                                for prop_name, prop_value in ops_props[op_name].items():
+                                    # prop_valus is the set of props values received by this op in this ops list.
+                                    if len(prop_value) == 1:
+                                        # Only 1 value for this prop. Print prop=value
+                                        props_strings += ['%s=%s' % (prop_name, prop_value.pop())]
+                                    else:
+                                        # Many values for this prop. Print prop:(valu1, valu2, ...)
+                                        props_strings += ['%s:%s' % (prop_name, tuple(sorted(list(prop_value))))]
+                                        pass
+                                r = '{%s}' % ', '.join(props_strings)
+                            return r
+
+                        ops_to_str = '[%s]' % '; '.join('%s*%s%s' % (ops_counts[k], k, props_to_str(k))
                                                         for k in sorted(ops_counts.keys()))
                         types_to_str = '[%s]' % ', '.join(sorted(str(t) for t in types))
                         table_multiple_ops.append((dir, ops_to_str, types_to_str, compile_time))
@@ -184,6 +217,7 @@ def print_compiledir_content():
     table_multiple_ops = sorted(table_multiple_ops, key=lambda t: (t[1], t[2]))
     for dir, ops_to_str, types_to_str, compile_time in table_multiple_ops:
         print(dir, '%.3fs' % compile_time, ops_to_str, types_to_str)
+        print()
 
     print()
     print_title(("List of %d compiled Op classes and "

--- a/theano/gpuarray/extra_ops.py
+++ b/theano/gpuarray/extra_ops.py
@@ -10,6 +10,9 @@ except ImportError:
 
 from .basic_ops import (as_gpuarray_variable, GpuKernelBase, Kernel, GpuReshape, infer_context_name)
 from .opt import register_opt, op_lifter, register_opt2
+from .type import gpu_context_type
+from theano.gof import ParamsType
+import theano.scalar as scalar
 
 
 class GpuCumOp(GpuKernelBase, Op):
@@ -21,9 +24,10 @@ class GpuCumOp(GpuKernelBase, Op):
     """
     SUPPORTED_NDIMS = 3
     __props__ = ('axis', 'mode')
+    params_type = ParamsType(axis=scalar.int32, context=gpu_context_type, device_is_not_cuda=scalar.bool)
 
     def __init__(self, axis, mode='add'):
-        self.axis = axis if axis else 0
+        self.axis = int(axis) if axis is not None else 0
         self.mode = mode
 
     def __eq__(self, other):
@@ -35,13 +39,18 @@ class GpuCumOp(GpuKernelBase, Op):
         return hash(self.axis) ^ hash(self.mode)
 
     def c_code_cache_version(self):
-        return (3,)
+        return (4,)
 
     def c_headers(self):
         return ['<numpy_compat.h>', '<gpuarray/types.h>', '<gpuarray_helper.h>']
 
     def c_header_dirs(self):
         return [os.path.dirname(__file__)]
+
+    def get_params(self, node):
+        context = GpuKernelBase.get_params(self, node)
+        device_is_not_cuda = (context.kind != b'cuda')
+        return self.params_type.get_params(axis=self.axis, context=context, device_is_not_cuda=device_is_not_cuda)
 
     def make_node(self, x):
         assert x.type.dtype == 'float32', "Only float32 supported for GpuCumOp"
@@ -226,26 +235,23 @@ class GpuCumOp(GpuKernelBase, Op):
         return kernels
 
     def c_code(self, node, nodename, inp, out, sub):
-        if node.inputs[0].type.context.kind != b'cuda':
-            raise NotImplementedError("cuda only")
-        x, = inp
-        z, = out
-        axis = self.axis if self.axis is not None else 0
-        fail = sub['fail']
-        ctx = sub['params']
-
-        code = """
-
+        return """
+        if (%(params)s->device_is_not_cuda) {
+            PyErr_SetString(PyExc_NotImplementedError, "cuda only");
+            %(fail)s
+        }
+        {
             const size_t* shape = PyGpuArray_DIMS(%(x)s);
             bool needAllocation = !%(z)s || PyGpuArray_NDIM(%(x)s) != PyGpuArray_NDIM(%(z)s);
 
-            int axis = %(axis)s;
+            int axis = %(params)s->axis;
             if (axis < 0) {
                 // Convert negative axis to positive axis.
                 axis += PyGpuArray_NDIM(%(x)s);
             }
 
-            if (theano_prep_output(&%(z)s, PyGpuArray_NDIM(%(x)s), PyGpuArray_DIMS(%(x)s), %(x)s->ga.typecode, GA_C_ORDER, %(ctx)s) != 0){
+            if (theano_prep_output(&%(z)s, PyGpuArray_NDIM(%(x)s), PyGpuArray_DIMS(%(x)s),
+                                   %(x)s->ga.typecode, GA_C_ORDER, %(params)s->context) != 0) {
                 %(fail)s;
             }
 
@@ -254,17 +260,17 @@ class GpuCumOp(GpuKernelBase, Op):
                 size_t max_grid_size1;
                 size_t max_grid_size2;
                 int err;
-                err = gpucontext_property(%(ctx)s->ctx, GA_CTX_PROP_MAXLSIZE0, &max_threads_dim0);
+                err = gpucontext_property(%(params)s->context->ctx, GA_CTX_PROP_MAXLSIZE0, &max_threads_dim0);
                 if (err != GA_NO_ERROR){
                     PyErr_SetString(PyExc_RuntimeError, "Could not fetch max_threads_dims0");
                     %(fail)s;
                 }
-                err = gpucontext_property(%(ctx)s->ctx, GA_CTX_PROP_MAXGSIZE1, &max_grid_size1);
+                err = gpucontext_property(%(params)s->context->ctx, GA_CTX_PROP_MAXGSIZE1, &max_grid_size1);
                 if (err != GA_NO_ERROR){
                     PyErr_SetString(PyExc_RuntimeError, "Could not fetch max_grid_size1");
                     %(fail)s;
                 }
-                err = gpucontext_property(%(ctx)s->ctx, GA_CTX_PROP_MAXGSIZE2, &max_grid_size2);
+                err = gpucontext_property(%(params)s->context->ctx, GA_CTX_PROP_MAXGSIZE2, &max_grid_size2);
                 if (err != GA_NO_ERROR){
                     PyErr_SetString(PyExc_RuntimeError, "Could not fetch max_grid_size2");
                     %(fail)s;
@@ -273,9 +279,8 @@ class GpuCumOp(GpuKernelBase, Op):
                     %(fail)s;
                 }
             }
-        """ % locals()
-
-        return code
+        }
+        """ % dict(x=inp[0], z=out[0], nodename=nodename, fail=sub['fail'], params=sub['params'])
 
     def c_support_code_struct(self, node, nodename):
         code = """

--- a/theano/gpuarray/neighbours.py
+++ b/theano/gpuarray/neighbours.py
@@ -24,7 +24,7 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
     params_type = ParamsType(mode=Images2Neibs.params_type, context=gpu_context_type)
 
     def get_params(self, node):
-        return self.params_type.get_params(self, context=GpuKernelBase.get_params(self, node))
+        return self.params_type.get_params(self, context=node.inputs[0].type.context)
 
     def make_node(self, ten4, neib_shape, neib_step):
         ten4 = as_gpuarray_variable(ten4, infer_context_name(ten4))

--- a/theano/gpuarray/neighbours.py
+++ b/theano/gpuarray/neighbours.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import, print_function, division
-import numpy as np
 
 from theano import Op, Apply, config
+from theano.gof import ParamsType
 from theano.tensor.nnet.neighbours import Images2Neibs
 import theano.tensor as T
 
 try:
-    import pygpu
     from pygpu import gpuarray
 except ImportError:
     pass
@@ -14,7 +13,7 @@ except ImportError:
 from .basic_ops import (as_gpuarray_variable, GpuKernelBase, Kernel,
                         infer_context_name)
 from .opt import register_opt2, op_lifter, register_opt
-from .type import GpuArrayType
+from .type import GpuArrayType, gpu_context_type
 
 
 class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
@@ -22,13 +21,10 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
     Images2Neibs for the GPU.
 
     """
-    def __init__(self, mode='valid'):
-        if mode not in ['valid', 'ignore_borders', 'wrap_centered']:
-            raise NotImplementedError("Only the mode valid, ignore_borders"
-                                      " and wrap_centered"
-                                      " have been implemented for the op"
-                                      " GpuImages2Neibs")
-        self.mode = mode
+    params_type = ParamsType(mode=Images2Neibs.params_type, context=gpu_context_type)
+
+    def get_params(self, node):
+        return self.params_type.get_params(self, context=GpuKernelBase.get_params(self, node))
 
     def make_node(self, ten4, neib_shape, neib_step):
         ten4 = as_gpuarray_variable(ten4, infer_context_name(ten4))
@@ -47,7 +43,7 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                                    context_name=ten4.type.context_name)()])
 
     def c_code_cache_version(self):
-        return (11,)
+        return (17,)
 
     def c_headers(self):
         return ['<numpy_compat.h>', '<gpuarray/types.h>']
@@ -58,13 +54,15 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
         flags = Kernel.get_flags(dtype_ten4, dtype_z)
         type_ten4 = gpuarray.dtype_to_ctype(dtype_ten4)
         type_z = gpuarray.dtype_to_ctype(dtype_z)
-        mode = self.mode
+        mode_constants = self.params_type.get_type('mode').c_support_code()
         kernels = []
         kname = "k_multi_warp_less"
         k_var = "k_multi_warp_less_" + nodename
         code = """
-// a version that uses less registers but doesn't work in all cases.
+        // a version that uses less registers but doesn't work in all cases.
+        %(mode_constants)s
         KERNEL void %(kname)s(
+            const ga_int mode,
             const ga_int nb_batch,
             const ga_int nb_stack,
             const ga_int height,
@@ -107,7 +105,7 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                             ga_int i = LID_1;     // loop over c
                             {
                                 ga_int ten4_2 = i + a * step_x;
-                                if("%(mode)s"=="wrap_centered"){
+                                if (mode == MODE_WRAP_CENTERED) {
                                     ten4_2 -= wrap_centered_idx_shift_x;
                                     if ( ten4_2 < 0 )
                                         ten4_2 += height;
@@ -117,7 +115,7 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                                 ga_int j = LID_0;  // loop over d
                                 {
                                     ga_int ten4_3 = j + b * step_y;
-                                    if("%(mode)s"=="wrap_centered"){
+                                    if (mode == MODE_WRAP_CENTERED) {
                                         ten4_3 -= wrap_centered_idx_shift_y;
                                         if ( ten4_3 < 0 )
                                             ten4_3 += width;
@@ -136,8 +134,9 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                                 }
                             }
             }
-        }""" % locals()
+        }""" % dict(kname=kname, type_ten4=type_ten4, type_z=type_z, mode_constants=mode_constants)
         params = [
+            'intc',
             'intc', 'intc', 'intc', 'intc', 'intc', 'intc',
             'intc', 'intc', 'intc', 'intc',
             'uintp', 'uintp', 'uintp', 'uintp',
@@ -151,7 +150,9 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
         kname = "k_multi_warp"
         k_var = "k_multi_warp_" + nodename
         code = """
+        %(mode_constants)s
         KERNEL void %(kname)s(
+            const ga_int mode,
             const ga_int nb_batch,
             const ga_int nb_stack,
             const ga_int height,
@@ -195,7 +196,7 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                             for (ga_int i = LID_1; i < c; i+=LDIM_1)
                             {
                                 ga_int ten4_2 = i + a * step_x;
-                                if("%(mode)s"=="wrap_centered"){
+                                if (mode == MODE_WRAP_CENTERED) {
                                     ten4_2 -= wrap_centered_idx_shift_x;
                                     if ( ten4_2 < 0 )
                                         ten4_2 += height;
@@ -206,7 +207,7 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                                 for (ga_int j = LID_0; j < d; j+=LDIM_0)
                                 {
                                     ga_int ten4_3 = j + b * step_y;
-                                    if("%(mode)s"=="wrap_centered"){
+                                    if (mode == MODE_WRAP_CENTERED) {
                                         ten4_3 -= wrap_centered_idx_shift_y;
                                         if ( ten4_3 < 0 )
                                             ten4_3 += width;
@@ -226,8 +227,9 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                             }
             }
         }
-        """ % locals()
+        """ % dict(kname=kname, type_ten4=type_ten4, type_z=type_z, mode_constants=mode_constants)
         params = [
+            'intc',
             'intc', 'intc', 'intc', 'intc', 'intc', 'intc',
             'intc', 'intc', 'intc', 'intc',
             'uintp', 'uintp', 'uintp', 'uintp',
@@ -249,18 +251,6 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
         """
 
     def c_code(self, node, name, inp, out, sub):
-        dtype_ten4 = node.inputs[0].dtype
-        dtype_neib_shape = node.inputs[1].dtype
-        dtype_neib_step = node.inputs[2].dtype
-        dtype_z = node.outputs[0].dtype
-        itemsize_ten4 = np.dtype(dtype_ten4).itemsize
-        itemsize_z = np.dtype(dtype_z).itemsize
-        typecode_z = pygpu.gpuarray.dtype_to_typecode(node.outputs[0].dtype)
-        ten4, neib_shape, neib_step = inp
-        z, = out
-        fail = sub['fail']
-        ctx = sub['params']
-        mode = self.mode
         err_check = """
             if (err != GA_NO_ERROR) {
                 PyErr_Format(PyExc_RuntimeError,
@@ -268,16 +258,23 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                              GpuKernel_error(fptr, err));
                 %(fail)s;
             }
-        """ % locals()
+        """ % dict(fail=sub['fail'])
         sync = ""
         if config.gpuarray.sync:
             sync = """
             err = GpuArray_sync(&%(z)s->ga);
             %(err_check)s
-            """ % locals()
+            """ % dict(z=out[0], err_check=err_check)
+        # NB: To reduce C code variability:
+        # For itemsize_ten4, I use GpuArray_ITEMSIZE(&ten4->ga) instead of np.dtype(node.inputs[0].dtype).itemsize
+        # For itemsize_z, I use itemsize_ten4, as ten4 and z have same type properties (deduced from make_node)
+        # For typecode_z, I use ten4->ga.typecode (for same reason as above)
         return """
         int grid_c = -1;
         int grid_d = -1;
+        size_t itemsize_ten4 = GpuArray_ITEMSIZE(&%(ten4)s->ga);
+        size_t itemsize_z = itemsize_ten4;
+        int typecode_z = %(ten4)s->ga.typecode;
 
         {
             if (PyGpuArray_NDIM(%(ten4)s) != 4)
@@ -310,10 +307,10 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
             const npy_intp step_y = (npy_intp) *(npy_%(dtype_neib_step)s*)
                                          PyArray_GETPTR1(%(neib_step)s, 1);
 
-            if ( "%(mode)s" == "wrap_centered") {
+            if (%(params)s->mode == MODE_WRAP_CENTERED) {
                 if (c%%2!=1 || d%%2!=1){
                     PyErr_Format(PyExc_TypeError,
-        "GpuImages2Neibs: in mode wrap_centered need patch with odd shapes");
+                                 "GpuImages2Neibs: in mode wrap_centered need patch with odd shapes");
                     %(fail)s;
                 }
                 if ( PyGpuArray_DIMS(%(ten4)s)[2] < c ||
@@ -334,7 +331,7 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                                      (size_t)step_y);
 
 
-            }else if ( "%(mode)s" == "valid") {
+            } else if (%(params)s->mode == MODE_VALID) {
                 if ( ((PyGpuArray_DIMS(%(ten4)s))[2] < c) ||
                      ((((PyGpuArray_DIMS(%(ten4)s))[2]-c) %% step_x)!=0))
                 {
@@ -359,14 +356,14 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                 grid_c = 1+(((PyGpuArray_DIMS(%(ten4)s))[2]-c)/step_x);
                 //number of patch in width
                 grid_d = 1+(((PyGpuArray_DIMS(%(ten4)s))[3]-d)/step_y);
-            }else if ( "%(mode)s" == "ignore_borders") {
+            } else if (%(params)s->mode == MODE_IGNORE_BORDERS) {
                 //number of patch in height
                 grid_c = 1+(((PyGpuArray_DIMS(%(ten4)s))[2]-c)/step_x);
                 //number of patch in width
                 grid_d = 1+(((PyGpuArray_DIMS(%(ten4)s))[3]-d)/step_y);
-            }else{
+            } else {
                 PyErr_Format(PyExc_TypeError,
-                             "GpuImages2Neibs:: unknown mode '%(mode)s'");
+                             "GpuImages2Neibs:: unknown mode %%d", %(params)s->mode);
                  %(fail)s;
             }
 
@@ -385,8 +382,8 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                 size_t dims[2];
                 dims[0] = z_dim0;
                 dims[1] = z_dim1;
-                %(z)s = pygpu_empty(2, dims, %(typecode_z)s,
-                                    GA_C_ORDER, %(ctx)s, Py_None);
+                %(z)s = pygpu_empty(2, dims, typecode_z,
+                                    GA_C_ORDER, %(params)s->context, Py_None);
                 if (!%(z)s)
                 {
                     PyErr_SetString(PyExc_MemoryError, "GpuImages2Neibs:"
@@ -399,6 +396,7 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
 
         { // NESTED SCOPE
 
+            const int mode = %(params)s->mode;
             const int nb_batch = PyGpuArray_DIMS(%(ten4)s)[0];
             const int nb_stack = PyGpuArray_DIMS(%(ten4)s)[1];
             const int height = PyGpuArray_DIMS(%(ten4)s)[2];
@@ -416,7 +414,7 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
             size_t threads_per_block[3] = {d, c, 1};
             //get the max threads per blocks
             size_t max_threads_dim;
-            int err = gpucontext_property(%(ctx)s->ctx, GA_CTX_PROP_MAXLSIZE, &max_threads_dim);
+            int err = gpucontext_property(%(params)s->context->ctx, GA_CTX_PROP_MAXLSIZE, &max_threads_dim);
             if (err != GA_NO_ERROR){
                 PyErr_SetString(PyExc_RuntimeError, "Could not fetch max_threads_dims");
                 %(fail)s;
@@ -444,14 +442,19 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
             }else{
                 fptr = &k_multi_warp_%(name)s;
             }
-            // printf("%%zu %%zu %%zu %%zu %%zu %%zu %%zu\\n", max_threads_dim, threads_per_block[0], threads_per_block[1], threads_per_block[2], n_blocks[0], n_blocks[1], n_blocks[2]);
-            size_t stride_A0 = PyGpuArray_STRIDES(%(ten4)s)[0] / %(itemsize_ten4)s;
-            size_t stride_A1 = PyGpuArray_STRIDES(%(ten4)s)[1] / %(itemsize_ten4)s;
-            size_t stride_A2 = PyGpuArray_STRIDES(%(ten4)s)[2] / %(itemsize_ten4)s;
-            size_t stride_A3 = PyGpuArray_STRIDES(%(ten4)s)[3] / %(itemsize_ten4)s;
-            size_t stride_Z0 = PyGpuArray_STRIDES(%(z)s)[0] / %(itemsize_z)s;
-            size_t stride_Z1 = PyGpuArray_STRIDES(%(z)s)[1] / %(itemsize_z)s;
-            void *kernel_params[] = {(void *)&nb_batch,
+            /*
+            printf("%%zu %%zu %%zu %%zu %%zu %%zu %%zu\\n",
+                   max_threads_dim, threads_per_block[0], threads_per_block[1], threads_per_block[2],
+                   n_blocks[0], n_blocks[1], n_blocks[2]);
+            */
+            size_t stride_A0 = PyGpuArray_STRIDES(%(ten4)s)[0] / itemsize_ten4;
+            size_t stride_A1 = PyGpuArray_STRIDES(%(ten4)s)[1] / itemsize_ten4;
+            size_t stride_A2 = PyGpuArray_STRIDES(%(ten4)s)[2] / itemsize_ten4;
+            size_t stride_A3 = PyGpuArray_STRIDES(%(ten4)s)[3] / itemsize_ten4;
+            size_t stride_Z0 = PyGpuArray_STRIDES(%(z)s)[0] / itemsize_z;
+            size_t stride_Z1 = PyGpuArray_STRIDES(%(z)s)[1] / itemsize_z;
+            void *kernel_params[] = {(void *)&mode,
+                                     (void *)&nb_batch,
                                      (void *)&nb_stack,
                                      (void *)&height, (void *)&width,
                                      (void *)&c, (void *)&d,
@@ -471,11 +474,18 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
             %(err_check)s
             %(sync)s
         } // END NESTED SCOPE
-        """ % locals()
+        """ % dict(ten4=inp[0], neib_shape=inp[1], neib_step=inp[2], z=out[0],
+                   dtype_neib_shape=node.inputs[1].dtype,
+                   dtype_neib_step=node.inputs[2].dtype,
+                   err_check=err_check,
+                   sync=sync,
+                   name=name,
+                   params=sub['params'],
+                   fail=sub['fail'])
 
-    def perform(self, node, inp, out, ctx):
+    def perform(self, node, inp, out, params):
         # Disable the perform method from the CPU version
-        Op.perform(self, node, inp, out, ctx)
+        Op.perform(self, node, inp, out, params)
 
 
 @register_opt('fast_compile')

--- a/theano/gpuarray/rng_mrg.py
+++ b/theano/gpuarray/rng_mrg.py
@@ -7,16 +7,15 @@ http://www.iro.umontreal.ca/~simardr/ssj/indexe.html
 """
 from __future__ import absolute_import, print_function, division
 
-import numpy as np
-
 from theano import Apply, tensor
 from theano.gof import local_optimizer
 from theano.sandbox.rng_mrg import mrg_uniform_base, mrg_uniform
 from theano.tensor import as_tensor_variable, get_vector_length
+from theano.scalar import int32 as int_t
 
 from .basic_ops import (GpuKernelBase, Kernel, infer_context_name,
                         host_from_gpu, as_gpuarray_variable)
-from .type import GpuArrayType
+from .type import GpuArrayType, gpu_context_type
 from .fp16_help import write_w
 from .opt import register_opt, register_opt2
 
@@ -24,6 +23,11 @@ from .opt import register_opt, register_opt2
 class GPUA_mrg_uniform(GpuKernelBase, mrg_uniform_base):
     # GpuArray version
     _f16_ok = True
+    params_type = mrg_uniform_base.params_type.extended(otypecode=int_t, context=gpu_context_type)
+
+    def get_params(self, node):
+        return self.params_type.get_params(self, otypecode=self.output_type.typecode,
+                                           context=GpuKernelBase.get_params(self, node))
 
     def make_node(self, rstate, size):
         # error checking slightly redundant here, since
@@ -163,40 +167,34 @@ class GPUA_mrg_uniform(GpuKernelBase, mrg_uniform_base):
                 ]
 
     def c_code(self, node, nodename, inp, out, sub):
-        rstate, size = inp
-        o_rstate, o_sample = out
-        inplace = int(self.inplace)
-        ndim = self.output_type.ndim
-        o_type_num = np.asarray(0, dtype=self.output_type.dtype).dtype.num
-        fail = sub['fail']
-        ctx = sub['params']
-        kname = self.gpu_kernels(node, nodename)[0].objvar
-        otypecode = str(self.output_type.typecode)
-
         return """
         npy_int64 M1 = 2147483647;      //2^31 - 1
-        // The +1 is to avoid odims[0] which fails on windows
-        size_t odims[%(ndim)s+1];
         size_t n_elements = 1;
         unsigned int n_streams;
         int must_alloc_sample = ((NULL == %(o_sample)s)
                 || !pygpu_GpuArray_Check((PyObject*)%(o_sample)s)
                 || !(%(o_sample)s->ga.flags & GA_C_CONTIGUOUS)
-                || (PyGpuArray_NDIM(%(o_sample)s) != %(ndim)s));
+                || (PyGpuArray_NDIM(%(o_sample)s) != %(params)s->ndim));
+
+        size_t* odims = (size_t*)malloc(%(params)s->ndim * sizeof(size_t));
+        if (odims == NULL) {
+            PyErr_NoMemory();
+            %(just_fail)s
+        }
 
         if (PyArray_NDIM(%(size)s) != 1)
         {
             PyErr_SetString(PyExc_ValueError, "size must be vector");
             %(fail)s
         }
-        if (PyArray_DIMS(%(size)s)[0] != %(ndim)s)
+        if (PyArray_DIMS(%(size)s)[0] != %(params)s->ndim)
         {
             PyErr_Format(PyExc_ValueError, "size must have length %%i (not %%li)",
-                %(ndim)s, PyArray_DIMS(%(size)s)[0]);
+                %(params)s->ndim, PyArray_DIMS(%(size)s)[0]);
             %(fail)s
         }
 
-        for (int i = 0; i < %(ndim)s; ++i)
+        for (int i = 0; i < %(params)s->ndim; ++i)
         {
             odims[i] = *(dtype_%(size)s *)PyArray_GETPTR1(%(size)s, i);
             n_elements *= odims[i];
@@ -214,8 +212,8 @@ class GPUA_mrg_uniform(GpuKernelBase, mrg_uniform_base):
         if (must_alloc_sample)
         {
             Py_XDECREF(%(o_sample)s);
-            %(o_sample)s = pygpu_empty(%(ndim)s, odims, %(otypecode)s, GA_C_ORDER,
-                                       %(ctx)s, Py_None);
+            %(o_sample)s = pygpu_empty(%(params)s->ndim, odims, %(params)s->otypecode, GA_C_ORDER,
+                                       %(params)s->context, Py_None);
             if(!%(o_sample)s)
             {
                 %(fail)s;
@@ -228,7 +226,7 @@ class GPUA_mrg_uniform(GpuKernelBase, mrg_uniform_base):
         }
 
         Py_XDECREF(%(o_rstate)s);
-        if (%(inplace)s)
+        if (%(params)s->inplace)
         {
             Py_INCREF(%(rstate)s);
             %(o_rstate)s = %(rstate)s;
@@ -280,10 +278,22 @@ class GPUA_mrg_uniform(GpuKernelBase, mrg_uniform_base):
               %(fail)s
           }
         }
-        """ % locals()
+
+        free(odims);
+        """ % dict(rstate=inp[0], size=inp[1],
+                   o_rstate=out[0], o_sample=out[1],
+                   kname=self.gpu_kernels(node, nodename)[0].objvar,
+                   params=sub['params'],
+                   just_fail=sub['fail'],
+                   fail="""
+                   {
+                     free(odims);
+                     %(fail)s
+                   }
+                   """ % dict(fail=sub['fail']))
 
     def c_code_cache_version(self):
-        return (12,)
+        return (14,)
 
 
 @register_opt2([mrg_uniform], 'fast_compile')

--- a/theano/gpuarray/rng_mrg.py
+++ b/theano/gpuarray/rng_mrg.py
@@ -25,9 +25,7 @@ class GPUA_mrg_uniform(GpuKernelBase, mrg_uniform_base):
     _f16_ok = True
     params_type = mrg_uniform_base.params_type.extended(otypecode=int_t, context=gpu_context_type)
 
-    def get_params(self, node):
-        return self.params_type.get_params(self, otypecode=self.output_type.typecode,
-                                           context=GpuKernelBase.get_params(self, node))
+    otypecode = property(lambda self: self.output_type.typecode)
 
     def make_node(self, rstate, size):
         # error checking slightly redundant here, since
@@ -42,6 +40,9 @@ class GPUA_mrg_uniform(GpuKernelBase, mrg_uniform_base):
         return Apply(self,
                      [rstate, size],
                      [rstate.type(), output_type])
+
+    def get_params(self, node):
+        return self.params_type.get_params(self, context=node.inputs[0].type.context)
 
     @classmethod
     def new(cls, rstate, ndim, dtype, size):

--- a/theano/gpuarray/subtensor.py
+++ b/theano/gpuarray/subtensor.py
@@ -7,9 +7,11 @@ from six import integer_types
 from six.moves import StringIO
 
 from theano import tensor, gof, Op
+from theano.gof import ParamsType
 from theano.gradient import grad_not_implemented
 import theano.tensor as T
 from theano.tensor.subtensor import IncSubtensor, Subtensor, get_idx_list
+from theano.scalar import bool as bool_t, int32 as int_t, uint32 as size_t
 
 try:
     import pygpu
@@ -589,7 +591,14 @@ class GpuAdvancedIncSubtensor1(Op):
     """
     _f16_ok = True
     __props__ = ('inplace', 'set_instead_of_inc')
-    params_type = gpu_context_type
+    params_type = ParamsType(inplace=bool_t,
+                             set_instead_of_inc=bool_t,
+                             context=gpu_context_type,
+                             # following params are for c_init_code_struct.
+                             ndim_input_0=size_t,
+                             ndim_input_1=size_t,
+                             typecode_input_0=int_t,
+                             typecode_input_1=int_t)
 
     def __init__(self, inplace=False, set_instead_of_inc=False):
         self.inplace = inplace
@@ -629,12 +638,17 @@ class GpuAdvancedIncSubtensor1(Op):
         return gof.Apply(self, [x_, y_, ilist_], [x_.type()])
 
     def get_params(self, node):
-        return node.outputs[0].type.context
+        return self.params_type.get_params(self, context=node.outputs[0].type.context,
+                                           # following params are for c_init_code_struct.
+                                           ndim_input_0=node.inputs[0].ndim,
+                                           ndim_input_1=node.inputs[1].ndim,
+                                           typecode_input_0=node.inputs[0].type.typecode,
+                                           typecode_input_1=node.inputs[1].type.typecode)
 
     # We can't use the parent version that loops on each index
     # as we also need to loop when set_instead_of_inc is True and the
     # parent doesn't loop in that case.
-    def perform(self, node, inp, out_, ctx=None):
+    def perform(self, node, inp, out_, params=None):
         # TODO opt to make this inplace
         x, y, idx = inp
         out, = out_
@@ -695,21 +709,18 @@ class GpuAdvancedIncSubtensor1(Op):
         return """
         gpuelemwise_arg args[2] = {{0}};
         args[0].name = "a";
-        args[0].typecode = %(type1)s;
+        args[0].typecode = %(params)s->typecode_input_0;
         args[0].flags = GE_READ|GE_WRITE;
         args[1].name = "b";
-        args[1].typecode = %(type2)s;
+        args[1].typecode = %(params)s->typecode_input_1;
         args[1].flags = GE_READ;
-        iadd = GpuElemwise_new(%(ctx)s->ctx, "", "a += b",
-                               2, args, %(nd)s, GE_CONVERT_F16);
+        iadd = GpuElemwise_new(%(params)s->context->ctx, "", "a += b",
+                               2, args, %(params)s->ndim_input_1, GE_CONVERT_F16);
         if (iadd == NULL) {
           PyErr_SetString(PyExc_RuntimeError, "Could not intialize inplace add support");
           %(fail)s
         }
-        """ % dict(ctx=sub['params'], fail=sub['fail'],
-                   type1=node.inputs[0].type.typecode,
-                   type2=node.inputs[1].type.typecode,
-                   nd=node.inputs[1].ndim)
+        """ % dict(params=sub['params'], fail=sub['fail'])
 
     def c_code(self, node, name, inputs, outputs, sub):
         if (node.inputs[0].ndim != node.inputs[1].ndim):
@@ -717,18 +728,26 @@ class GpuAdvancedIncSubtensor1(Op):
 
         return """
         PyGpuArrayObject *row_x, *row_y;
-        ssize_t start[%(nd)s], step[%(nd)s];
+        size_t nd = %(params)s->ndim_input_0;
+        ssize_t *start = NULL, *step = NULL;
         size_t num_indices, j;
         int ret;
         int broadcast_y;
 
-        for (j = 0; j < %(nd)s; j++) {
+        start = (ssize_t*)malloc(nd * sizeof(ssize_t));
+        step = (ssize_t*)malloc(nd * sizeof(ssize_t));
+        if (start == NULL || step == NULL) {
+            PyErr_NoMemory();
+            %(fail)s
+        }
+
+        for (j = 0; j < nd; ++j) {
           start[j] = 0;
           step[j] = 1;
         }
         step[0] = 0;
         num_indices = PyArray_SIZE(%(ind)s);
-        if (!%(inplace)s) {
+        if (!%(params)s->inplace) {
           %(out)s = theano_try_copy(%(out)s, %(x)s);
           if (%(out)s == NULL)
             %(fail)s
@@ -767,7 +786,7 @@ class GpuAdvancedIncSubtensor1(Op):
               %(fail)s;
             }
 
-            if (%(set_instead_of_inc)s) {
+            if (%(params)s->set_instead_of_inc) {
               ret = GpuArray_setarray(&row_x->ga, &row_y->ga);
             } else {
               void *args[2];
@@ -781,13 +800,21 @@ class GpuAdvancedIncSubtensor1(Op):
               PyErr_SetString(PyExc_RuntimeError, "Failed to set/inc elements");
           }
         }
+
+        free(start);
+        free(step);
         """ % dict(x=inputs[0], y=inputs[1], ind=inputs[2], out=outputs[0],
-                   fail=sub['fail'], inplace=int(self.inplace),
-                   nd=node.inputs[0].ndim,
-                   set_instead_of_inc=int(self.set_instead_of_inc))
+                   params=sub['params'],
+                   fail="""
+                   {
+                        free(start);
+                        free(step);
+                        %s
+                   }
+                   """ % sub['fail'])
 
     def c_code_cache_version(self):
-        return (1,)
+        return (3,)
 
 
 class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, HideC,
@@ -798,6 +825,8 @@ class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, HideC,
 
     """
     _f16_ok = True
+    params_type = GpuAdvancedIncSubtensor1.params_type
+    get_params = GpuAdvancedIncSubtensor1.get_params
 
     def make_node(self, x, y, ilist):
         """
@@ -830,14 +859,11 @@ class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, HideC,
 
         return gof.Apply(self, [x_, y_, ilist_], [x_.type()])
 
-    def get_params(self, node):
-        return node.outputs[0].type.context
-
-    def perform(self, node, inp, out, ctx):
+    def perform(self, node, inp, out, params):
         return super(GpuAdvancedIncSubtensor1_dev20, self).perform(node, inp, out)
 
     def c_code_cache_version(self):
-        return (9,)
+        return (11,)
 
     def c_headers(self):
         return ['<numpy_compat.h>', '<gpuarray_helper.h>',
@@ -847,7 +873,7 @@ class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, HideC,
         return [os.path.dirname(__file__)]
 
     def c_code(self, node, name, inputs, outputs, sub):
-        ctx = self.get_params(node)
+        ctx = self.get_params(node).context
         if ctx.kind != b'cuda':
             raise NotImplementedError("cuda only")
         if (node.inputs[0].ndim != node.inputs[1].ndim or
@@ -855,16 +881,9 @@ class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, HideC,
                 int(ctx.bin_id[-2]) < 2):
             raise NotImplementedError("This case does not have C code yet.")
 
-        x = inputs[0]
-        y = inputs[1]
-        ind = inputs[2]
-        out = outputs[0]
-        fail = sub['fail']
-        set_instead_of_inc = int(self.set_instead_of_inc)
-        inplace = int(self.inplace)
         return """
 int err;
-if (%(inplace)s) {
+if (%(params)s->inplace) {
   Py_XDECREF(%(out)s);
   %(out)s = %(x)s;
   Py_INCREF(%(out)s);
@@ -874,25 +893,19 @@ if (%(inplace)s) {
 if (!%(out)s) {
   %(fail)s
 }
-if (GpuArray_vector_add_fast(%(out)s, %(y)s, %(ind)s, %(set_instead_of_inc)s)) {
+if (GpuArray_vector_add_fast(%(out)s, %(y)s, %(ind)s, %(params)s->set_instead_of_inc)) {
   %(fail)s
 }
-        """ % locals()
+        """ % dict(x=inputs[0], y=inputs[1], ind=inputs[2], out=outputs[0], fail=sub['fail'], params=sub['params'])
 
     def gpu_kernels(self, node, nodename):
         dtype_x = node.inputs[0].dtype
         dtype_y = node.inputs[1].dtype
         dtype_ind = node.inputs[2].dtype
-        dtype_out = node.outputs[0].dtype
-        itemsize_x = np.dtype(dtype_x).itemsize
-        itemsize_y = np.dtype(dtype_y).itemsize
-        itemsize_ind = np.dtype(dtype_ind).itemsize
-        itemsize_out = np.dtype(dtype_out).itemsize
-        flags = Kernel.get_flags(dtype_x, dtype_y, dtype_ind)
         type_x = gpuarray.dtype_to_ctype(dtype_x)
         type_y = gpuarray.dtype_to_ctype(dtype_y)
         type_ind = gpuarray.dtype_to_ctype(dtype_ind)
-        type_out = gpuarray.dtype_to_ctype(dtype_out)
+        flags = Kernel.get_flags(dtype_x, dtype_y, dtype_ind)
         kname = "k_vector_add_fast"
         k_var = "k_vector_add_fast_" + nodename
         code = """
@@ -1000,7 +1013,7 @@ __device__ ga_half atomicExch(ga_half *addr, ga_half val) {
              }
              return;
         }
-        """ % locals()
+        """ % dict(type_x=type_x, type_y=type_y, type_ind=type_ind)
         params = [
             'uintp', 'uintp', 'intp', 'intp', gpuarray.GpuArray, 'uintp',
             'uintp', 'uintp', 'intp', 'intp', gpuarray.GpuArray, 'uintp',
@@ -1010,26 +1023,19 @@ __device__ ga_half atomicExch(ga_half *addr, ga_half val) {
                        flags=flags, objvar=k_var)]
 
     def c_support_code_struct(self, node, nodename):
-        dtype_x = node.inputs[0].dtype
-        dtype_y = node.inputs[1].dtype
-        dtype_ind = node.inputs[2].dtype
-        dtype_out = node.outputs[0].dtype
-        itemsize_x = np.dtype(dtype_x).itemsize
-        itemsize_y = np.dtype(dtype_y).itemsize
-        itemsize_ind = np.dtype(dtype_ind).itemsize
-        itemsize_out = np.dtype(dtype_out).itemsize
-        k_var = "k_vector_add_fast_" + nodename
-
         return super(GpuAdvancedIncSubtensor1_dev20, self).c_support_code_struct(node, nodename) + """
         int GpuArray_vector_add_fast(PyGpuArrayObject* py_self,
                                      PyGpuArrayObject* py_other,
-                                     PyGpuArrayObject *indices_arr,
+                                     PyGpuArrayObject* indices_arr,
                                      const int set_instead_of_inc)
         {
             size_t threads_per_block[3] = {std::min(PyGpuArray_DIMS(py_self)[1], (size_t)256), 1, 1};
             size_t n_blocks[3] = {std::min(PyGpuArray_SIZE(indices_arr), (size_t)4096), 1, 1};
             gpudata *errbuf;
             int err, kerr = 0;
+            size_t itemsize_x = GpuArray_ITEMSIZE(&py_self->ga);
+            size_t itemsize_y = GpuArray_ITEMSIZE(&py_other->ga);
+            size_t itemsize_ind = GpuArray_ITEMSIZE(&indices_arr->ga);
 
             if (threads_per_block[0] > 0 && n_blocks[0] > 0) {
               err = gpudata_property(py_self->ga.data,
@@ -1039,11 +1045,11 @@ __device__ ga_half atomicExch(ga_half *addr, ga_half val) {
                 return 1;
               }
 
-              ssize_t stride_X0 = PyGpuArray_STRIDES(py_self)[0] / %(itemsize_x)s;
-              ssize_t stride_X1 = PyGpuArray_STRIDES(py_self)[1] / %(itemsize_x)s;
-              ssize_t stride_Y0 = PyGpuArray_DIMS(py_other)[0] == 1 ? 0 : PyGpuArray_STRIDES(py_other)[0] / %(itemsize_y)s;
-              ssize_t stride_Y1 = PyGpuArray_DIMS(py_other)[1] == 1 ? 0 : PyGpuArray_STRIDES(py_other)[1] / %(itemsize_y)s;
-              ssize_t stride_ind = PyGpuArray_STRIDES(indices_arr)[0] / %(itemsize_ind)s;
+              ssize_t stride_X0 = PyGpuArray_STRIDES(py_self)[0] / itemsize_x;
+              ssize_t stride_X1 = PyGpuArray_STRIDES(py_self)[1] / itemsize_x;
+              ssize_t stride_Y0 = PyGpuArray_DIMS(py_other)[0] == 1 ? 0 : PyGpuArray_STRIDES(py_other)[0] / itemsize_y;
+              ssize_t stride_Y1 = PyGpuArray_DIMS(py_other)[1] == 1 ? 0 : PyGpuArray_STRIDES(py_other)[1] / itemsize_y;
+              ssize_t stride_ind = PyGpuArray_STRIDES(indices_arr)[0] / itemsize_ind;
               void *kernel_params[] = {(void *)&PyGpuArray_DIMS(py_self)[0],
                                        (void *)&PyGpuArray_DIMS(py_self)[1],
                                        (void *)&stride_X0,
@@ -1083,7 +1089,7 @@ __device__ ga_half atomicExch(ga_half *addr, ga_half val) {
             }
           return 0;
         }
-        """ % locals()
+        """ % dict(k_var="k_vector_add_fast_" + nodename)
 
 
 class GpuExtractDiag(Op):

--- a/theano/gpuarray/subtensor.py
+++ b/theano/gpuarray/subtensor.py
@@ -594,7 +594,8 @@ class GpuAdvancedIncSubtensor1(Op):
     params_type = ParamsType(inplace=bool_t,
                              set_instead_of_inc=bool_t,
                              context=gpu_context_type,
-                             # following params are for c_init_code_struct.
+                             # following params are used into c_init_code_struct(),
+                             # as inputs are not available in that function.
                              ndim_input_0=size_t,
                              ndim_input_1=size_t,
                              typecode_input_0=int_t,
@@ -639,7 +640,7 @@ class GpuAdvancedIncSubtensor1(Op):
 
     def get_params(self, node):
         return self.params_type.get_params(self, context=node.outputs[0].type.context,
-                                           # following params are for c_init_code_struct.
+                                           # following params are used into c_init_code_struct().
                                            ndim_input_0=node.inputs[0].ndim,
                                            ndim_input_1=node.inputs[1].ndim,
                                            typecode_input_0=node.inputs[0].type.typecode,
@@ -809,12 +810,12 @@ class GpuAdvancedIncSubtensor1(Op):
                    {
                         free(start);
                         free(step);
-                        %s
+                        %(fail)s
                    }
-                   """ % sub['fail'])
+                   """ % dict(fail=sub['fail']))
 
     def c_code_cache_version(self):
-        return (3,)
+        return (3, 1)
 
 
 class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, HideC,

--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -305,9 +305,8 @@ class mrg_uniform_base(Op):
         self.warned_numpy_version = False
 
     # These attributes (used as params) are created as properties
-    # to avoid some crashes in FAST_COMPILE mode. It seems __init__()
-    # method is not called in that mode, so that some attributes may
-    # not have been initialized.
+    # to make them available even for old pickled objects, e.g.
+    # when testing old interface or when using FAST_COMPILE mode.
     ndim = property(lambda self: self.output_type.ndim)
     otypenum = property(lambda self: np.dtype(self.output_type.dtype).num)
     otype_is_float32 = property(lambda self: self.output_type.dtype == 'float32')
@@ -588,12 +587,12 @@ class mrg_uniform(mrg_uniform_base):
                    fail="""
                    {
                        free(odims);
-                       %s
+                       %(fail)s
                    }
-                   """ % sub['fail'])
+                   """ % dict(fail=sub['fail']))
 
     def c_code_cache_version(self):
-        return (11,)
+        return (11, 1)
 
 
 def guess_n_streams(size, warn=False):

--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -21,7 +21,8 @@ from theano.tensor import (TensorType, as_tensor_variable, get_vector_length,
                            cast, opt, scal)
 from theano.tensor import sqrt, log, sin, cos, join, prod
 from theano.compile import optdb
-from theano.gof import local_optimizer
+from theano.gof import local_optimizer, ParamsType
+from theano.scalar import bool as bool_t, int32 as int_t
 from . import multinomial
 
 
@@ -286,11 +287,17 @@ def mrg_next_value(rstate, new_rstate):
 class mrg_uniform_base(Op):
     # TODO : need description for class, parameter
     __props__ = ("output_type", "inplace")
+    params_type = ParamsType(inplace=bool_t, ndim=int_t, otypenum=int_t, otype_is_float32=bool_t)
 
     def __init__(self, output_type, inplace=False):
         Op.__init__(self)
         self.output_type = output_type
+        # params
         self.inplace = inplace
+        self.ndim = self.output_type.ndim
+        self.otypenum = np.dtype(self.output_type.dtype).num
+        self.otype_is_float32 = (self.output_type.dtype == 'float32')
+        # end params
         if inplace:
             self.destroy_map = {0: [0]}
         self.warned_numpy_version = False
@@ -325,6 +332,7 @@ class mrg_uniform(mrg_uniform_base):
                 broad.append(tensor.extract_constant(size[i]) == 1)
         output_type = self.output_type.clone(broadcastable=broad)()
         rstate = as_tensor_variable(rstate)
+        size = as_tensor_variable(size)
         return Apply(self,
                      [rstate, size],
                      [rstate.type(), output_type])
@@ -337,7 +345,7 @@ class mrg_uniform(mrg_uniform_base):
         op = cls(TensorType(dtype, (False,) * ndim))
         return op(rstate, v_size)
 
-    def perform(self, node, inp, out):
+    def perform(self, node, inp, out, params):
         rstate, size = inp
         o_rstate, o_sample = out
         n_elements = 1
@@ -371,45 +379,105 @@ class mrg_uniform(mrg_uniform_base):
         o_rstate[0] = node.outputs[0].type.filter(rstate)
         o_sample[0] = node.outputs[1].type.filter(rval.reshape(size))
 
+    def c_support_code(self):
+        return "\n".join("""
+        void cpu_rng_mrg_uniform_%(dtype)s(PyArrayObject* o_sample, PyArrayObject* o_rstate,
+                                           npy_int64 n_elements, int n_streams) {
+            const npy_int32 i0 = 0;
+            const npy_int32 i7 = 7;
+            const npy_int32 i9 = 9;
+            const npy_int32 i15 = 15;
+            const npy_int32 i16 = 16;
+            const npy_int32 i22 = 22;
+            const npy_int32 i24 = 24;
+
+            const npy_int32 M1 = 2147483647;      //2^31 - 1
+            const npy_int32 M2 = 2147462579;      //2^31 - 21069
+            const npy_int32 MASK12 = 511;       //2^9 - 1
+            const npy_int32 MASK13 = 16777215;  //2^24 - 1
+            const npy_int32 MASK2 = 65535;      //2^16 - 1
+            const npy_int32 MULT2 = 21069;
+
+            %(dtype)s* sample_data = (%(dtype)s *) PyArray_DATA(o_sample);
+            npy_int32* state_data = (npy_int32 *) PyArray_DATA(o_rstate);
+            for (int i = 0; i < n_elements; ++i)
+            {
+                npy_int32 * state_data_i = state_data + (i%%n_streams)*6;
+                npy_int32 y1, y2, x11, x12, x13, x21, x22, x23;
+
+                x11 = state_data_i[0];
+                x12 = state_data_i[1];
+                x13 = state_data_i[2];
+                x21 = state_data_i[3];
+                x22 = state_data_i[4];
+                x23 = state_data_i[5];
+
+                y1 = ((x12 & MASK12) << i22) + (x12 >> i9) + ((x13 & MASK13) << i7) + (x13 >> i24);
+                if ((y1 < 0 || y1 >= M1))     //must also check overflow
+                    y1 -= M1;
+                y1 += x13;
+                if ((y1 < 0 or y1 >= M1))
+                    y1 -= M1;
+                x13 = x12;
+                x12 = x11;
+                x11 = y1;
+
+                y1 = ((x21 & MASK2) << i15) + (MULT2 * (x21 >> i16));
+                if (y1 < 0 || y1 >= M2)
+                    y1 -= M2;
+                y2 = ((x23 & MASK2) << i15) + (MULT2 * (x23 >> i16));
+                if (y2 < 0 || y2 >= M2)
+                    y2 -= M2;
+                y2 += x23;
+                if (y2 < 0 || y2 >= M2)
+                    y2 -= M2;
+                y2 += y1;
+                if (y2 < 0 or y2 >= M2)
+                    y2 -= M2;
+
+                x23 = x22;
+                x22 = x21;
+                x21 = y2;
+
+                if (x11 <= x21) {
+                    assert((x11 - x21 + M1) <= M1);
+                    sample_data[i] = (x11 - x21 + M1) * %(NORM)s;
+                }
+                else
+                {
+                    assert(x11 - x21 <= M1);
+                    sample_data[i] = (x11 - x21) * %(NORM)s;
+                }
+
+                state_data_i[0]= x11;
+                state_data_i[1]= x12;
+                state_data_i[2]= x13;
+                state_data_i[3]= x21;
+                state_data_i[4]= x22;
+                state_data_i[5]= x23;
+            }
+        }
+        """ % dict(dtype=dtype, NORM=NORM) for dtype, NORM in (
+            ('npy_float32', '4.6566126e-10f'),
+            ('npy_float64', '4.656612873077392578125e-10')
+        ))
+
     def c_code(self, node, name, inp, out, sub):
-        rstate, size = inp
         # If we try to use the C code here with something else than a
         # TensorType, something is wrong (likely one of the GPU ops
         # not defining C code correctly).
-        assert isinstance(node.inputs[0].type, TensorType)
-        o_rstate, o_sample = out
-        if self.inplace:
-            o_rstate_requirement = (
-                'NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_ALIGNED')
-        else:
-            o_rstate_requirement = (
-                'NPY_ARRAY_ENSURECOPY|NPY_ARRAY_C_CONTIGUOUS|'
-                'NPY_ARRAY_ALIGNED')
-        ndim = self.output_type.ndim
-        o_type_num = np.asarray(0, dtype=self.output_type.dtype).dtype.num
-        fail = sub['fail']
-        if self.output_type.dtype == 'float32':
-            otype = 'float'
-            NORM = '4.6566126e-10f'  # np.float32(1.0/(2**31+65))
-            # this was determined by finding the biggest number such that
-            # np.float32(number * M1) < 1.0
-        else:
-            otype = 'double'
-            NORM = '4.656612873077392578125e-10'
+        # NB: first node should always be a TensorType, as it is created with as_tensor_variable() into make_node.
         return """
         //////// <code generated by mrg_uniform>
-        // The +1 is to avoid odims[0] which fails on windows
-        // We have to read size[i] as an int64, but odims has to be intp*
-        // for NumPy on 32-bit platforms.
-        npy_intp odims[%(ndim)s+1];
         npy_int64 odims_i;
         npy_int64 n_elements = 1;
         int n_streams = 0;
         int must_alloc_sample = ((NULL == %(o_sample)s)
-                                 || (PyArray_NDIM(%(o_sample)s) != %(ndim)s)
+                                 || (PyArray_NDIM(%(o_sample)s) != %(params)s->ndim)
                                  || !(PyArray_ISCONTIGUOUS(%(o_sample)s)));
-        %(otype)s * sample_data;
-        npy_int32 * state_data;
+        int o_rstate_requirement = %(params)s->inplace ?
+                                    (NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_ALIGNED) :
+                                    (NPY_ARRAY_ENSURECOPY|NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_ALIGNED);
 
         const npy_int32 i0 = 0;
         const npy_int32 i7 = 7;
@@ -426,19 +494,27 @@ class mrg_uniform(mrg_uniform_base):
         const npy_int32 MASK2 = 65535;      //2^16 - 1
         const npy_int32 MULT2 = 21069;
 
+        // We have to read size[i] as an int64, but odims has to be intp*
+        // for NumPy on 32-bit platforms.
+        npy_intp* odims = (npy_intp*)malloc(%(params)s->ndim * sizeof(npy_intp));
+        if (odims == NULL) {
+            PyErr_NoMemory();
+            %(just_fail)s
+        }
+
         if (PyArray_NDIM(%(size)s) != 1)
         {
             PyErr_SetString(PyExc_ValueError, "size must be vector");
             %(fail)s
         }
-        if (PyArray_DIMS(%(size)s)[0] != %(ndim)s)
+        if (PyArray_DIMS(%(size)s)[0] != %(params)s->ndim)
         {
             PyErr_Format(PyExc_ValueError, "size must have length %%i (not %%i)",
-                %(ndim)s, int(PyArray_DIMS(%(size)s)[0]));
+                %(params)s->ndim, int(PyArray_DIMS(%(size)s)[0]));
             %(fail)s
         }
 
-        for (int i = 0; i < %(ndim)s; ++i)
+        for (int i = 0; i < %(params)s->ndim; ++i)
         {
             odims_i = *(dtype_%(size)s *)PyArray_GETPTR1(%(size)s, i);
             odims[i] = odims_i;
@@ -459,7 +535,7 @@ class mrg_uniform(mrg_uniform_base):
         if (must_alloc_sample)
         {
             Py_XDECREF(%(o_sample)s);
-            %(o_sample)s = (PyArrayObject*)PyArray_SimpleNew(%(ndim)s, odims, %(o_type_num)s);
+            %(o_sample)s = (PyArrayObject*)PyArray_SimpleNew(%(params)s->ndim, odims, %(params)s->otypenum);
             if(!%(o_sample)s) {
                 PyErr_SetString(PyExc_MemoryError, "failed to alloc mrg_uniform output");
                 %(fail)s
@@ -468,7 +544,7 @@ class mrg_uniform(mrg_uniform_base):
         Py_XDECREF(%(o_rstate)s);
         %(o_rstate)s = (PyArrayObject*)PyArray_FromAny(
             (PyObject*)%(rstate)s,
-            NULL, 0, 0, %(o_rstate_requirement)s,NULL);
+            NULL, 0, 0, o_rstate_requirement,NULL);
 
         if (PyArray_NDIM(%(o_rstate)s) != 2)
         {
@@ -487,69 +563,27 @@ class mrg_uniform(mrg_uniform_base):
         }
         n_streams = PyArray_DIMS(%(o_rstate)s)[0];
 
-        sample_data = (%(otype)s *) PyArray_DATA(%(o_sample)s);
-        state_data = (npy_int32 *) PyArray_DATA(%(o_rstate)s);
-        for (int i = 0; i < n_elements; ++i)
-        {
-            npy_int32 * state_data_i = state_data + (i%%n_streams)*6;
-            npy_int32 y1, y2, x11, x12, x13, x21, x22, x23;
-
-            x11 = state_data_i[0];
-            x12 = state_data_i[1];
-            x13 = state_data_i[2];
-            x21 = state_data_i[3];
-            x22 = state_data_i[4];
-            x23 = state_data_i[5];
-
-            y1 = ((x12 & MASK12) << i22) + (x12 >> i9) + ((x13 & MASK13) << i7) + (x13 >> i24);
-            if ((y1 < 0 || y1 >= M1))     //must also check overflow
-                y1 -= M1;
-            y1 += x13;
-            if ((y1 < 0 or y1 >= M1))
-                y1 -= M1;
-            x13 = x12;
-            x12 = x11;
-            x11 = y1;
-
-            y1 = ((x21 & MASK2) << i15) + (MULT2 * (x21 >> i16));
-            if (y1 < 0 || y1 >= M2)
-                y1 -= M2;
-            y2 = ((x23 & MASK2) << i15) + (MULT2 * (x23 >> i16));
-            if (y2 < 0 || y2 >= M2)
-                y2 -= M2;
-            y2 += x23;
-            if (y2 < 0 || y2 >= M2)
-                y2 -= M2;
-            y2 += y1;
-            if (y2 < 0 or y2 >= M2)
-                y2 -= M2;
-
-            x23 = x22;
-            x22 = x21;
-            x21 = y2;
-
-            if (x11 <= x21) {
-                assert((x11 - x21 + M1) <= M1);
-                sample_data[i] = (x11 - x21 + M1) * %(NORM)s;
-            }
-            else
-            {
-                assert(x11 - x21 <= M1);
-                sample_data[i] = (x11 - x21) * %(NORM)s;
-            }
-
-            state_data_i[0]= x11;
-            state_data_i[1]= x12;
-            state_data_i[2]= x13;
-            state_data_i[3]= x21;
-            state_data_i[4]= x22;
-            state_data_i[5]= x23;
+        if (%(params)s->otype_is_float32) {
+            cpu_rng_mrg_uniform_npy_float32(%(o_sample)s, %(o_rstate)s, n_elements, n_streams);
+        } else {
+            cpu_rng_mrg_uniform_npy_float64(%(o_sample)s, %(o_rstate)s, n_elements, n_streams);
         }
+
+        free(odims);
         //////// </ code generated by mrg_uniform>
-        """ % locals()
+        """ % dict(rstate=inp[0], size=inp[1],
+                   o_rstate=out[0], o_sample=out[1],
+                   params=sub['params'],
+                   just_fail=sub['fail'],
+                   fail="""
+                   {
+                       free(odims);
+                       %s
+                   }
+                   """ % sub['fail'])
 
     def c_code_cache_version(self):
-        return (8, )
+        return (11,)
 
 
 def guess_n_streams(size, warn=False):

--- a/theano/tensor/nnet/neighbours.py
+++ b/theano/tensor/nnet/neighbours.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import theano
 from theano import Op, Apply
+from theano.gof import EnumList
 import theano.tensor as T
 from theano.gradient import grad_not_implemented
 from theano.gradient import grad_undefined
@@ -33,12 +34,18 @@ class Images2Neibs(Op):
     """
 
     __props__ = ("mode",)
+    params_type = EnumList(('MODE_VALID', 'valid'),
+                           ('MODE_IGNORE_BORDERS', 'ignore_borders'),
+                           ('MODE_WRAP_CENTERED', 'wrap_centered'))
+
+    def get_params(self, node):
+        return self.mode
 
     def __init__(self, mode='valid'):
         if mode not in ['valid', 'wrap_centered', 'ignore_borders']:
             raise NotImplementedError("Only the mode valid, ignore_borders"
                                       " and wrap_centered have been"
-                                      " implemented for the op Images2Neibs")
+                                      " implemented for the op %s" % type(self).__name__)
         self.mode = mode
 
     def __str__(self):
@@ -152,9 +159,9 @@ class Images2Neibs(Op):
                 grad_undefined(self, 2, neib_step)]
 
     def c_code_cache_version(self):
-        return (7,)
+        return (8,)
 
-    def perform(self, node, inp, out_):
+    def perform(self, node, inp, out_, params):
         ten4, neib_shape, neib_step = inp
         z, = out_
         # GpuImages2Neibs should not run this perform in DebugMode
@@ -278,11 +285,6 @@ class Images2Neibs(Op):
         return [(z_dim0, z_dim1)]
 
     def c_code(self, node, name, inp, out, sub):
-        ten4, neib_shape, neib_step = inp
-        z, = out
-
-        fail = sub['fail']
-        mode = self.mode
         return """
 #ifndef CEIL_INTDIV
 #define CEIL_INTDIV(a, b) ((a/b) + ((a %% b) ? 1: 0))
@@ -342,7 +344,7 @@ class Images2Neibs(Op):
             %(fail)s;
         }
 
-        if ( "%(mode)s" == "wrap_centered") {
+        if (%(mode)s == MODE_WRAP_CENTERED) {
             if (c%%2!=1 || d%%2!=1){
                 PyErr_Format(PyExc_TypeError,
                              "Images2Neibs: in mode wrap_centered"
@@ -364,7 +366,7 @@ class Images2Neibs(Op):
             grid_c = CEIL_INTDIV(((PyArray_DIMS(%(ten4)s))[2]),step_x);
             grid_d = CEIL_INTDIV(((PyArray_DIMS(%(ten4)s))[3]),step_y);
 
-        }else if ( "%(mode)s" == "valid") {
+        } else if (%(mode)s == MODE_VALID) {
             if ( ((PyArray_DIMS(%(ten4)s))[2] < c) ||
                  ( (((PyArray_DIMS(%(ten4)s))[2]-c) %% step_x)!=0))
             {
@@ -389,14 +391,14 @@ class Images2Neibs(Op):
             grid_c = 1+(((PyArray_DIMS(%(ten4)s))[2]-c)/step_x);
             //number of patch in width
             grid_d = 1+(((PyArray_DIMS(%(ten4)s))[3]-d)/step_y);
-        }else if ( "%(mode)s" == "ignore_borders") {
+        } else if (%(mode)s == MODE_IGNORE_BORDERS) {
             //number of patch in height
             grid_c = 1+(((PyArray_DIMS(%(ten4)s))[2]-c)/step_x);
             //number of patch in width
             grid_d = 1+(((PyArray_DIMS(%(ten4)s))[3]-d)/step_y);
-        }else{
+        } else {
             PyErr_Format(PyExc_TypeError,
-                         "Images2Neibs: unknow mode '%(mode)s'");
+                         "Images2Neibs: unknow mode %%d", %(mode)s);
             %(fail)s;
         }
 
@@ -456,7 +458,7 @@ class Images2Neibs(Op):
                         for (int i = 0; i < c; i++)     // loop over c
                         {
                             int ten4_2 = i + a * step_x;
-                            if ( "%(mode)s" == "wrap_centered" ){
+                            if (%(mode)s == MODE_WRAP_CENTERED) {
                                 ten4_2 -= wrap_centered_idx_shift_x;
                                 if ( ten4_2 < 0 ) ten4_2 += height;
                                 else if (ten4_2 >= height) ten4_2 -= height;
@@ -465,7 +467,7 @@ class Images2Neibs(Op):
                             {
 
                                 int ten4_3 = j + b * step_y;
-                                if ( "%(mode)s" == "wrap_centered" ){
+                                if (%(mode)s == MODE_WRAP_CENTERED) {
                                     ten4_3 -= wrap_centered_idx_shift_y;
                                     if ( ten4_3 < 0 ) ten4_3 += width;
                                     else if (ten4_3 >= width) ten4_3 -= width;
@@ -482,7 +484,8 @@ class Images2Neibs(Op):
                         }
                     }
         } // END NESTED SCOPE
-        """ % locals()
+        """ % dict(ten4=inp[0], neib_shape=inp[1], neib_step=inp[2], z=out[0],
+                   fail=sub['fail'], mode=sub['params'])
 
 
 def images2neibs(ten4, neib_shape, neib_step=None, mode='valid'):

--- a/theano/tensor/signal/pool.c
+++ b/theano/tensor/signal/pool.c
@@ -1,0 +1,320 @@
+#section support_code
+
+typedef struct _PoolDimUtils {
+    int* z;
+    int* r;
+    int* ws;
+    int* st;
+    int* pd;
+} PoolDimUtils;
+int PoolDimUtils_init(PoolDimUtils* p, size_t nd) {
+    p->z = (int*)malloc(nd * sizeof(int));
+    p->r = (int*)malloc(nd * sizeof(int));
+    p->ws = (int*)malloc(nd * sizeof(int));
+    p->st = (int*)malloc(nd * sizeof(int));
+    p->pd = (int*)malloc(nd * sizeof(int));
+    return (p->z != NULL && p->r != NULL && p->ws != NULL && p->st != NULL && p->pd != NULL);
+}
+void PoolDimUtils_cleanup(PoolDimUtils* p) {
+    free(p->z);
+    free(p->r);
+    free(p->ws);
+    free(p->st);
+    free(p->pd);
+    p->z = p->r = p->ws = p->st = p->pd = NULL;
+}
+
+typedef struct _PoolRunUtils {
+    int* r_st;
+    int* r_end;
+    int* r_idx;
+    npy_intp* i_idx;
+    npy_intp* o_idx;
+} PoolRunUtils;
+int PoolRunUtils_init(PoolRunUtils* p, size_t nd, size_t total_ndim) {
+    p->r_st = (int*)malloc(nd * sizeof(int));
+    p->r_end = (int*)malloc(nd * sizeof(int));
+    p->r_idx = (int*)malloc(nd * sizeof(int));
+    p->i_idx = (npy_intp*)malloc(total_ndim * sizeof(npy_intp));
+    p->o_idx = (npy_intp*)malloc(total_ndim * sizeof(npy_intp));
+    return (p->r_st != NULL && p->r_end != NULL && p->r_idx != NULL && p->i_idx != NULL && p->o_idx != NULL);
+};
+void PoolRunUtils_cleanup(PoolRunUtils* p) {
+    free(p->r_st);
+    free(p->r_end);
+    free(p->r_idx);
+    free(p->i_idx);
+    free(p->o_idx);
+    p->r_st = p->r_end = p->r_idx = NULL;
+    p->i_idx = p->o_idx = NULL;
+};
+
+#section support_code_apply
+
+void loop_over_pooling_region(PyArrayObject* _x, int dim_id, int total_ndim, int non_pool_ndim,
+                              PoolRunUtils* pool_r, DTYPE_INPUT_0* collector, PARAMS_TYPE* p) {
+    int* r_st = pool_r->r_st;
+    int* r_end = pool_r->r_end;
+    npy_intp* i_idx = pool_r->i_idx;
+    // go through the pooled region in the unpadded input
+    for (int m = r_st[dim_id]; m < r_end[dim_id]; ++m) {
+        i_idx[non_pool_ndim + dim_id] = m;
+
+        int next_dim = dim_id + 1;
+        if (next_dim < p->ndim) {
+            loop_over_pooling_region(_x, next_dim, total_ndim, non_pool_ndim, pool_r, collector, p);
+        } else {
+            // update maximum
+            DTYPE_INPUT_0 a;
+            if (total_ndim == 4)
+                a = ((DTYPE_INPUT_0 *) (PyArray_GETPTR4(_x, i_idx[0], i_idx[1], i_idx[2], i_idx[3])))[0];
+            else
+                a = ((DTYPE_INPUT_0 *) (PyArray_GetPtr(_x, i_idx)))[0];
+
+            if (p->mode == MODE_MAX) {
+                *collector = (a > *collector) ? a : *collector;
+            } else {
+                *collector += a;
+            }
+        }
+
+    } // for loop over region
+}
+
+void loop_over_pooling_dimension(PyArrayObject* _x, int dim_id, int total_ndim, int non_pool_ndim,
+                                 PoolDimUtils* pool_d, PoolRunUtils* pool_r, DTYPE_INPUT_0* collector,
+                                 PyArrayObject* out, PARAMS_TYPE* p) {
+    int* r_st = pool_r->r_st;
+    int* r_end = pool_r->r_end;
+    int* r_idx = pool_r->r_idx;
+    npy_intp* i_idx = pool_r->i_idx;
+    npy_intp* o_idx = pool_r->o_idx;
+    int* z = pool_d->z;
+    int* r = pool_d->r;
+    int* ws = pool_d->ws;
+    int* st = pool_d->st;
+    int* pd = pool_d->pd;
+    for (r_idx[dim_id] = 0; r_idx[dim_id] < z[dim_id]; ++r_idx[dim_id]) {
+        r_st[dim_id] = r_idx[dim_id] * st[dim_id];
+        r_end[dim_id] = r_st[dim_id] + ws[dim_id];
+        // skip the padding
+        r_st[dim_id] = r_st[dim_id] < pd[dim_id] ? pd[dim_id] : r_st[dim_id];
+        r_end[dim_id] = r_end[dim_id] > (r[dim_id] - pd[dim_id]) ? r[dim_id] - pd[dim_id] : r_end[dim_id];
+        // from padded_img space to img space
+        r_st[dim_id] -= pd[dim_id];
+        r_end[dim_id] -= pd[dim_id];
+        // handle the case where no padding, ignore border is True
+        if (p->ignore_border) {
+            r_end[dim_id] = r_end[dim_id] > r[dim_id] ? r[dim_id] : r_end[dim_id];
+        }
+        // use the index to find the correct position in the output
+        o_idx[non_pool_ndim + dim_id] = r_idx[dim_id];
+
+        int next_dim = dim_id + 1;
+        if (next_dim < p->ndim) {
+            /// New loop with i+1.
+            loop_over_pooling_dimension(_x, next_dim, total_ndim, non_pool_ndim, pool_d, pool_r, collector, out, p);
+        } else {
+            /// Local code.
+            // get a pointer to the correct position in the output
+            DTYPE_OUTPUT_0 *z_ptr;
+            if (total_ndim == 4)
+                z_ptr = ((DTYPE_OUTPUT_0 *) (PyArray_GETPTR4(out, o_idx[0], o_idx[1], o_idx[2], o_idx[3])));
+            else
+                z_ptr = ((DTYPE_OUTPUT_0 *) (PyArray_GetPtr(out, o_idx)));
+            if (p->mode == MODE_MAX) {
+                for (int ii = 0; ii < p->ndim; ++ii) {
+                    // set the first index of dimension ii.
+                    i_idx[non_pool_ndim + ii] = r_st[ii];
+                }
+                // use the first element as the initial value of collector
+                if (total_ndim == 4)
+                    *collector = ((DTYPE_INPUT_0 *) (PyArray_GETPTR4(_x, i_idx[0], i_idx[1], i_idx[2], i_idx[3])))[0];
+                else
+                    *collector = ((DTYPE_INPUT_0 *) (PyArray_GetPtr(_x, i_idx)))[0];
+
+                loop_over_pooling_region(_x, 0, total_ndim, non_pool_ndim, pool_r, collector, p);
+
+                z_ptr[0] = *collector;
+            } else {
+                // Case if p->mode in {MODE_SUM, MODE_AVERAGE_EXC_PAD, MODE_AVERAGE_INC_PAD}.
+                // initialize the sum at zero
+                *collector = ((DTYPE_INPUT_0) (0));
+
+                loop_over_pooling_region(_x, 0, total_ndim, non_pool_ndim, pool_r, collector, p);
+
+                if (p->mode == MODE_SUM) {
+                    z_ptr[0] = *collector;
+                } else if (p->mode == MODE_AVERAGE_INC_PAD && p->ignore_border) {
+                    DTYPE_OUTPUT_0 region_size = 1;
+                    for (int ii = 0; ii < p->ndim; ++ii)
+                        region_size *= ws[ii];
+                    z_ptr[0] = *collector / region_size;
+                } else {
+                    DTYPE_OUTPUT_0 region_size = 1;
+                    for (int ii = 0; ii < p->ndim; ++ii)
+                        region_size *= (r_end[ii] - r_st[ii]);
+                    z_ptr[0] = *collector / region_size;
+                }
+            }
+        }
+    }
+}
+
+int APPLY_SPECIFIC(pool)(PyArrayObject* _x, PyArrayObject* _ws, PyArrayObject* _stride, PyArrayObject* _pad,
+                          PyArrayObject** out, PARAMS_TYPE* wrapper) {
+    int typenum = PyArray_ObjectType((PyObject *) _x, 0);
+    int total_ndim = PyArray_NDIM(_x);
+    int nd = wrapper->ndim;
+    int non_pool_ndim = total_ndim - nd;
+    if (PyArray_NDIM(_x) != total_ndim) {
+        PyErr_Format(PyExc_ValueError, "x must be a %d-D ndarray", total_ndim);
+        return -1;
+    }
+    if (PyArray_DIM(_ws, 0) != nd) {
+        PyErr_Format(PyExc_ValueError, "ws must be a vector of size %d", nd);
+        return -1;
+    }
+    if (PyArray_DIM(_stride, 0) != nd) {
+        PyErr_Format(PyExc_ValueError, "stride must be a vector of size %d", nd);
+        return -1;
+    }
+    if (PyArray_DIM(_pad, 0) != nd) {
+        PyErr_Format(PyExc_ValueError, "pad must be a vector of size %d", nd);
+        return -1;
+    }
+    PoolDimUtils pool_d;
+    if (!PoolDimUtils_init(&pool_d, nd)) {
+        PyErr_NoMemory();
+        PoolDimUtils_cleanup(&pool_d);
+        return -1;
+    }
+    int* z = pool_d.z;		// shape of the output
+    int* r = pool_d.r;		// shape of the padded_input
+    int* ws = pool_d.ws;
+    int* st = pool_d.st;
+    int* pd = pool_d.pd;
+    int nonzero_padding = 0;
+    for (int i = 0; i < nd; ++i) {
+        ws[i] = *((npy_intp *) PyArray_GETPTR1(_ws, i));
+        st[i] = *((npy_intp *) PyArray_GETPTR1(_stride, i));
+        pd[i] = *((npy_intp *) PyArray_GETPTR1(_pad, i));
+        r[i] = PyArray_DIMS(_x)[non_pool_ndim + i] + 2 * pd[i];
+        if (pd[i] > 0)
+            nonzero_padding = 1;
+    }
+    if (!wrapper->ignore_border && nonzero_padding) {
+        PyErr_SetString(PyExc_ValueError, "padding must be zero when ignore border is False");
+        PoolDimUtils_cleanup(&pool_d);
+        return -1;
+    }
+    if (wrapper->ignore_border) {
+        for (int i = 0; i < nd; ++i) {
+            // '/' in C is different from '/' in python
+            if (r[i] - ws[i] < 0) {
+                z[i] = 0;
+            } else {
+                z[i] = (r[i] - ws[i]) / st[i] + 1;
+            }
+        }
+    } else for (int i = 0; i < nd; ++i) {
+        // decide how many rows/cols the output has
+        if (st[i] >= ws[i]) {
+            z[i] = (r[i] - 1) / st[i] + 1;
+        } else {
+            z[i] = std::max(0, (r[i] - 1 - ws[i] + st[i]) / st[i]) + 1;
+        }
+
+        assert(z[i] > 0);
+    }
+    // memory allocation of z if necessary
+    int mem_nec = 0;
+    if ((!(*out)) || *PyArray_DIMS(*out) != total_ndim) {
+        mem_nec = 1;
+    }
+    if (!mem_nec) {
+        for (int i = 0; i < non_pool_ndim; ++i) {
+            if (PyArray_DIMS(*out)[i] != PyArray_DIMS(_x)[i]) {
+                mem_nec = 1;
+                break;
+            }
+        }
+    }
+    if (!mem_nec) {
+        for (int i = 0; i < nd; ++i) {
+            if (PyArray_DIMS(*out)[non_pool_ndim + i] != z[i]) {
+                mem_nec = 1;
+                break;
+            }
+        }
+    }
+    if (mem_nec) {
+        if (*out) Py_XDECREF(*out);
+        npy_intp* dims = (npy_intp*)malloc(total_ndim * sizeof(npy_intp));
+        if (dims == NULL) {
+            PyErr_NoMemory();
+            PoolDimUtils_cleanup(&pool_d);
+            return -1;
+        }
+        for (int i = 0; i < non_pool_ndim; ++i) {
+            dims[i] = PyArray_DIMS(_x)[i];
+        }
+        for (int i = 0; i < nd; ++i) {
+            dims[non_pool_ndim + i] = z[i];
+        }
+        //TODO: zeros not necessary
+        *out = (PyArrayObject *) PyArray_ZEROS(total_ndim, dims, typenum, 0);
+        free(dims);
+    }
+    // initialize temp var for the value in a region
+    DTYPE_INPUT_0 collector;
+    int z_prod = 1;
+    // do not run if any z[i] is zero
+    for (int i = 0; i < nd; ++i) {
+        z_prod *= z[i];
+    }
+    if (z_prod) {
+        PoolRunUtils pool_r;
+        if (!PoolRunUtils_init(&pool_r, nd, total_ndim)) {
+            PyErr_NoMemory();
+            PoolDimUtils_cleanup(&pool_d);
+            PoolRunUtils_cleanup(&pool_r);
+            return -1;
+        }
+        // will be used to hold start and end index of a region
+        int* r_st = pool_r.r_st;
+        int* r_end = pool_r.r_end;
+        // index for iterating over the pooling regions
+        int* r_idx = pool_r.r_idx;
+        // placeholder for PyArray indexing (output)
+        npy_intp* o_idx = pool_r.o_idx;
+        // placeholder for PyArray indexing (input)
+        npy_intp* i_idx = pool_r.i_idx;
+        // loop over non-pooling dimensions
+        int non_pooling_prod = 1;
+        for (int i = 0; i < non_pool_ndim; ++i) {
+            non_pooling_prod *= PyArray_DIMS(_x)[i];
+        }
+        /** first loop over non-pooling dimensions **/
+        // NB: Pragma directive for OpenMP should be ignored by the compiler if OpenMP is not available.
+        #pragma omp parallel for private(r_st, r_end, r_idx, i_idx, o_idx, maximum) schedule(static)
+        for (int t = 0; t < non_pooling_prod; ++t) {
+            // compute the non-pooling index in each dimension
+            if (non_pool_ndim != 0) {
+                o_idx[0] = t;
+                i_idx[0] = t;
+                for (int i = 1; i < non_pool_ndim; ++i) {
+                    o_idx[i] = o_idx[i - 1] / PyArray_DIMS(_x)[i - 1];
+                    o_idx[i - 1] = o_idx[i - 1] % PyArray_DIMS(_x)[i - 1];
+                    i_idx[i] = o_idx[i];
+                    i_idx[i - 1] = o_idx[i - 1];
+                }
+            }
+            // then loop over each region in each pooling dimension
+            loop_over_pooling_dimension(_x, 0, total_ndim, non_pool_ndim, &pool_d, &pool_r, &collector, *out, wrapper);
+        } // for loop over non-pooling dimensions
+        PoolRunUtils_cleanup(&pool_r);
+    } // if z_prod
+    PoolDimUtils_cleanup(&pool_d);
+    return 0;
+}

--- a/theano/tensor/signal/pool.py
+++ b/theano/tensor/signal/pool.py
@@ -613,6 +613,9 @@ class Pool(OpenMPOp, COp):
         headers += super(Pool, self).c_headers()
         return headers
 
+    def c_code_cache_version(self):
+        return (COp.c_code_cache_version(self), self.openmp)
+
 
 class PoolGrad(OpenMPOp):
     __props__ = ('ignore_border', 'mode', 'ndim')

--- a/theano/tensor/signal/tests/test_pool.py
+++ b/theano/tensor/signal/tests/test_pool.py
@@ -1146,6 +1146,11 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
                 utt.assert_allclose(var_dx, fix_dx)
 
     def test_old_pool_interface(self):
+        # Temporarly desactivated because I got some errors
+        # even with Python 3 since I converted signal.Pool to a COp.
+        # Should we just drop old interface testing ? Is it used again ?
+        if issubclass(Pool, theano.gof.COp):
+            raise SkipTest('Skip old pool interface.')
         if sys.version_info[0] != 3:
             # Only tested with python 3 because of pickling issues.
             raise SkipTest('Skip old pool interface with python 2.x')

--- a/theano/tensor/signal/tests/test_pool.py
+++ b/theano/tensor/signal/tests/test_pool.py
@@ -364,7 +364,7 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
             utt.assert_allclose(np.asarray(output_shape), numpy_output_val.shape)
             f = function([], maxpool_op)
             output_val = f()
-            utt.assert_allclose(output_val, numpy_output_val)
+            utt.assert_allclose(numpy_output_val, output_val)
 
     def test_DownsampleFactorMaxStride(self):
         rng = np.random.RandomState(utt.fetch_seed())

--- a/theano/tensor/signal/tests/test_pool.py
+++ b/theano/tensor/signal/tests/test_pool.py
@@ -1146,11 +1146,6 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
                 utt.assert_allclose(var_dx, fix_dx)
 
     def test_old_pool_interface(self):
-        # Temporarly desactivated because I got some errors
-        # even with Python 3 since I converted signal.Pool to a COp.
-        # Should we just drop old interface testing ? Is it used again ?
-        if issubclass(Pool, theano.gof.COp):
-            raise SkipTest('Skip old pool interface.')
         if sys.version_info[0] != 3:
             # Only tested with python 3 because of pickling issues.
             raise SkipTest('Skip old pool interface with python 2.x')

--- a/theano/tensor/subtensor.py
+++ b/theano/tensor/subtensor.py
@@ -12,7 +12,7 @@ import theano
 from theano.compat import izip
 from theano.gradient import DisconnectedType
 from theano import gof
-from theano.gof import Apply, hashtype, Op, Type, MethodNotDefined
+from theano.gof import Apply, hashtype, Op, Type, MethodNotDefined, ParamsType
 from theano.printing import pprint
 from theano import scalar as scal
 from theano.tensor.basic import alloc
@@ -1681,6 +1681,7 @@ class AdvancedSubtensor1(Op):
     # of the grad() method.
     __props__ = ()
     _f16_ok = True
+    check_input = False
 
     def __init__(self, sparse_grad=False):
         self.sparse_grad = sparse_grad
@@ -1868,10 +1869,13 @@ class AdvancedIncSubtensor1(Op):
     """
 
     __props__ = ('inplace', 'set_instead_of_inc')
+    check_input = False
+    params_type = ParamsType(inplace=scal.bool,
+                             set_instead_of_inc=scal.int8)
 
     def __init__(self, inplace=False, set_instead_of_inc=False):
-        self.inplace = inplace
-        self.set_instead_of_inc = set_instead_of_inc
+        self.inplace = bool(inplace)
+        self.set_instead_of_inc = int(bool(set_instead_of_inc))
         if inplace:
             self.destroy_map = {0: [0]}
 
@@ -1952,17 +1956,11 @@ class AdvancedIncSubtensor1(Op):
             raise NotImplementedError
         x, y, idx = input_names
         out = output_names[0]
-        fail = sub['fail']
-        inc_or_set = 1 - self.set_instead_of_inc
-        if self.inplace:  # convert bool to int
-            inplace = 1
-        else:
-            inplace = 0
         copy_of_x = self.copy_of_x(x)
 
         return """
         PyObject* rval = NULL;
-        if (%(inplace)s)
+        if (%(params)s->inplace)
         {
             if (%(x)s != %(out)s)
             {
@@ -1976,19 +1974,20 @@ class AdvancedIncSubtensor1(Op):
             Py_XDECREF(%(out)s);
             %(out)s = %(copy_of_x)s;
         }
-        PyObject *arglist = Py_BuildValue("OOOi",%(out)s, %(idx)s, %(y)s, %(inc_or_set)d);
+        PyObject *arglist = Py_BuildValue("OOOi",%(out)s, %(idx)s, %(y)s, (1 - %(params)s->set_instead_of_inc));
         rval = inplace_increment(NULL, arglist);
         Py_XDECREF(arglist);
         if (rval == NULL) {
             %(fail)s;
         }
         Py_XDECREF(rval);
-        """ % locals()
+        """ % dict(x=x, y=y, idx=idx, out=out, copy_of_x=copy_of_x,
+                   params=sub['params'], fail=sub['fail'])
 
     def c_code_cache_version(self):
-        return (3,)
+        return (4,)
 
-    def perform(self, node, inp, out_):
+    def perform(self, node, inp, out_, params):
         # TODO opt to make this inplace
         x, y, idx = inp
         out, = out_


### PR DESCRIPTION
This PR updates many Ops so that they now use ParamsType to bundle many parameters into one Python/C object.

I was mainly focused on new backend, but I have also worked on other Ops outside gpuarray.

I may have to re-read the code again, but we can now observe ParamsType in some different use cases.

@abergeron @lamblin @nouiz 