### PR TITLE
Remove goto in OpenMP Elemwise fail code

### DIFF
--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -94,22 +94,36 @@ class CodeBlock:
                         "\ndouble __DUMMY_%(id)i;\n" % sub)  # % sub
 
 
-def failure_code(sub):
+def failure_code(sub, use_goto=True):
     """
     Code contained in sub['fail'], usually substituted for %(fail)s.
 
     It sets information about current error, then goto the code
     actually handling the failure, which is defined in struct_gen().
 
+    Parameters
+    ----------
+    sub: dict
+        Contains other code snippets that can be substituted,
+        in particular 'failure_var' and 'id'.
+    use_goto: bool, True by default
+        Include a "goto" statement to the failure label.
+        Passing False is sometimes required, in which cases we have to
+        be careful to avoid executing incorrect code.
+
     """
+    if use_goto:
+        goto_statement = 'goto __label_%(id)i;' % sub
+    else:
+        goto_statement = ''
     return '''{
-        %(failure_var)s = %(id)s;
+        %(failure_var)s = %(id)i;
         if (!PyErr_Occurred()) {
             PyErr_SetString(PyExc_RuntimeError,
                 "Unexpected error in an Op's C code. "
                 "No Python exception was set.");
-            }
-        goto __label_%(id)i;}''' % sub
+        }
+        %(goto_statement)s}''' % dict(sub, goto_statement=goto_statement)
 
 
 def failure_code_init(sub):

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -1040,15 +1040,7 @@ second dimension
         if self.openmp:
             # If we are using openmp, we need to get rid of the "goto"
             # statement in sub['fail']. For now we recreate it here.
-            fail = '''
-                {
-                    %(failure_var)s = %(id)s;
-                    if (!PyErr_Occurred()) {
-                        PyErr_SetString(PyExc_RuntimeError,
-                            "Unexpected error in an Op's C code. "
-                            "No Python exception was set.");
-                    }
-                }''' % sub
+            fail = gof.cc.failure_code(sub, use_goto=False)
         else:
             fail = sub['fail']
         task_code = self.scalar_op.c_code(


### PR DESCRIPTION
This makes the code compile, but crash gracefully when intdiv / mod by zero, when using openmp in elemwise.

Fixes #5875.
Counter-proposal for #5876.