### PR TITLE
avoid creating float64 variables

### DIFF
--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -775,13 +775,13 @@ class MRG_RandomStreams(object):
         """
         low = as_tensor_variable(low)
         high = as_tensor_variable(high)
-        
+
         if dtype is None:
             dtype = scal.upcast(config.floatX, low.dtype, high.dtype)
 
         low = cast(low, dtype=dtype)
         high = cast(high, dtype=dtype)
-        
+
         low = undefined_grad(low)
         high = undefined_grad(high)
 

--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -774,14 +774,16 @@ class MRG_RandomStreams(object):
 
         """
         low = as_tensor_variable(low)
-        low = undefined_grad(low)
         high = as_tensor_variable(high)
-        high = undefined_grad(high)
+        
         if dtype is None:
             dtype = scal.upcast(config.floatX, low.dtype, high.dtype)
 
         low = cast(low, dtype=dtype)
         high = cast(high, dtype=dtype)
+        
+        low = undefined_grad(low)
+        high = undefined_grad(high)
 
         if isinstance(size, tuple):
             msg = "size must be a tuple of int or a Theano variable"


### PR DESCRIPTION
If theano config.warn64 is set on 'raise' or 'warn', this generates an error/warning. This should help avoid that.