### PR TITLE
Fix tests in debugmode

### DIFF
--- a/.jenkins/jenkins_buildbot_python2.sh
+++ b/.jenkins/jenkins_buildbot_python2.sh
@@ -45,6 +45,9 @@ FLAGS=on_shape_error=raise,$FLAGS
 #      while we want all other runs to run with 'floatX=float64'.
 FLAGS=${FLAGS},device=cpu,floatX=float64
 
+# Only use elements in the cache for < 7 days
+FLAGS=${FLAGS},cmodule.age_thresh_use=604800
+
 echo "Executing tests with mode=FAST_RUN"
 NAME=fastrun
 FILE=${ROOT_CWD}/theano_${NAME}_tests.xml

--- a/.jenkins/jenkins_buildbot_python2_debug.sh
+++ b/.jenkins/jenkins_buildbot_python2_debug.sh
@@ -42,6 +42,9 @@ FLAGS=on_shape_error=raise,$FLAGS
 #      while we want all other runs to run with 'floatX=float64'.
 FLAGS=${FLAGS},device=cpu,floatX=float64
 
+# Only use elements in the cache for < 7 days
+FLAGS=${FLAGS},cmodule.age_thresh_use=604800
+
 #we change the seed and record it everyday to test different combination. We record it to be able to reproduce bug caused by different seed. We don't want multiple test in DEBUG_MODE each day as this take too long.
 seed=$RANDOM
 echo "Executing tests with mode=DEBUG_MODE with seed of the day $seed"

--- a/theano/gof/tests/test_types.py
+++ b/theano/gof/tests/test_types.py
@@ -117,6 +117,7 @@ class MyOpEnumList(Op):
                 o[0] = a // b
         else:
             raise NotImplementedError('Unknown op id ' + str(op))
+        o[0] = np.float64(o[0])
 
     def c_code_cache_version(self):
         return (1,)


### PR DESCRIPTION
I suspect the issues regarding [the bool / int8 mismatch](http://darjeeling.iro.umontreal.ca:8080/job/Theano_buildbot_python2_debug/153/testReport/theano.tensor.tests.test_opt/Test_local_useless_elemwise_comparison/test_equality_shapes/) are due to old cached module, since I cannot reproduce locally.