### PR TITLE
Added an optimization for inplace gpu_cusolver_solve and tests

### DIFF
--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -60,6 +60,11 @@ def attach_cusolver_handle_to_context(ctx):
         with ctx:
             ctx.cusolver_handle = cusolver.cusolverDnCreate()
 
+# it is a subset of all cases available in slinalg's MATRIX_STRUCTURE
+MATRIX_STRUCTURES_SOLVE = (
+    'general',
+    'symmetric')
+
 
 class GpuCusolverSolve(Op):
     """
@@ -79,7 +84,8 @@ class GpuCusolverSolve(Op):
         self.inplace = inplace
         self.A_structure = A_structure
         if self.inplace:
-            self.destroy_map = {0: [0, 1]}
+            self.destroy_map = {0: [0]}
+        assert A_structure in MATRIX_STRUCTURES_SOLVE
         super(GpuCusolverSolve, self).__init__()
 
     def make_node(self, inp1, inp2):


### PR DESCRIPTION
This addresses some comments in #5754 :
 - fixed the destroy map
 - added an optimization for inplace (for A) in gpuarray/opt.py
 - added A_structure and trans in the op lifter

For the op lifter, as only 2 cases are implemented in gpu_solve (general using LU decomposition and symmetric using cholesky) I considered that if the user requires a solve op for another case, it would be more efficient to keep it on the cpu, than to move it to the gpu using the general LU case.
@notoraptor 