### PR TITLE
minor fix to test_nnet.py

### DIFF
--- a/theano/tensor/nnet/tests/test_nnet.py
+++ b/theano/tensor/nnet/tests/test_nnet.py
@@ -1775,9 +1775,9 @@ class T_sigmoid_binary_crossentropy(unittest.TestCase):
         utt.seed_rng()
 
     def _get_test_inputs(self, n=50):
-        pred, target = numpy.random.randn(2, n).astype(config.floatX)
+        pred, target = np.random.randn(2, n).astype(config.floatX)
         # apply sigmoid to target, but not pred
-        return [pred, 1 / (1 + numpy.exp(-target))]
+        return [pred, 1 / (1 + np.exp(-target))]
 
     def test_matches_binary_crossentropy(self):
         """


### PR DESCRIPTION
Noticed that Travis [failed](https://travis-ci.org/Theano/Theano/builds/227725922) after @lamblin merged my PR #5758, as I wrote the tests added to `test_nnet.py` when the import was done as `import numpy`, but it's apparently since been changed to `import numpy as np`.  This updates `test_nnet.py` accordingly and should fix the Travis failures.