### PR TITLE
Magma gpu QR/Cholesky/Eigh

### DIFF
--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -375,8 +375,18 @@ class GpuMagmaBase(COp):
             return [config.magma.library_path]
         return []
 
+    def prepare_node(self, node, storage_map, compute_map, impl):
+        from skcuda.magma import magma_init
+        ctx = node.inputs[0].type.context
+        if not getattr(ctx, 'is_magma_initialized', False):
+            magma_init()
+            ctx.is_magma_initialized = True
 
-class GpuMagmaSVD(COp):
+    def get_params(self, node):
+        return node.inputs[0].type.context
+
+
+class GpuMagmaSVD(GpuMagmaBase):
     """Computes the svd of a matrix :math:`A` using magma library.
 
     .. warning::
@@ -418,6 +428,7 @@ class GpuMagmaSVD(COp):
                                               context_name=ctx_name)()])
 
     def prepare_node(self, node, storage_map, compute_map, impl):
+        super(GpuMagmaSVD, self).prepare_node(node, storage_map, compute_map, impl)
         # Check node to prevent eventual errors with old pickled nodes.
         if self.compute_uv:
             A, B, C = node.outputs

--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -258,6 +258,9 @@ class GpuCholesky(Op):
             self.destroy_map = {0: [0]}
         super(GpuCholesky, self).__init__()
 
+    def clone_inplace(self):
+        return self.__class__(lower=self.lower, inplace=True)
+
     def make_node(self, inp):
         if not cusolver_available:
             raise RuntimeError('CUSOLVER is not available and '
@@ -553,6 +556,9 @@ class GpuMagmaCholesky(CGpuKernelBase):
         if config.magma.library_path:
             return [config.magma.library_path]
         return []
+
+    def clone_inplace(self):
+        return self.__class__(lower=self.lower, inplace=True)
 
     def make_node(self, A):
         ctx_name = infer_context_name(A)

--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -415,7 +415,8 @@ class GpuMagmaSVD(GpuMagmaBase):
         A = gpu_contiguous(A)
         if A.ndim != 2:
             raise LinAlgError("Matrix rank error")
-        assert A.dtype == 'float32'
+        if A.dtype != 'float32':
+            raise TypeError("only `float32` is supported for now")
         if self.compute_uv:
             return theano.Apply(self, [A],
                                 # return S, U, VT
@@ -504,6 +505,8 @@ class GpuMagmaMatrixInverse(GpuMagmaBase):
         A = gpu_contiguous(A)
         if A.ndim != 2:
             raise LinAlgError("Matrix rank error")
+        if A.dtype != 'float32':
+            raise TypeError("only `float32` is supported for now")
         return theano.Apply(self, [A], [A.type()])
 
     def get_params(self, node):
@@ -548,6 +551,8 @@ class GpuMagmaCholesky(GpuMagmaBase, CGpuKernelBase):
         A = gpu_contiguous(A)
         if A.ndim != 2:
             raise LinAlgError("Matrix rank error")
+        if A.dtype != 'float32':
+            raise TypeError("only `float32` is supported for now")
         return theano.Apply(self, [A], [A.type()])
 
     def get_op_params(self):
@@ -583,6 +588,8 @@ class GpuMagmaQR(GpuMagmaBase, CGpuKernelBase):
         A = gpu_contiguous(A)
         if A.ndim != 2:
             raise LinAlgError("Matrix rank error")
+        if A.dtype != 'float32':
+            raise TypeError("only `float32` is supported for now")
         if self.complete:
             return theano.Apply(self, [A], [A.type(), A.type()])
         else:
@@ -620,6 +627,8 @@ class GpuMagmaEigh(GpuMagmaBase):
         A = gpu_contiguous(A)
         if A.ndim != 2:
             raise LinAlgError("Matrix rank error")
+        if A.dtype != 'float32':
+            raise TypeError("only `float32` is supported for now")
         if self.compute_v:
             return theano.Apply(self, [A],
                                 [GpuArrayType(A.dtype, broadcastable=[False],

--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -379,8 +379,9 @@ class GpuMagmaBase(COp):
         from skcuda.magma import magma_init
         ctx = node.inputs[0].type.context
         if not getattr(ctx, 'is_magma_initialized', False):
-            magma_init()
-            ctx.is_magma_initialized = True
+            with ctx:
+                magma_init()
+                ctx.is_magma_initialized = True
 
     def get_params(self, node):
         return node.inputs[0].type.context

--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -664,7 +664,7 @@ class GpuMagmaEigh(GpuMagmaBase):
                                 # return D, V
                                 [GpuArrayType(A.dtype, broadcastable=[False],
                                               context_name=ctx_name)(),
-                                A.type()])
+                                 A.type()])
         else:
             return theano.Apply(self, [A],
                                 # return D

--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -400,6 +400,7 @@ class GpuMagmaSVD(COp):
     def make_node(self, A):
         ctx_name = infer_context_name(A)
         A = as_gpuarray_variable(A, ctx_name)
+        A = gpu_contiguous(A)
         if A.ndim != 2:
             raise LinAlgError("Matrix rank error")
         assert A.dtype == 'float32'
@@ -484,13 +485,13 @@ class GpuMagmaMatrixInverse(GpuMagmaBase):
     def clone_inplace(self):
         return self.__class__(inplace=True)
 
-    def make_node(self, x):
-        ctx_name = infer_context_name(x)
-        x = as_gpuarray_variable(x, ctx_name)
-        assert x.dtype == 'float32'
-        if x.ndim != 2:
+    def make_node(self, A):
+        ctx_name = infer_context_name(A)
+        A = as_gpuarray_variable(A, ctx_name)
+        A = gpu_contiguous(A)
+        if A.ndim != 2:
             raise LinAlgError("Matrix rank error")
-        return theano.Apply(self, [x], [x.type()])
+        return theano.Apply(self, [A], [A.type()])
 
     def get_params(self, node):
         return self.params_type.get_params(self, context=node.inputs[0].type.context)
@@ -603,6 +604,7 @@ class GpuMagmaEigh(GpuMagmaBase):
     def make_node(self, A):
         ctx_name = infer_context_name(A)
         A = as_gpuarray_variable(A, ctx_name)
+        A = gpu_contiguous(A)
         if A.ndim != 2:
             raise LinAlgError("Matrix rank error")
         if self.compute_v:

--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -353,6 +353,7 @@ def gpu_cholesky(A, lower=True):
     return GpuCholesky(lower)(A)
 
 
+# TODO: add support for float64
 class GpuMagmaBase(COp):
     """Base class for magma related operations. Add the necessary headers,
     libraries and optionally the location of headers and library.

--- a/theano/gpuarray/magma_cholesky.c
+++ b/theano/gpuarray/magma_cholesky.c
@@ -52,25 +52,24 @@ int APPLY_SPECIFIC(magma_cholesky)(PyGpuArrayObject *A, PyGpuArrayObject **L,
                     "GpuMagmaCholesky: unsupported data type");
     return -1;
   }
-
-  // This is early to match the exit() in the fail label.
-  cuda_enter(c->ctx);
-  magma_init();
-
   if (!GpuArray_IS_C_CONTIGUOUS(&A->ga)) {
     PyErr_SetString(PyExc_ValueError,
                     "GpuMagmaCholesky: requires data to be C-contiguous");
-    goto fail;
+    return -1;
   }
   if (PyGpuArray_NDIM(A) != 2) {
     PyErr_SetString(PyExc_ValueError, "GpuMagmaCholesky: matrix rank error");
-    goto fail;
+    return -1;
   }
   dims = PyGpuArray_DIMS(A);
   if (dims[0] != dims[1]) {
     PyErr_SetString(PyExc_ValueError, "GpuMagmaCholesky: matrix is not square");
-    goto fail;
+    return -1;
   }
+
+  // This is early to match the exit() in the fail label.
+  cuda_enter(c->ctx);
+  magma_init();
 
 #ifdef INPLACE
   Py_XDECREF(*L);

--- a/theano/gpuarray/magma_cholesky.c
+++ b/theano/gpuarray/magma_cholesky.c
@@ -115,8 +115,8 @@ int APPLY_SPECIFIC(magma_cholesky)(PyGpuArrayObject *A, PyGpuArrayObject **L,
 #ifdef LOWER
   res = tril_kernel_scall(1, &n2, 0, n2, N, (*L)->ga.data);
   if (res != GA_NO_ERROR) {
-    PyErr_Format(PyExc_RuntimeError, "GpuMagmaCholesky: triu_kernel %s.",
-                 GpuKernel_error(&k_triu_kernel, res));
+    PyErr_Format(PyExc_RuntimeError, "GpuMagmaCholesky: tril_kernel %s.",
+                 GpuKernel_error(&k_tril_kernel, res));
     goto fail;
   }
 #else

--- a/theano/gpuarray/magma_cholesky.c
+++ b/theano/gpuarray/magma_cholesky.c
@@ -39,7 +39,7 @@ setup_ext_cuda();
 #section support_code_struct
 
 int APPLY_SPECIFIC(magma_cholesky)(PyGpuArrayObject *A, PyGpuArrayObject **L,
-                                   PARAMS_TYPE* params) {
+                                   PARAMS_TYPE *params) {
   const size_t *dims;
   size_t N, n2;
   magma_uplo_t ul;

--- a/theano/gpuarray/magma_cholesky.c
+++ b/theano/gpuarray/magma_cholesky.c
@@ -65,7 +65,6 @@ int APPLY_SPECIFIC(magma_cholesky)(PyGpuArrayObject *A, PyGpuArrayObject **L,
 
   // This is early to match the exit() in the fail label.
   cuda_enter(c->ctx);
-  magma_init();
 
 #ifdef INPLACE
   Py_XDECREF(*L);
@@ -125,7 +124,6 @@ int APPLY_SPECIFIC(magma_cholesky)(PyGpuArrayObject *A, PyGpuArrayObject **L,
 #endif
   res = 0;
 fail:
-  magma_finalize();
   cuda_exit(c->ctx);
   return res;
 }

--- a/theano/gpuarray/magma_cholesky.c
+++ b/theano/gpuarray/magma_cholesky.c
@@ -1,0 +1,136 @@
+#section kernels
+
+#kernel tril_kernel : size, size, *:
+
+KERNEL void tril_kernel(const ga_size nthreads, const ga_size ncols,
+                        GLOBAL_MEM DTYPE_INPUT_0 *a) {
+  // grid stride looping
+  for (ga_size index = GID_0 * LDIM_0 + LID_0; index < nthreads;
+       index += LDIM_0 * GDIM_0) {
+    unsigned int ix = index / ncols;
+    unsigned int iy = index % ncols;
+    if (index < nthreads) {
+      if (ix < iy) {
+        a[index] = 0.0;
+      }
+    }
+  }
+}
+
+#kernel triu_kernel : size, size, *:
+
+KERNEL void triu_kernel(const ga_size nthreads, const ga_size ncols,
+                        GLOBAL_MEM DTYPE_INPUT_0 *a) {
+  // grid stride looping
+  for (ga_size index = GID_0 * LDIM_0 + LID_0; index < nthreads;
+       index += LDIM_0 * GDIM_0) {
+    unsigned int ix = index / ncols;
+    unsigned int iy = index % ncols;
+    if (index < nthreads) {
+      if (ix > iy) {
+        a[index] = 0.0;
+      }
+    }
+  }
+}
+
+#section init_code
+
+setup_ext_cuda();
+
+#section support_code_struct
+
+int APPLY_SPECIFIC(magma_cholesky)(PyGpuArrayObject *A, PyGpuArrayObject **L,
+                                   PyGpuContextObject *c) {
+  const size_t *dims;
+  size_t N, n2;
+  magma_uplo_t ul;
+  int res = -1, info;
+
+  if (A->ga.typecode != GA_FLOAT) {
+    PyErr_SetString(PyExc_TypeError,
+                    "GpuMagmaCholesky: unsupported data type");
+    return -1;
+  }
+
+  // This is early to match the exit() in the fail label.
+  cuda_enter(c->ctx);
+  magma_init();
+
+  if (!GpuArray_IS_C_CONTIGUOUS(&A->ga)) {
+    PyErr_SetString(PyExc_ValueError,
+                    "GpuMagmaCholesky: requires data to be C-contiguous");
+    goto fail;
+  }
+  if (PyGpuArray_NDIM(A) != 2) {
+    PyErr_SetString(PyExc_ValueError, "GpuMagmaCholesky: matrix rank error");
+    goto fail;
+  }
+  dims = PyGpuArray_DIMS(A);
+  if (dims[0] != dims[1]) {
+    PyErr_SetString(PyExc_ValueError, "GpuMagmaCholesky: matrix is not square");
+    goto fail;
+  }
+
+#ifdef INPLACE
+  Py_XDECREF(*L);
+  *L = A;
+  Py_INCREF(*L);
+#else
+  *L = theano_try_copy(*L, A);
+  if (*L == NULL) {
+    PyErr_SetString(
+        PyExc_RuntimeError,
+        "GpuMagmaCholesky: failed to allocate memory for the output");
+    goto fail;
+  }
+#endif
+
+  // magma matrix cholesky
+  N = dims[0];
+  n2 = N * N;
+
+// Magma requires column-major order for the matrix A. Instead of changing
+// matrix order which requires copying data, we can compute cholesky
+// decomposition where we change parameters lower to upper and upper to
+// lower.
+#ifdef LOWER
+  ul = MagmaUpper;
+#else
+  ul = MagmaLower;
+#endif
+  magma_spotrf_gpu(ul, N, (float *)PyGpuArray_DEV_DATA(*L), N, &info);
+  if (info > 0) {
+    PyErr_Format(PyExc_RuntimeError, "GpuMagmaCholesky: the leading minor of "
+                                     "order %d is not positive definite",
+                 info);
+    goto fail;
+  } else if (info < 0) {
+    PyErr_Format(
+        PyExc_RuntimeError,
+        "GpuMagmaCholesky: magma_spotrf_gpu argument %d has an illegal value",
+        -info);
+    goto fail;
+  }
+
+#ifdef LOWER
+  res = tril_kernel_scall(1, &n2, 0, n2, N, (*L)->ga.data);
+  if (res != GA_NO_ERROR) {
+    PyErr_Format(PyExc_RuntimeError, "GpuMagmaCholesky: triu_kernel %s.",
+                 GpuKernel_error(&k_triu_kernel, res));
+    goto fail;
+  }
+#else
+  res = triu_kernel_scall(1, &n2, 0, n2, N, (*L)->ga.data);
+  if (res != GA_NO_ERROR) {
+    PyErr_Format(PyExc_RuntimeError, "GpuMagmaCholesky: triu_kernel %s.",
+                 GpuKernel_error(&k_triu_kernel, res));
+    goto fail;
+  }
+#endif
+  res = 0;
+fail:
+  magma_finalize();
+  cuda_exit(c->ctx);
+  return res;
+}

--- a/theano/gpuarray/magma_cholesky.c
+++ b/theano/gpuarray/magma_cholesky.c
@@ -9,10 +9,8 @@ KERNEL void tril_kernel(const ga_size nthreads, const ga_size ncols,
        index += LDIM_0 * GDIM_0) {
     unsigned int ix = index / ncols;
     unsigned int iy = index % ncols;
-    if (index < nthreads) {
-      if (ix < iy) {
-        a[index] = 0.0;
-      }
+    if (ix < iy) {
+      a[index] = 0.0;
     }
   }
 }
@@ -26,10 +24,8 @@ KERNEL void triu_kernel(const ga_size nthreads, const ga_size ncols,
        index += LDIM_0 * GDIM_0) {
     unsigned int ix = index / ncols;
     unsigned int iy = index % ncols;
-    if (index < nthreads) {
-      if (ix > iy) {
-        a[index] = 0.0;
-      }
+    if (ix > iy) {
+      a[index] = 0.0;
     }
   }
 }

--- a/theano/gpuarray/magma_eigh.c
+++ b/theano/gpuarray/magma_eigh.c
@@ -47,7 +47,6 @@ int APPLY_SPECIFIC(magma_eigh)(PyGpuArrayObject *A_,
 
   // This is early to match the exit() in the fail label.
   cuda_enter(c->ctx);
-  magma_init();
 
   // magma matrix eigen decomposition of a symmetric matrix
   N = PyGpuArray_DIM(A, 0);
@@ -133,7 +132,6 @@ fail:
     magma_free_pinned(work_data);
   if (iwork_data != NULL)
     magma_free_cpu(iwork_data);
-  magma_finalize();
   cuda_exit(c->ctx);
   return res;
 }

--- a/theano/gpuarray/magma_eigh.c
+++ b/theano/gpuarray/magma_eigh.c
@@ -1,0 +1,139 @@
+#section init_code
+
+setup_ext_cuda();
+
+#section support_code_struct
+
+int APPLY_SPECIFIC(magma_eigh)(PyGpuArrayObject *A_,
+                               PyGpuArrayObject **D,
+#ifdef COMPUTE_V
+                               PyGpuArrayObject **V,
+#endif
+                               PyGpuContextObject *c) {
+  PyGpuArrayObject *A = NULL;
+  magma_int_t N, liwork, *iwork_data = NULL;
+  size_t d_dims[1], v_dims[2];
+  magma_uplo_t uplo;
+  magma_vec_t jobz;
+  float *w_data = NULL, *wA_data = NULL, *work_data = NULL, lwork;
+  int res = -1, info;
+
+  if (A_->ga.typecode != GA_FLOAT) {
+    PyErr_SetString(PyExc_TypeError,
+                    "GpuMagmaEigh: Unsupported data type");
+    return -1;
+  }
+  if (!GpuArray_IS_C_CONTIGUOUS(&A_->ga)) {
+    PyErr_SetString(PyExc_ValueError,
+                    "GpuMagmaEigh: requires data to be C-contiguous");
+    return -1;
+  }
+  if (PyGpuArray_NDIM(A_) != 2) {
+    PyErr_SetString(PyExc_ValueError,
+                    "GpuMagmaEigh: matrix rank error");
+    return -1;
+  }
+  if (PyGpuArray_DIM(A_, 0) != PyGpuArray_DIM(A_, 1)) {
+    PyErr_SetString(PyExc_ValueError,
+                    "GpuMagmaEigh: matrix is not square");
+    return -1;
+  }
+  A = pygpu_copy(A_, GA_F_ORDER);
+  if (A == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GpuMagmaQR: failed to change to column-major order");
+    return -1;
+  }
+
+  // This is early to match the exit() in the fail label.
+  cuda_enter(c->ctx);
+  magma_init();
+
+  // magma matrix eigen decomposition of a symmetric matrix
+  N = PyGpuArray_DIM(A, 0);
+
+#ifdef LOWER
+  uplo = MagmaLower;
+#else
+  uplo = MagmaUpper;
+#endif
+#ifdef COMPUTE_V
+  jobz = MagmaVec;
+#else
+  jobz = MagmaNoVec;
+#endif
+
+  if (MAGMA_SUCCESS != magma_smalloc_pinned(&w_data, N)) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GpuMagmaSVD: failed to allocate working memory");
+    goto fail;
+  }
+  if (MAGMA_SUCCESS != magma_smalloc_pinned(&wA_data, N * N)) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GpuMagmaSVD: failed to allocate working memory");
+    goto fail;
+  }
+
+  // query for workspace size
+  magma_ssyevd_gpu(jobz, uplo, N, NULL, N, NULL, NULL, N, &lwork,
+                   -1, &liwork, -1, &info);
+
+  if (MAGMA_SUCCESS != magma_smalloc_pinned(&work_data, (size_t)lwork)) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GpuMagmaEigh: failed to allocate working memory");
+    goto fail;
+  }
+  if (MAGMA_SUCCESS != magma_imalloc_cpu(&iwork_data, liwork)) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GpuMagmaEigh: failed to allocate working memory");
+    goto fail;
+  }
+
+  magma_ssyevd_gpu(jobz, uplo, N, (float *)PyGpuArray_DEV_DATA(A), N, w_data,
+                   wA_data, N, work_data, (size_t)lwork, iwork_data, liwork,
+                   &info);
+  if (info > 0) {
+    PyErr_Format(
+        PyExc_RuntimeError,
+        "GpuMagmaEigh:  %d off-diagonal elements of an didn't converge to zero",
+        info);
+    goto fail;
+  } else if (info < 0) {
+    PyErr_Format(
+        PyExc_RuntimeError,
+        "GpuMagmaEigh: magma_ssyevd_gpu argument %d has an illegal value", -info);
+    goto fail;
+  }
+
+  d_dims[0] = N;
+  if (theano_prep_output(D, 1, d_dims, A->ga.typecode, GA_C_ORDER, c) != 0){
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GpuMagmaEigh: failed to allocate memory for the output");
+    goto fail;
+  }
+  cudaMemcpy(PyGpuArray_DEV_DATA(*D), w_data, N * sizeof(float),
+             cudaMemcpyDeviceToDevice);
+
+#ifdef COMPUTE_V
+  *V = theano_try_copy(*V, A);
+  if (*V == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GpuMagmaEigh: failed to allocate memory for the output");
+    goto fail;
+  }
+#endif
+
+  res = 0;
+fail:
+  if (w_data != NULL)
+    magma_free_pinned(w_data);
+  if (wA_data != NULL)
+    magma_free_pinned(wA_data);
+  if (work_data != NULL)
+    magma_free_pinned(work_data);
+  if (iwork_data != NULL)
+    magma_free_cpu(iwork_data);
+  magma_finalize();
+  cuda_exit(c->ctx);
+  return res;
+}

--- a/theano/gpuarray/magma_eigh.c
+++ b/theano/gpuarray/magma_eigh.c
@@ -65,12 +65,12 @@ int APPLY_SPECIFIC(magma_eigh)(PyGpuArrayObject *A_,
 
   if (MAGMA_SUCCESS != magma_smalloc_pinned(&w_data, N)) {
     PyErr_SetString(PyExc_RuntimeError,
-                    "GpuMagmaSVD: failed to allocate working memory");
+                    "GpuMagmaEigh: failed to allocate working memory");
     goto fail;
   }
   if (MAGMA_SUCCESS != magma_smalloc_pinned(&wA_data, N * N)) {
     PyErr_SetString(PyExc_RuntimeError,
-                    "GpuMagmaSVD: failed to allocate working memory");
+                    "GpuMagmaEigh: failed to allocate working memory");
     goto fail;
   }
 

--- a/theano/gpuarray/magma_eigh.c
+++ b/theano/gpuarray/magma_eigh.c
@@ -132,6 +132,7 @@ fail:
     magma_free_pinned(work_data);
   if (iwork_data != NULL)
     magma_free_cpu(iwork_data);
+  Py_XDECREF(A);
   cuda_exit(c->ctx);
   return res;
 }

--- a/theano/gpuarray/magma_eigh.c
+++ b/theano/gpuarray/magma_eigh.c
@@ -41,7 +41,7 @@ int APPLY_SPECIFIC(magma_eigh)(PyGpuArrayObject *A_,
   A = pygpu_copy(A_, GA_F_ORDER);
   if (A == NULL) {
     PyErr_SetString(PyExc_RuntimeError,
-                    "GpuMagmaQR: failed to change to column-major order");
+                    "GpuMagmaEigh: failed to change to column-major order");
     return -1;
   }
 

--- a/theano/gpuarray/magma_inv.c
+++ b/theano/gpuarray/magma_inv.c
@@ -93,7 +93,6 @@ fail:
     magma_free(piv);
   if (dwork != NULL)
     gpudata_release(dwork);
-  magma_finalize();
   cuda_exit(params->context->ctx);
   return res;
 }

--- a/theano/gpuarray/magma_inv.c
+++ b/theano/gpuarray/magma_inv.c
@@ -25,7 +25,7 @@ int APPLY_SPECIFIC(magma_inv)(PyGpuArrayObject *A, PyGpuArrayObject **A_inv,
   if (!GpuArray_IS_C_CONTIGUOUS(&A->ga)) {
     PyErr_SetString(PyExc_ValueError,
                     "GpuMagmaMatrixInverse: requires data to be C-contiguous");
-    return 1;
+    goto fail;
   }
   if (PyGpuArray_NDIM(A) != 2) {
     PyErr_SetString(PyExc_ValueError,

--- a/theano/gpuarray/magma_inv.c
+++ b/theano/gpuarray/magma_inv.c
@@ -5,7 +5,7 @@ setup_ext_cuda();
 #section support_code_struct
 
 int APPLY_SPECIFIC(magma_inv)(PyGpuArrayObject *A, PyGpuArrayObject **A_inv,
-                              PARAMS_TYPE* params) {
+                              PARAMS_TYPE *params) {
   const size_t *dims;
   magma_int_t N, ldwork, info;
   magma_int_t *piv = NULL;

--- a/theano/gpuarray/magma_inv.c
+++ b/theano/gpuarray/magma_inv.c
@@ -20,7 +20,6 @@ int APPLY_SPECIFIC(magma_inv)(PyGpuArrayObject *A, PyGpuArrayObject **A_inv,
 
   // This is early to match the exit() in the fail label.
   cuda_enter(params->context->ctx);
-  magma_init();
 
   if (!GpuArray_IS_C_CONTIGUOUS(&A->ga)) {
     PyErr_SetString(PyExc_ValueError,

--- a/theano/gpuarray/magma_qr.c
+++ b/theano/gpuarray/magma_qr.c
@@ -67,7 +67,6 @@ int APPLY_SPECIFIC(magma_qr)(PyGpuArrayObject *A_,
 
   // This is early to match the exit() in the fail label.
   cuda_enter(c->ctx);
-  magma_init();
 
   // magma matrix qr
   M = PyGpuArray_DIM(A, 0);
@@ -148,7 +147,6 @@ fail:
     magma_free_pinned(tau_data);
   if (work_data != NULL)
     gpudata_release(work_data);
-  magma_finalize();
   cuda_exit(c->ctx);
   return res;
 }

--- a/theano/gpuarray/magma_qr.c
+++ b/theano/gpuarray/magma_qr.c
@@ -147,6 +147,7 @@ fail:
     magma_free_pinned(tau_data);
   if (work_data != NULL)
     gpudata_release(work_data);
+  Py_XDECREF(A);
   cuda_exit(c->ctx);
   return res;
 }

--- a/theano/gpuarray/magma_qr.c
+++ b/theano/gpuarray/magma_qr.c
@@ -1,9 +1,10 @@
 #section kernels
 
-#kernel triu_kernel : size, size, *:
+#kernel triu_kernel : size, size, size, *:
 
 KERNEL void triu_kernel(const ga_size nthreads, const ga_size ncols,
-                        GLOBAL_MEM DTYPE_INPUT_0 *a) {
+                        const ga_size a_off, GLOBAL_MEM DTYPE_INPUT_0 *a) {
+  a = (GLOBAL_MEM DTYPE_INPUT_0 *)(((char *)a) + a_off);
   // grid stride looping
   for (ga_size index = GID_0 * LDIM_0 + LID_0; index < nthreads;
        index += LDIM_0 * GDIM_0) {
@@ -103,7 +104,7 @@ int APPLY_SPECIFIC(magma_qr)(PyGpuArrayObject *A_,
     goto fail;
   }
   n2 = K * N;
-  res = triu_kernel_scall(1, &n2, 0, n2, N, (*R)->ga.data);
+  res = triu_kernel_scall(1, &n2, 0, n2, N, (*R)->ga.offset, (*R)->ga.data);
   if (res != GA_NO_ERROR) {
     PyErr_Format(PyExc_RuntimeError, "GpuMagmaQR: triu_kernel %s.",
                  GpuKernel_error(&k_triu_kernel, res));

--- a/theano/gpuarray/magma_qr.c
+++ b/theano/gpuarray/magma_qr.c
@@ -49,11 +49,6 @@ int APPLY_SPECIFIC(magma_qr)(PyGpuArrayObject *A_,
                     "GpuMagmaQR: Unsupported data type");
     return -1;
   }
-  if (!GpuArray_IS_C_CONTIGUOUS(&A->ga)) {
-    PyErr_SetString(PyExc_ValueError,
-                    "GpuMagmaQR: requires data to be C-contiguous");
-    return -1;
-  }
 
   // This is early to match the exit() in the fail label.
   cuda_enter(params->context->ctx);

--- a/theano/gpuarray/magma_qr.c
+++ b/theano/gpuarray/magma_qr.c
@@ -1,0 +1,156 @@
+#section kernels
+
+#kernel triu_kernel : size, size, *:
+
+KERNEL void triu_kernel(const ga_size nthreads, const ga_size ncols,
+                        GLOBAL_MEM DTYPE_INPUT_0 *a) {
+  // grid stride looping
+  for (ga_size index = GID_0 * LDIM_0 + LID_0; index < nthreads;
+       index += LDIM_0 * GDIM_0) {
+    const ga_size ix = index / ncols;
+    const ga_size iy = index % ncols;
+    if (ix > iy) {
+      a[index] = 0.0;
+    }
+  }
+}
+
+#section init_code
+
+setup_ext_cuda();
+
+#section support_code
+
+static PyGpuArrayObject *pygpu_narrow(PyGpuArrayObject *src, size_t dim,
+                                      size_t size) {
+  PyGpuArrayObject *src_view = pygpu_view(src, Py_None);
+  src_view->ga.dimensions[dim] = size;
+  return pygpu_copy(src_view, GA_C_ORDER);
+}
+
+#section support_code_struct
+
+int APPLY_SPECIFIC(magma_qr)(PyGpuArrayObject *A_,
+#ifdef COMPLETE
+                             PyGpuArrayObject **Q,
+#endif
+                             PyGpuArrayObject **R,
+                             PyGpuContextObject *c) {
+  PyGpuArrayObject *A = NULL;
+  magma_int_t M, N, K, nb, ldwork;
+  size_t n2;
+  float *tau_data = NULL;
+  gpudata *work_data = NULL;
+  int res = -1, info;
+  A = A_;
+
+  if (A->ga.typecode != GA_FLOAT) {
+    PyErr_SetString(PyExc_TypeError,
+                    "GpuMagmaQR: Unsupported data type");
+    return -1;
+  }
+
+  if (!GpuArray_IS_C_CONTIGUOUS(&A->ga)) {
+    PyErr_SetString(PyExc_ValueError,
+                    "GpuMagmaQR: requires data to be C-contiguous");
+    return -1;
+  }
+  if (PyGpuArray_NDIM(A) != 2) {
+    PyErr_SetString(PyExc_ValueError, "GpuMagmaQR: matrix rank error");
+    return -1;
+  }
+
+  A = pygpu_copy(A_, GA_F_ORDER);
+  if (A == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GpuMagmaQR: failed to change to column-major order");
+    return -1;
+  }
+
+  // This is early to match the exit() in the fail label.
+  cuda_enter(c->ctx);
+  magma_init();
+
+  // magma matrix qr
+  M = PyGpuArray_DIM(A, 0);
+  N = PyGpuArray_DIM(A, 1);
+  K = std::min(M, N);
+
+  if (MAGMA_SUCCESS != magma_smalloc_pinned(&tau_data, N * N)) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GpuMagmaQR: failed to allocate working memory");
+    goto fail;
+  }
+
+  nb = magma_get_sgeqrf_nb(M, N);
+  ldwork = (2 * K + magma_roundup(N, 32)) * nb;
+  work_data = gpudata_alloc(c->ctx, ldwork * sizeof(float), NULL, 0, NULL);
+  if (work_data == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GpuMagmaQR: failed to allocate working memory");
+    goto fail;
+  }
+
+  // compute R
+  magma_sgeqrf2_gpu(M, N, (float *)PyGpuArray_DEV_DATA(A), M, tau_data, &info);
+  if (info != 0) {
+    PyErr_Format(
+        PyExc_RuntimeError,
+        "GpuMagmaQR: magma_sgeqrf2_gpu argument %d has an illegal value", -info);
+    goto fail;
+  }
+  *R = pygpu_narrow(A, 0, K);
+  if (*R == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "GpuMagmaQR: failed to narrow array");
+    goto fail;
+  }
+  n2 = K * N;
+  res = triu_kernel_scall(1, &n2, 0, n2, N, (*R)->ga.data);
+  if (res != GA_NO_ERROR) {
+    PyErr_Format(PyExc_RuntimeError, "GpuMagmaQR: triu_kernel %s.",
+                 GpuKernel_error(&k_triu_kernel, res));
+    goto fail;
+  }
+
+#ifdef COMPLETE
+  // compute Q
+  Py_XDECREF(A);
+  A = pygpu_copy(A_, GA_F_ORDER);
+  if (A == NULL) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "GpuMagmaQR: failed to change to column-major order");
+    return -1;
+  }
+  magma_sgeqrf_gpu(M, N, (float *)PyGpuArray_DEV_DATA(A), M, tau_data,
+                   *(float **)work_data, &info);
+  if (info != 0) {
+    PyErr_Format(
+        PyExc_RuntimeError,
+        "GpuMagmaQR: magma_sgeqrf_gpu argument %d has an illegal value", -info);
+    goto fail;
+  }
+
+  magma_sorgqr_gpu(M, K, K, (float *)PyGpuArray_DEV_DATA(A), M, tau_data,
+                   *(float **)work_data, nb, &info);
+  if (info != 0) {
+    PyErr_Format(
+        PyExc_RuntimeError,
+        "GpuMagmaQR: magma_sorgqr_gpu argument %d has an illegal value", -info);
+    goto fail;
+  }
+  *Q = pygpu_narrow(A, 1, K);
+  if (*Q == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "GpuMagmaQR: failed to narrow array");
+    goto fail;
+  }
+#endif
+  res = 0;
+fail:
+  if (tau_data != NULL)
+    magma_free_pinned(tau_data);
+  if (work_data != NULL)
+    gpudata_release(work_data);
+  magma_finalize();
+  cuda_exit(c->ctx);
+  return res;
+}

--- a/theano/gpuarray/magma_qr.c
+++ b/theano/gpuarray/magma_qr.c
@@ -25,6 +25,7 @@ static PyGpuArrayObject *pygpu_narrow(PyGpuArrayObject *src, size_t dim,
                                       size_t size) {
   PyGpuArrayObject *src_view = pygpu_view(src, Py_None);
   src_view->ga.dimensions[dim] = size;
+  GpuArray_fix_flags(&src_view->ga);
   return pygpu_copy(src_view, GA_C_ORDER);
 }
 

--- a/theano/gpuarray/magma_qr.c
+++ b/theano/gpuarray/magma_qr.c
@@ -72,7 +72,7 @@ int APPLY_SPECIFIC(magma_qr)(PyGpuArrayObject *A_,
   // magma matrix qr
   M = PyGpuArray_DIM(A, 0);
   N = PyGpuArray_DIM(A, 1);
-  K = std::min(M, N);
+  K = M < N ? M : N;
 
   if (MAGMA_SUCCESS != magma_smalloc_pinned(&tau_data, N * N)) {
     PyErr_SetString(PyExc_RuntimeError,

--- a/theano/gpuarray/magma_qr.c
+++ b/theano/gpuarray/magma_qr.c
@@ -49,7 +49,6 @@ int APPLY_SPECIFIC(magma_qr)(PyGpuArrayObject *A_,
                     "GpuMagmaQR: Unsupported data type");
     return -1;
   }
-
   if (!GpuArray_IS_C_CONTIGUOUS(&A->ga)) {
     PyErr_SetString(PyExc_ValueError,
                     "GpuMagmaQR: requires data to be C-contiguous");
@@ -59,7 +58,6 @@ int APPLY_SPECIFIC(magma_qr)(PyGpuArrayObject *A_,
     PyErr_SetString(PyExc_ValueError, "GpuMagmaQR: matrix rank error");
     return -1;
   }
-
   A = pygpu_copy(A_, GA_F_ORDER);
   if (A == NULL) {
     PyErr_SetString(PyExc_RuntimeError,

--- a/theano/gpuarray/magma_svd.c
+++ b/theano/gpuarray/magma_svd.c
@@ -32,7 +32,7 @@ int APPLY_SPECIFIC(magma_svd)(PyGpuArrayObject *A,
   if (!GpuArray_IS_C_CONTIGUOUS(&A->ga)) {
     PyErr_SetString(PyExc_ValueError,
                     "GpuMagmaMatrixInverse: requires data to be C-contiguous");
-    return 1;
+    goto fail;
   }
   if (PyGpuArray_NDIM(A) != 2) {
     PyErr_SetString(PyExc_ValueError,

--- a/theano/gpuarray/magma_svd.c
+++ b/theano/gpuarray/magma_svd.c
@@ -8,7 +8,7 @@ int APPLY_SPECIFIC(magma_svd)(PyGpuArrayObject *A,
                               PyGpuArrayObject **S,
                               PyGpuArrayObject **U, // may be NULL
                               PyGpuArrayObject **VT, // may be NULL
-                              PARAMS_TYPE* params) {
+                              PARAMS_TYPE *params) {
   bool compute_uv = (U != NULL);
   magma_int_t *iwork = NULL, iunused[1];
   magma_int_t M, N, K, ldu, ldv, M_U, N_VT, info;

--- a/theano/gpuarray/magma_svd.c
+++ b/theano/gpuarray/magma_svd.c
@@ -27,7 +27,6 @@ int APPLY_SPECIFIC(magma_svd)(PyGpuArrayObject *A,
 
   // This is early to match the exit() in the fail label.
   cuda_enter(params->context->ctx);
-  magma_init();
 
   if (!GpuArray_IS_C_CONTIGUOUS(&A->ga)) {
     PyErr_SetString(PyExc_ValueError,

--- a/theano/gpuarray/magma_svd.c
+++ b/theano/gpuarray/magma_svd.c
@@ -21,7 +21,7 @@ int APPLY_SPECIFIC(magma_svd)(PyGpuArrayObject *A,
 
   if (A->ga.typecode != GA_FLOAT) {
     PyErr_SetString(PyExc_TypeError,
-                    "GpuMagmaMatrixInverse: Unsupported data type");
+                    "GpuMagmaSVD: Unsupported data type");
     return -1;
   }
 
@@ -31,12 +31,12 @@ int APPLY_SPECIFIC(magma_svd)(PyGpuArrayObject *A,
 
   if (!GpuArray_IS_C_CONTIGUOUS(&A->ga)) {
     PyErr_SetString(PyExc_ValueError,
-                    "GpuMagmaMatrixInverse: requires data to be C-contiguous");
+                    "GpuMagmaSVD: requires data to be C-contiguous");
     goto fail;
   }
   if (PyGpuArray_NDIM(A) != 2) {
     PyErr_SetString(PyExc_ValueError,
-                    "GpuMagmaMatrixInverse: matrix rank error");
+                    "GpuMagmaSVD: matrix rank error");
     goto fail;
   }
 
@@ -44,7 +44,7 @@ int APPLY_SPECIFIC(magma_svd)(PyGpuArrayObject *A,
   // reverse dimensions because MAGMA expects column-major matrices:
   M = PyGpuArray_DIM(A, 1);
   N = PyGpuArray_DIM(A, 0);
-  K = std::min(M, N);
+  K = M < N ? M : N;
 
   if (MAGMA_SUCCESS !=  magma_smalloc_pinned(&a_data, M * N)) {
     PyErr_SetString(PyExc_RuntimeError,

--- a/theano/gpuarray/magma_svd.c
+++ b/theano/gpuarray/magma_svd.c
@@ -166,7 +166,6 @@ fail:
     magma_free_pinned(work);
   if (iwork != NULL)
     magma_free_cpu(iwork);
-  magma_finalize();
   cuda_exit(params->context->ctx);
   return res;
 }

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -2123,7 +2123,7 @@ matrix_ops_db = LocalGroupDB()
 matrix_ops_db2 = LocalGroupDB(local_opt=theano.gof.opt.GraphToGPULocalOptGroup)
 matrix_ops_db2.__name__ = "matrix_ops_db2"
 
-# For Cholesky decomposition, magma is slower than cusolver (tested for
+# For Cholesky decomposition, magma 2.2 is slower than cusolver 8 (tested for
 # matrices of size 1000). Thus, cusolver is prioritized during graph
 # optimizations. To explicitly use magma, you should disable cusolver using
 # `optimizer_excluding=cusolver` in Theano config.

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -2124,12 +2124,12 @@ matrix_ops_db2 = LocalGroupDB(local_opt=theano.gof.opt.GraphToGPULocalOptGroup)
 matrix_ops_db2.__name__ = "matrix_ops_db2"
 lifter = op_lifter([slinalg.Cholesky])(local_gpu_cholesky)
 matrix_ops_db.register("local_gpu_cholesky", lifter,
-                       'gpuarray', 'fast_compile', 'fast_run',
-                       position=1)
+                       'gpuarray', 'fast_compile', 'fast_run', 'cusolver',
+                       position=0)
 matrix_ops_db2.register("local_gpu_cholesky",
                         local_optimizer([slinalg.Cholesky])(local_gpu_cholesky),
-                        'gpuarray', 'fast_compile', 'fast_run',
-                        position=1)
+                        'gpuarray', 'fast_compile', 'fast_run', 'cusolver',
+                        position=0)
 register_opt('fast_compile', name='matrix_ops_db')(matrix_ops_db)
 register_opt2([slinalg.Solve], 'fast_compile', name='matrix_ops_db2')(matrix_ops_db2)
 
@@ -2148,11 +2148,11 @@ def local_gpu_magma_cholesky(op, context_name, inputs, outputs):
 lifter = op_lifter([slinalg.Cholesky])(local_gpu_magma_cholesky)
 matrix_ops_db.register("local_gpu_magma_cholesky", lifter,
                        'gpuarray', 'fast_compile', 'fast_run', 'magma',
-                       position=0)
+                       position=1)
 matrix_ops_db2.register("local_gpu_magma_cholesky",
                         local_optimizer([slinalg.Cholesky])(local_gpu_magma_cholesky),
                         'gpuarray', 'fast_compile', 'fast_run', 'magma',
-                        position=0)
+                        position=1)
 
 
 @register_inplace()

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -2149,7 +2149,12 @@ def local_inplace_gpu_cholesky(node):
 def local_gpu_magma_cholesky(op, context_name, inputs, outputs):
     if not config.magma.enabled:
         return
-    return GpuMagmaCholesky(lower=op.lower, inplace=op.destructive)
+    if inputs[0].dtype not in ['float16', 'float32']:
+        return
+    op = GpuMagmaCholesky(lower=op.lower, inplace=op.destructive)
+    if inputs[0].dtype == 'float16':
+        return op(inputs[0].astype('float32')).astype('float16')
+    return op
 lifter = op_lifter([slinalg.Cholesky])(local_gpu_magma_cholesky)
 matrix_ops_db.register("local_gpu_magma_cholesky", lifter,
                        'gpuarray', 'fast_compile', 'fast_run', 'magma',
@@ -2174,7 +2179,12 @@ def local_inplace_gpu_magma_cholesky(node):
 def local_gpu_magma_qr(op, context_name, inputs, outputs):
     if not config.magma.enabled or op.mode != 'reduced':
         return
-    return GpuMagmaQR()
+    if inputs[0].dtype not in ['float16', 'float32']:
+        return
+    op = GpuMagmaQR(complete=True)
+    if inputs[0].dtype == 'float16':
+        return op(inputs[0].astype('float32')).astype('float16')
+    return op
 
 
 @register_opt('magma', 'fast_compile')
@@ -2183,7 +2193,12 @@ def local_gpu_magma_qr(op, context_name, inputs, outputs):
 def local_gpu_magma_qr_incomplete(op, context_name, inputs, outputs):
     if not config.magma.enabled:
         return
-    return GpuMagmaQR(complete=False)
+    if inputs[0].dtype not in ['float16', 'float32']:
+        return
+    op = GpuMagmaQR(complete=False)
+    if inputs[0].dtype == 'float16':
+        return op(inputs[0].astype('float32')).astype('float16')
+    return op
 
 
 # Matrix inverse
@@ -2215,7 +2230,12 @@ def local_inplace_gpu_magma_matrix_inverse(node):
 def local_gpu_magma_eigh(op, context_name, inputs, outputs):
     if not config.magma.enabled:
         return
-    return GpuMagmaEigh(UPLO=op.UPLO, compute_v=True)
+    if inputs[0].dtype not in ['float16', 'float32']:
+        return
+    op = GpuMagmaEigh(UPLO=op.UPLO, compute_v=True)
+    if inputs[0].dtype == 'float16':
+        return op(inputs[0].astype('float32')).astype('float16')
+    return op
 
 
 # Singular Value Decomposition

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -2122,6 +2122,11 @@ def local_gpu_cholesky(op, context_name, inputs, outputs):
 matrix_ops_db = LocalGroupDB()
 matrix_ops_db2 = LocalGroupDB(local_opt=theano.gof.opt.GraphToGPULocalOptGroup)
 matrix_ops_db2.__name__ = "matrix_ops_db2"
+
+# For Cholesky decomposition, magma is slower than cusolver (tested for
+# matrices of size 1000). Thus, cusolver is prioritized during graph
+# optimizations. To explicitly use magma, you should disable cusolver using
+# `optimizer_excluding=cusolver` in Theano config.
 lifter = op_lifter([slinalg.Cholesky])(local_gpu_cholesky)
 matrix_ops_db.register("local_gpu_cholesky", lifter,
                        'gpuarray', 'fast_compile', 'fast_run', 'cusolver',

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -74,7 +74,7 @@ from .subtensor import (GpuIncSubtensor, GpuSubtensor,
 from .opt_util import alpha_merge, output_merge, pad_dims, unpad_dims
 from .reduction import GpuMaxAndArgmax
 from .linalg import (GpuCusolverSolve, MATRIX_STRUCTURES_SOLVE, GpuCholesky,
-                     cusolver_available, GpuMagmaMatrixInverse, GpuMagmaSVD,
+                     cusolver_available, GpuMagmaMatrixInverse, gpu_svd,
                      GpuMagmaCholesky, GpuMagmaQR, GpuMagmaEigh)
 
 _logger = logging.getLogger("theano.gpuarray.opt")

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -2183,7 +2183,8 @@ def local_gpu_magma_qr(op, context_name, inputs, outputs):
         return
     op = GpuMagmaQR(complete=True)
     if inputs[0].dtype == 'float16':
-        return op(inputs[0].astype('float32')).astype('float16')
+        outputs = op(inputs[0].astype('float32'))
+        return [o.astype('float16') for o in outputs]
     return op
 
 

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -379,7 +379,7 @@ class TestMagma(unittest.TestCase):
         A = theano.tensor.fmatrix("A")
         fn = theano.function([A], qr(A), mode=mode_with_gpu)
         assert any([
-            isinstance(node.op, GpuMagmaQR)
+            isinstance(node.op, GpuMagmaQR) and node.op.complete
             for node in fn.maker.fgraph.toposort()
         ])
 
@@ -387,7 +387,7 @@ class TestMagma(unittest.TestCase):
         A = theano.tensor.fmatrix("A")
         fn = theano.function([A], qr(A, mode='r'), mode=mode_with_gpu)
         assert any([
-            isinstance(node.op, GpuMagmaQR)
+            isinstance(node.op, GpuMagmaQR) and not node.op.complete
             for node in fn.maker.fgraph.toposort()
         ])
 

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -385,3 +385,11 @@ class TestMagma(unittest.TestCase):
             isinstance(node.op, GpuMagmaQR)
             for node in fn.maker.fgraph.toposort()
         ])
+
+    def test_gpu_qr_incomplete_opt(self):
+        A = theano.tensor.fmatrix("A")
+        fn = theano.function([A], qr(A, mode='r'), mode=mode_with_gpu)
+        assert any([
+            isinstance(node.op, GpuMagmaQR)
+            for node in fn.maker.fgraph.toposort()
+        ])

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -11,7 +11,7 @@ from theano.gpuarray.linalg import (GpuCholesky, GpuMagmaCholesky,
                                     GpuMagmaEigh, GpuMagmaMatrixInverse,
                                     GpuMagmaQR, GpuMagmaSVD,
                                     cusolver_available, gpu_matrix_inverse,
-                                    gpu_solve, gpu_svd)
+                                    gpu_solve, gpu_svd, gpu_qr)
 from theano.tensor.nlinalg import (SVD, MatrixInverse, QRFull,
                                    QRIncomplete, eigh, matrix_inverse, qr)
 from theano.tensor.slinalg import Cholesky, cholesky
@@ -376,7 +376,7 @@ class TestMagma(unittest.TestCase):
 
     def run_gpu_qr(self, A_val, complete=True):
         A = theano.tensor.fmatrix("A")
-        fn = theano.function([A], GpuMagmaQR(complete=complete)(A),
+        fn = theano.function([A], gpu_qr(A, complete=complete),
                              mode=mode_with_gpu)
         return fn(A_val)
 

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -135,7 +135,7 @@ class TestGpuCholesky(unittest.TestCase):
         cholesky_op = GpuCholesky(lower=lower, inplace=inplace)
         chol_A = cholesky_op(A)
         return theano.function([A], chol_A, accept_inplace=inplace,
-                               mode=mode_with_gpu.excluding('magma'))
+                               mode=mode_with_gpu)
 
     def compare_gpu_cholesky_to_np(self, A_val, lower=True, inplace=False):
         # Helper function to compare op output to np.cholesky output.
@@ -149,7 +149,7 @@ class TestGpuCholesky(unittest.TestCase):
 
     def test_gpu_cholesky_opt(self):
         A = theano.tensor.matrix("A", dtype="float32")
-        fn = theano.function([A], cholesky(A), mode=mode_with_gpu.excluding('magma'))
+        fn = theano.function([A], cholesky(A), mode=mode_with_gpu)
         assert any([isinstance(node.op, GpuCholesky)
                     for node in fn.maker.fgraph.toposort()])
 
@@ -309,7 +309,7 @@ class TestMagma(unittest.TestCase):
     def run_gpu_cholesky(self, A_val, lower=True):
         A = theano.tensor.fmatrix("A")
         f = theano.function([A], GpuMagmaCholesky(lower=lower)(A),
-                            mode=mode_with_gpu)
+                            mode=mode_with_gpu.excluding('cusolver'))
         return f(A_val)
 
     def check_cholesky(self, N, lower=True, rtol=None, atol=None):
@@ -326,7 +326,7 @@ class TestMagma(unittest.TestCase):
 
     def test_gpu_cholesky_opt(self):
         A = theano.tensor.matrix("A", dtype="float32")
-        fn = theano.function([A], cholesky(A), mode=mode_with_gpu)
+        fn = theano.function([A], cholesky(A), mode=mode_with_gpu.excluding('cusolver'))
         assert any([isinstance(node.op, GpuMagmaCholesky)
                     for node in fn.maker.fgraph.toposort()])
 

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -241,7 +241,7 @@ class TestMagma(unittest.TestCase):
         # Copied from theano.tensor.tests.test_basic.rand.
         A_val = test_rng.rand(N, N).astype('float32') * 2 - 1
         A_val_inv = fn(A_val)
-        utt.assert_allclose(np.dot(A_val_inv, A_val), np.eye(N), atol=1e-2)
+        utt.assert_allclose(np.eye(N), np.dot(A_val_inv, A_val), atol=1e-2)
 
     def test_gpu_matrix_inverse_inplace(self):
         N = 1000
@@ -388,9 +388,9 @@ class TestMagma(unittest.TestCase):
             R_gpu = self.run_gpu_qr(A, complete=complete)
 
         Q_np, R_np = np.linalg.qr(A, mode='reduced')
-        utt.assert_allclose(R_gpu, R_np, rtol=rtol, atol=atol)
+        utt.assert_allclose(R_np, R_gpu, rtol=rtol, atol=atol)
         if complete:
-            utt.assert_allclose(Q_gpu, Q_np, rtol=rtol, atol=atol)
+            utt.assert_allclose(Q_np, Q_gpu, rtol=rtol, atol=atol)
 
     def test_gpu_qr(self):
         self.check_gpu_qr(1000, 500, atol=1e-3)
@@ -428,14 +428,14 @@ class TestMagma(unittest.TestCase):
             d_gpu, v_gpu = self.run_gpu_eigh(A, UPLO=UPLO, compute_v=compute_v)
         else:
             d_gpu = self.run_gpu_eigh(A, UPLO=UPLO, compute_v=False)
-        utt.assert_allclose(d_gpu, d_np, rtol=rtol, atol=atol)
+        utt.assert_allclose(d_np, d_gpu, rtol=rtol, atol=atol)
         if compute_v:
             utt.assert_allclose(
-                np.dot(v_gpu, v_gpu.T), np.eye(N), rtol=rtol, atol=atol)
+                np.eye(N), np.dot(v_gpu, v_gpu.T), rtol=rtol, atol=atol)
             D_m = np.zeros_like(A)
             np.fill_diagonal(D_m, d_gpu)
             utt.assert_allclose(
-                np.dot(np.dot(v_gpu, D_m), v_gpu.T), A, rtol=rtol, atol=atol)
+                A, np.dot(np.dot(v_gpu, D_m), v_gpu.T), rtol=rtol, atol=atol)
 
     def test_gpu_eigh(self):
         self.check_gpu_eigh(1000, UPLO='L', atol=1e-3)

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -12,7 +12,7 @@ from theano.gpuarray.linalg import (GpuCholesky, GpuMagmaCholesky,
                                     GpuMagmaQR, GpuMagmaSVD,
                                     cusolver_available, gpu_matrix_inverse,
                                     gpu_solve, gpu_svd)
-from theano.tensor.nlinalg import (SVD, Eigh, MatrixInverse, QRFull,
+from theano.tensor.nlinalg import (SVD, MatrixInverse, QRFull,
                                    QRIncomplete, eigh, matrix_inverse, qr)
 from theano.tensor.slinalg import Cholesky, cholesky
 from theano.tests import unittest_tools as utt

--- a/theano/tensor/nlinalg.py
+++ b/theano/tensor/nlinalg.py
@@ -539,7 +539,7 @@ class QRIncomplete(Op):
     Incomplete QR Decomposition.
 
     Computes the QR decomposition of a matrix.
-    Factor the matrix a as qr and return a single matrix.
+    Factor the matrix a as qr and return a single matrix R.
 
     """
 
@@ -552,14 +552,14 @@ class QRIncomplete(Op):
     def make_node(self, x):
         x = as_tensor_variable(x)
         assert x.ndim == 2, "The input of qr function should be a matrix."
-        q = theano.tensor.matrix(dtype=x.dtype)
-        return Apply(self, [x], [q])
+        r = theano.tensor.matrix(dtype=x.dtype)
+        return Apply(self, [x], [r])
 
     def perform(self, node, inputs, outputs):
         (x,) = inputs
-        (q,) = outputs
+        (r,) = outputs
         assert x.ndim == 2, "The input of qr function should be a matrix."
-        q[0] = self._numop(x, self.mode)
+        r[0] = self._numop(x, self.mode)
 
 
 def qr(a, mode="reduced"):

--- a/theano/tensor/nlinalg.py
+++ b/theano/tensor/nlinalg.py
@@ -559,8 +559,7 @@ class QRIncomplete(Op):
         (x,) = inputs
         (q,) = outputs
         assert x.ndim == 2, "The input of qr function should be a matrix."
-        q[0] = self._numop(x,
-                           self.mode)
+        q[0] = self._numop(x, self.mode)
 
 
 def qr(a, mode="reduced"):


### PR DESCRIPTION
Adds a wrapper for gpu magma QR decomposition, Cholesky decomposition and Eigen decomposition for symmetric matrices. Optimization group was created for matrix ops. Cusolver is always used first when it is available. The reason is that cusolver Cholesky decomposition is faster than magma Cholesky decomposition (tested for size 1000).