### PR TITLE
Avoid AttributeError in `pp`.

### DIFF
--- a/theano/printing.py
+++ b/theano/printing.py
@@ -506,7 +506,7 @@ class DefaultPrinter:
         if output in pstate.memo:
             return pstate.memo[output]
         pprinter = pstate.pprinter
-        node = output.owner
+        node = getattr(output, 'owner', None)
         if node is None:
             return leaf_printer.process(output, pstate)
         new_precedence = -1000


### PR DESCRIPTION
Easy fix. 

Question: now `pp` behaves like `repr` in the cases it failed before - is that ok? Or should it behave like `print`?

fix gh-5925