### PR TITLE
Add flag and implementation of build_infer_shape.

### DIFF
--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -800,6 +800,15 @@ AddConfigVar(
 
 
 AddConfigVar(
+    'build_infer_shape',
+    ("If 'True', Theano will try to infer the shape while building the graph."
+     "In the future, that will be the default."),
+    # TODO: set False by default! (currently shared var consider shp constant).
+    BoolParam(True),
+    in_c_key=False)
+
+
+AddConfigVar(
     'print_test_value',
     ("If 'True', the __eval__ of a Theano variable will return its test_value "
      "when this is available. This has the practical conseguence that, e.g., "

--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -614,6 +614,59 @@ class PureOp(object):
         return_list = kwargs.pop('return_list', False)
         node = self.make_node(*inputs, **kwargs)
 
+        # Infer shape
+        # TODO: Re-init auto_name temporary.
+        if hasattr(node.op, 'infer_shape') and theano.config.build_infer_shape:
+            def get_shape(x):
+                shp = None
+                if hasattr(x.tag, 'shape'):
+                    shp = x.tag.shape
+                elif isinstance(x, theano.Constant) and hasattr(x.data,
+                                                                'shape'):
+                    shp = x.data.shape
+                elif isinstance(x, theano.compile.SharedVariable):
+                    # TODO: Here we suppose SharedVariable have constanst shapes
+                    d = x.get_value(
+                        borrow=True, return_internal_type=True)
+                    if hasattr(d, 'shape'):
+                        shp = d.shape
+                if shp is None and hasattr(x, 'ndim'):
+                    shp = (None,) * x.ndim
+                # For type that don't have a ndim/shape
+                if shp is None:
+                    return shp
+                shp = list(shp)
+                for idx, s in enumerate(shp):
+                    if s is None:
+                        s = theano.scalar.int64()
+                        s = theano.tensor.lscalar()
+                        shp[idx] = s
+                    else:
+                        assert s >= 0
+                return tuple(shp)
+
+            inp_shps = [get_shape(x) for x in node.inputs]
+            with theano.configparser.change_flags(compute_test_value='off'):
+                try:
+                    out_shps = node.op.infer_shape(node, inp_shps)
+                except (theano.tensor.basic.ShapeError, NotImplementedError):
+                    out_shps = [None] * len(node.outputs)
+            for v, shp in zip(node.outputs, out_shps):
+                if shp is None:
+                    v.tag.shape = None
+                    continue
+                shp = list(shp)
+                for idx, s in enumerate(shp):
+                    try:
+                        s = theano.tensor.get_scalar_constant_value(s)
+                        # We want python int, not numpy array.
+                        s = int(s)
+                    except theano.tensor.NotScalarConstantError:
+                        s = None
+                    shp[idx] = s
+                v.tag.shape = shp
+                assert v.ndim == len(shp)
+
         if config.compute_test_value != 'off':
             run_perform = True
 

--- a/theano/tensor/tests/test_raw_random.py
+++ b/theano/tensor/tests/test_raw_random.py
@@ -435,9 +435,13 @@ class T_random_function(utt.InferShapeTester):
         self.assertTrue(np.all(val1 == numpy_val1))
 
         # This call lacks "ndim_added=1", so ndim_added defaults to 0.
-        # A ValueError should be raised.
+        # A IndexError/ValueError should be raised.
         rf0 = RandomFunction(permutation_helper, tensor.imatrix, 8)
-        post_r0, out0 = rf0(rng_R, (7,), 8)
+        # The infer_shape raise an indexerror
+        with theano.configparser.change_flags(build_infer_shape=True):
+            self.assertRaises(IndexError, rf0, rng_R, (7,), 8)
+        with theano.configparser.change_flags(build_infer_shape=False):
+            post_r0, out0 = rf0(rng_R, (7,), 8)
         f0 = compile.function(
                 [compile.In(rng_R,
                     value=np.random.RandomState(utt.fetch_seed()),


### PR DESCRIPTION
TODO:
- make ShapeFeature reuse the constant shape from shared variable
- don't change the autoname due to that PR.
- Make basic safety check that sharedvariable shapes don't change, like in set_value. But don't try to cover the hard cases.