### PR TITLE
[doc/requirements.inc] Specify which 'lib' or 'lib64' should be added…

### DIFF
--- a/doc/requirements.inc
+++ b/doc/requirements.inc
@@ -102,6 +102,6 @@ Install and configure the GPU drivers (recommended)
         program. This folder is called the *cuda root* directory.
 
 2. Fix 'lib' path
-    * Add the 'lib' subdirectory (and/or 'lib64' subdirectory if you have a
+    * Add the CUDA 'lib' subdirectory (and/or 'lib64' subdirectory if you have a
       64-bit OS) to your ``$LD_LIBRARY_PATH`` environment 
-      variable.
+      variable. Example: ``/usr/local/cuda/lib64``


### PR DESCRIPTION
… to LD_LIBRARY_PATH

When reading this documentation, I first added '/lib' and '/lib64' in LD_LIBRARY_PATH.
In order to avoid other users to do this mistake, I propose to update the
documentation like this.