### PR TITLE
(small fix) update usage of `dnn.enabled`

### DIFF
--- a/theano/gpuarray/__init__.py
+++ b/theano/gpuarray/__init__.py
@@ -71,6 +71,10 @@ def init_dev(dev, name=None, preallocate=None):
             avail = dnn.dnn_available(name)
             if avail:
                 context.cudnn_handle = dnn._make_handle(context)
+            elif config.dnn.enabled == 'True':
+                raise RuntimeError(
+                    "You enabled cuDNN, but we aren't able to use it: %s" %
+                    dnn.dnn_available.msg)
             if config.print_active_device:
                 if avail:
                     print("Using cuDNN version %d on context %s" % (dnn.version(), name),

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -165,13 +165,7 @@ def dnn_present():
     if dnn_present.avail:
         dnn_present.avail, dnn_present.msg = _dnn_check_version()
         if not dnn_present.avail:
-            raise RuntimeError(dnn_present.msg)
-
-    if config.dnn.enabled == "True":
-        if not dnn_present.avail:
-            raise RuntimeError(
-                "You enabled cuDNN, but we aren't able to use it: %s" %
-                dnn_present.msg)
+            return False
 
     return dnn_present.avail
 


### PR DESCRIPTION
Make dnn_present() always return a Boolean, and move checking of `dnn.enabled=="True"` into init_dev().

A code that calls either `dnn_present()`, `dnn_available()` or `version()` is now responsible for raising an exception if these functions fail and if `dnn.enabled` is `"True"`.

@nouiz @abergeron 