### PR TITLE
fast cycle detection flag added

### DIFF
--- a/.jenkins/jenkins_buildbot_nogpp.sh
+++ b/.jenkins/jenkins_buildbot_nogpp.sh
@@ -47,7 +47,7 @@ NAME=fastrun
 FILE=${ROOT_CWD}/theano_${NAME}_tests.xml
 echo "THEANO_FLAGS=cmodule.warn_no_version=True,${FLAGS},mode=FAST_RUN ${NOSETESTS} ${PROFILING} ${THEANO_PARAM} ${XUNIT}${FILE} ${SUITE}${NAME}"
 date
-THEANO_FLAGS=cmodule.warn_no_version=True,${FLAGS},mode=FAST_RUN ${NOSETESTS} ${PROFILING} ${THEANO_PARAM} ${XUNIT}${FILE} ${SUITE}${NAME}
+THEANO_FLAGS=cmodule.warn_no_version=True,${FLAGS},cycle_detection='fast',mode=FAST_RUN ${NOSETESTS} ${PROFILING} ${THEANO_PARAM} ${XUNIT}${FILE} ${SUITE}${NAME}
 echo "Number of elements in the compiledir:"
 ls ${COMPILEDIR}|wc -l
 echo

--- a/.jenkins/jenkins_buildbot_python2.sh
+++ b/.jenkins/jenkins_buildbot_python2.sh
@@ -58,7 +58,7 @@ echo
 
 BASE_COMPILEDIR=$HOME/.theano/buildbot_theano_python2
 ROOT_CWD=$WORKSPACE/nightly_build
-FLAGS=base_compiledir=$BASE_COMPILEDIR
+FLAGS=base_compiledir=$BASE_COMPILEDIR,cycle_detection='fast'
 COMPILEDIR=`THEANO_FLAGS=$FLAGS python -c "from __future__ import print_function; import theano; print(theano.config.compiledir)"`
 NOSETESTS=bin/theano-nose
 export PYTHONPATH=${WORKSPACE}:$PYTHONPATH

--- a/.jenkins/jenkins_buildbot_python2_32bit.sh
+++ b/.jenkins/jenkins_buildbot_python2_32bit.sh
@@ -13,4 +13,4 @@ echo
 
 FILE=${BUILDBOT_DIR}/theano_python32bit_tests.xml
 set -x
-PYTHONPATH=$HOME/anaconda2_32bit/lib/python2.7/site-packages THEANO_FLAGS=device=cpu,force_device=true,lib.amdlibm=False,compiledir=$HOME/.theano/buildbot_theano_python2_32bit $HOME/anaconda2_32bit/bin/python bin/theano-nose ${THEANO_PARAM} ${XUNIT}${FILE}
+PYTHONPATH=$HOME/anaconda2_32bit/lib/python2.7/site-packages THEANO_FLAGS=device=cpu,cycle_detection='fast',force_device=true,lib.amdlibm=False,compiledir=$HOME/.theano/buildbot_theano_python2_32bit $HOME/anaconda2_32bit/bin/python bin/theano-nose ${THEANO_PARAM} ${XUNIT}${FILE}

--- a/.jenkins/jenkins_buildbot_python2_debug.sh
+++ b/.jenkins/jenkins_buildbot_python2_debug.sh
@@ -55,7 +55,7 @@ echo
 
 BASE_COMPILEDIR=$HOME/.theano/buildbot_theano_python2_debug
 ROOT_CWD=$WORKSPACE/nightly_build
-FLAGS=base_compiledir=$BASE_COMPILEDIR
+FLAGS=base_compiledir=$BASE_COMPILEDIR,cycle_detection='fast'
 COMPILEDIR=`THEANO_FLAGS=$FLAGS python -c "from __future__ import print_function; import theano; print(theano.config.compiledir)"`
 NOSETESTS=bin/theano-nose
 export PYTHONPATH=${WORKSPACE}:$PYTHONPATH

--- a/.jenkins/jenkins_buildbot_python3.sh
+++ b/.jenkins/jenkins_buildbot_python3.sh
@@ -57,6 +57,7 @@ echo
 echo
 
 set -x
+<<<<<<< HEAD
 
 # Fast compile and float64
 FILE=${BUILDBOT_DIR}/theano_python3_fastcompile_f64_tests.xml
@@ -66,4 +67,5 @@ THEANO_FLAGS=$THEANO_FLAGS,compiledir=$COMPILEDIR,mode=FAST_COMPILE,warn.ignore_
 # Fast run and float32
 FILE=${BUILDBOT_DIR}/theano_python3_fastrun_f32_tests.xml
 NAME=fastrun_f32
-THEANO_FLAGS=$THEANO_FLAGS,compiledir=$COMPILEDIR,mode=FAST_RUN,warn.ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,magma.enabled=true,floatX=float32 python3 bin/theano-nose ${THEANO_PARAM} ${XUNIT}${FILE} ${SUITE}${NAME}
+THEANO_FLAGS=$THEANO_FLAGS,compiledir=$COMPILEDIR,cycle_detection='fast',mode=FAST_RUN,warn.ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,magma.enabled=true,floatX=float32 python3 bin/theano-nose ${THEANO_PARAM} ${XUNIT}${FILE} ${SUITE}${NAME}
+

--- a/.jenkins/jenkins_buildbot_release_extra.sh
+++ b/.jenkins/jenkins_buildbot_release_extra.sh
@@ -23,7 +23,7 @@ echo
 
 BASE_COMPILEDIR=$HOME/.theano/buildbot_theano_release
 ROOT_CWD=$WORKSPACE/nightly_build
-FLAGS=base_compiledir=$BASE_COMPILEDIR
+FLAGS=base_compiledir=$BASE_COMPILEDIR,cycle_detection='fast'
 COMPILEDIR=`THEANO_FLAGS=$FLAGS python -c "from __future__ import print_function; import theano; print(theano.config.compiledir)"`
 NOSETESTS=bin/theano-nose
 export PYTHONPATH=${WORKSPACE}:$PYTHONPATH

--- a/.jenkins/jenkins_test1.sh
+++ b/.jenkins/jenkins_test1.sh
@@ -10,5 +10,5 @@ echo "===== Testing theano core"
 # Test theano core
 PARTS="theano -e gpuarray"
 THEANO_PARAM="${PARTS} --with-timer --timer-top-n 10 --with-xunit --xunit-file=theanocore_tests.xml"
-FLAGS="mode=FAST_RUN,floatX=float32,on_opt_error=raise,on_shape_error=raise,cmodule.age_thresh_use=604800"
+FLAGS="mode=FAST_RUN,cycle_detection='fast',floatX=float32,on_opt_error=raise,on_shape_error=raise,cmodule.age_thresh_use=604800"
 THEANO_FLAGS=${FLAGS} bin/theano-nose ${THEANO_PARAM}

--- a/.jenkins/jenkins_test2.sh
+++ b/.jenkins/jenkins_test2.sh
@@ -51,6 +51,6 @@ python -c 'import pygpu; print(pygpu.__file__)'
 THEANO_GPUARRAY_TESTS="theano/gpuarray/tests \
                        theano/scan_module/tests/test_scan.py:T_Scan_Gpuarray \
                        theano/scan_module/tests/test_scan_checkpoints.py:TestScanCheckpoint.test_memory"
-FLAGS="init_gpu_device=$DEVICE,gpuarray.preallocate=1000,mode=FAST_RUN,on_opt_error=raise,on_shape_error=raise,cmodule.age_thresh_use=604800"
+FLAGS="init_gpu_device=$DEVICE,cycle_detection='fast',gpuarray.preallocate=1000,mode=FAST_RUN,on_opt_error=raise,on_shape_error=raise,cmodule.age_thresh_use=604800"
 FLAGS=${FLAGS},magma.enabled=true # Enable magma GPU library
 THEANO_FLAGS=${FLAGS} time nosetests --with-xunit --xunit-file=theanogpuarray_tests.xml ${THEANO_GPUARRAY_TESTS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
       env: PART="theano/tensor/nnet" THEANO_FLAGS="mode=FAST_COMPILE,floatX=float32"
 
 script:
-  - export THEANO_FLAGS=$THEANO_FLAGS,warn.ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,gcc.cxxflags=-pipe
+  - export THEANO_FLAGS=$THEANO_FLAGS,cycle_detection='fast',warn.ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,gcc.cxxflags=-pipe
   - python --version
   - uname -a
   - free -m

--- a/theano/gof/tests/test_destroyhandler.py
+++ b/theano/gof/tests/test_destroyhandler.py
@@ -11,6 +11,7 @@ from theano.gof.opt import (OpKeyOptimizer, PatternSub, NavigatorOptimizer,
 from theano.gof import destroyhandler
 from theano.gof.fg import FunctionGraph, InconsistencyError
 from theano.gof.toolbox import ReplaceValidate
+from theano.tests.unittest_tools import expectedFailure_fast
 
 from copy import copy
 
@@ -167,6 +168,7 @@ def test_misc():
 ######################
 
 
+@expectedFailure_fast
 def test_aliased_inputs_replacement():
     x, y, z = inputs()
     tv = transpose_view(x)
@@ -198,6 +200,7 @@ def test_indestructible():
     consistent(g)
 
 
+@expectedFailure_fast
 def test_usage_loop_through_views_2():
     x, y, z = inputs()
     e0 = transpose_view(transpose_view(sigmoid(x)))
@@ -208,6 +211,7 @@ def test_usage_loop_through_views_2():
     inconsistent(g)  # we cut off the path to the sigmoid
 
 
+@expectedFailure_fast
 def test_destroyers_loop():
     # AddInPlace(x, y) and AddInPlace(y, x) should not coexist
     x, y, z = inputs()
@@ -257,6 +261,7 @@ def test_aliased_inputs2():
     inconsistent(g)
 
 
+@expectedFailure_fast
 def test_aliased_inputs_tolerate():
     x, y, z = inputs()
     e = add_in_place_2(x, x)
@@ -271,6 +276,7 @@ def test_aliased_inputs_tolerate2():
     inconsistent(g)
 
 
+@expectedFailure_fast
 def test_same_aliased_inputs_ignored():
     x, y, z = inputs()
     e = add_in_place_3(x, x)
@@ -278,6 +284,7 @@ def test_same_aliased_inputs_ignored():
     consistent(g)
 
 
+@expectedFailure_fast
 def test_different_aliased_inputs_ignored():
     x, y, z = inputs()
     e = add_in_place_3(x, transpose_view(x))
@@ -312,6 +319,7 @@ def test_indirect():
     inconsistent(g)
 
 
+@expectedFailure_fast
 def test_indirect_2():
     x, y, z = inputs()
     e0 = transpose_view(x)
@@ -323,6 +331,7 @@ def test_indirect_2():
     consistent(g)
 
 
+@expectedFailure_fast
 def test_long_destroyers_loop():
     x, y, z = inputs()
     e = dot(dot(add_in_place(x, y),
@@ -364,6 +373,7 @@ def test_multi_destroyers():
         pass
 
 
+@expectedFailure_fast
 def test_multi_destroyers_through_views():
     x, y, z = inputs()
     e = dot(add(transpose_view(z), y), add(z, x))
@@ -406,6 +416,7 @@ def test_usage_loop_through_views():
     consistent(g)
 
 
+@expectedFailure_fast
 def test_usage_loop_insert_views():
     x, y, z = inputs()
     e = dot(add_in_place(x, add(y, z)),
@@ -439,6 +450,7 @@ def test_value_repl_2():
     consistent(g)
 
 
+@expectedFailure_fast
 def test_multiple_inplace():
     # this tests issue #5223
     # there were some problems with Ops that have more than

--- a/theano/gpuarray/tests/test_dnn.py
+++ b/theano/gpuarray/tests/test_dnn.py
@@ -1621,6 +1621,7 @@ def test_without_dnn_batchnorm_train_without_running_averages():
     f_abstract(X, Scale, Bias, Dy)
 
 
+@utt.expectedFailure_fast
 def test_dnn_batchnorm_train_inplace():
     # test inplace_running_mean and inplace_running_var
     if not dnn.dnn_available(test_ctx_name):
@@ -1743,6 +1744,7 @@ def test_batchnorm_inference():
                 utt.assert_allclose(outputs_abstract[5], outputs_ref[5], rtol=2e-3, atol=4e-5)  # dvar
 
 
+@utt.expectedFailure_fast
 def test_batchnorm_inference_inplace():
     # test inplace
     if not dnn.dnn_available(test_ctx_name):

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -164,6 +164,7 @@ class TestGpuCholesky(unittest.TestCase):
             GpuCholesky(lower=True, inplace=False)(A)
         self.assertRaises(AssertionError, invalid_input_func)
 
+    @utt.expectedFailure_fast
     def test_diag_chol(self):
         # Diagonal matrix input Cholesky test.
         for lower in [True, False]:
@@ -172,6 +173,7 @@ class TestGpuCholesky(unittest.TestCase):
                 A_val = np.diag(np.random.uniform(size=5).astype("float32") + 1)
                 self.compare_gpu_cholesky_to_np(A_val, lower=lower, inplace=inplace)
 
+    @utt.expectedFailure_fast
     def test_dense_chol_lower(self):
         # Dense matrix input lower-triangular Cholesky test.
         for lower in [True, False]:

--- a/theano/gpuarray/tests/test_opt.py
+++ b/theano/gpuarray/tests/test_opt.py
@@ -577,6 +577,7 @@ def test_no_complex():
                     mode=mode_with_gpu)
 
 
+@utt.expectedFailure_fast
 def test_local_lift_solve():
     if not cusolver_available:
         raise SkipTest('No cuSolver')
@@ -611,6 +612,7 @@ def test_gpu_solve_not_inplace():
     utt.assert_allclose(f_cpu(A_val, b_val), f_gpu(A_val, b_val))
 
 
+@utt.expectedFailure_fast
 def test_local_lift_cholesky():
     if not cusolver_available:
         raise SkipTest('No cuSolver')

--- a/theano/sparse/tests/test_basic.py
+++ b/theano/sparse/tests/test_basic.py
@@ -3200,6 +3200,7 @@ import theano.tensor.tests.test_sharedvar
     theano_fct_=lambda a: dense_from_sparse(a * 2.),
     ref_fct_=lambda a: np.asarray((a * 2).todense()),
     cast_value_=scipy.sparse.csr_matrix,
+    expect_fail_fast_shape_inplace=False,
 )
 class test_shared_options(object):
     pass

--- a/theano/tensor/nnet/tests/test_opt.py
+++ b/theano/tensor/nnet/tests/test_opt.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, print_function, division
+import unittest
 import theano
 from theano import tensor
 from theano.gof.opt import check_stack_trace
@@ -24,6 +25,9 @@ def test_blocksparse_inplace_gemv_opt():
     else:
         assert f.maker.fgraph.toposort()[-1].op.inplace
         assert check_stack_trace(f, ops_to_check=[sparse_block_gemv_inplace])
+
+if theano.config.cycle_detection == 'fast' and theano.config.mode != 'FAST_COMPILE':
+    test_blocksparse_inplace_gemv_opt = unittest.expectedFailure(test_blocksparse_inplace_gemv_opt)
 
 
 def test_blocksparse_inplace_outer_opt():

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -4757,6 +4757,9 @@ class T_exp(unittest.TestCase):
             np.asarray([[1.5089518, 1.48439076, -4.7820262],
                         [2.04832468, 0.50791564, -1.58892269]])])
 
+    if theano.config.cycle_detection == 'fast' and theano.config.mode != 'FAST_COMPILE':
+        test_grad_1 = unittest.expectedFailure(test_grad_1)
+
     def test_int(self):
         x = ivector()
         f = function([x], exp(x))

--- a/theano/tensor/tests/test_blas.py
+++ b/theano/tensor/tests/test_blas.py
@@ -501,6 +501,7 @@ def just_gemm(i, o, ishapes=[(4, 3), (3, 5), (4, 5), (), ()],
         raise
 
 
+@unittest_tools.expectedFailure_fast
 def test_gemm_opt0():
     """Many subgraphs whose dots can be eliminated"""
     X, Y, Z, a, b = XYZab()

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -1988,6 +1988,7 @@ class test_local_subtensor_lift(unittest.TestCase):
         assert len(prog) == 3
         f([4, 5])  # let debugmode test something
 
+    @utt.expectedFailure_fast
     def test4(self):
         # basic test that the optimization doesn't work with broadcasting
         # ... It *could* be extended to,

--- a/theano/tensor/tests/test_sharedvar.py
+++ b/theano/tensor/tests/test_sharedvar.py
@@ -27,6 +27,7 @@ def makeSharedTester(shared_constructor_,
                      theano_fct_,
                      ref_fct_,
                      cast_value_=np.asarray,
+                     expect_fail_fast_shape_inplace=True,
                      ):
     """
     This is a generic fct to allow reusing the same test function
@@ -549,6 +550,10 @@ def makeSharedTester(shared_constructor_,
                 assert sum([node.op.__class__.__name__ in ["Gemm", "GpuGemm", "StructuredDot"] for node in topo]) == 1
                 assert all(node.op == tensor.blas.gemm_inplace for node in topo if isinstance(node.op, tensor.blas.Gemm))
                 assert all(node.op.inplace for node in topo if node.op.__class__.__name__ == "GpuGemm")
+
+        if theano.config.cycle_detection == 'fast' and expect_fail_fast_shape_inplace and theano.config.mode != 'FAST_COMPILE':
+            test_specify_shape_inplace = unittest.expectedFailure(test_specify_shape_inplace)
+
         def test_values_eq(self):
             """ Test the type.values_eq[_approx] function"""
             dtype = self.dtype

--- a/theano/tests/unittest_tools.py
+++ b/theano/tests/unittest_tools.py
@@ -446,8 +446,12 @@ class AttemptManyTimes:
 
         return attempt_multiple_times
 
-def expectedFailure_fast():
+
+def expectedFailure_fast(f):
     """A Decorator to handle the test cases that are failing when
-    THEANO_FALGS =cycle_detection='fast'.
+    THEANO_FLAGS =cycle_detection='fast'.
     """
-    return unittest.expectedFailure if theano.config.cycle_detection == 'fast' else lambda x: x
+    if theano.config.cycle_detection == 'fast':
+        return unittest.expectedFailure(f)
+    else:
+        return f

--- a/theano/tests/unittest_tools.py
+++ b/theano/tests/unittest_tools.py
@@ -445,3 +445,9 @@ class AttemptManyTimes:
                         current_seed = str(int(current_seed) + 1)
 
         return attempt_multiple_times
+
+def expectedFailure_fast():
+    """A Decorator to handle the test cases that are failing when
+    THEANO_FALGS =cycle_detection='fast'.
+    """
+    return unittest.expectedFailure if theano.config.cycle_detection == 'fast' else lambda x: x


### PR DESCRIPTION
This PR only aims to find the tests that fail when we set the cycle_detection flag to fast. I could not run all of them locally. I get memory limit errors. I will close it after. 