### PR TITLE
(small fix) Add doc for `dnn.include_path` and `dnn.library_path`.

### DIFF
--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -638,13 +638,13 @@ import theano and print the config variable, as in:
 
 .. attribute:: config.dnn.include_path
 
-    Default: ``include`` sub-folder in CUDA root directory.
+    Default: ``include`` sub-folder in CUDA root directory, or headers paths defined for the compiler.
 
     Location of the cudnn header.
 
 .. attribute:: config.dnn.library_path
 
-    Default: Library sub-folder (``lib64`` on Linux) in CUDA root directory.
+    Default: Library sub-folder (``lib64`` on Linux) in CUDA root directory, or libraries paths defined for the compiler.
 
     Location of the cudnn library.
 

--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -638,15 +638,15 @@ import theano and print the config variable, as in:
 
 .. attribute:: config.dnn.include_path
 
-    Default: ``''``
+    Default: ``include`` sub-folder in CUDA root directory.
 
-    Location of the cudnn header (defaults to the cuda root).
+    Location of the cudnn header.
 
 .. attribute:: config.dnn.library_path
 
-    Default: ``''``
+    Default: Library sub-folder (``lib64`` on Linux) in CUDA root directory.
 
-    Location of the cudnn library (defaults to the cuda root).
+    Location of the cudnn library.
 
 .. attribute:: config.conv.assert_shape
 

--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -636,6 +636,18 @@ import theano and print the config variable, as in:
 
     If ``'no_check'``, assume present and the version between header and library match (so less compilation at context init)",
 
+.. attribute:: config.dnn.include_path
+
+    Default: ``''``
+
+    Location of the cudnn header (defaults to the cuda root).
+
+.. attribute:: config.dnn.library_path
+
+    Default: ``''``
+
+    Location of the cudnn library (defaults to the cuda root).
+
 .. attribute:: config.conv.assert_shape
 
     If True, AbstractConv* ops will verify that user-provided


### PR DESCRIPTION
It seems these two Theano flags are not in the documentation: http://deeplearning.net/software/theano_versions/dev/library/config.html