### PR TITLE
Work around erroneous dnn_conv results with algo small an large batches

### DIFF
--- a/theano/gpuarray/dnn_fwd.c
+++ b/theano/gpuarray/dnn_fwd.c
@@ -171,8 +171,8 @@ APPLY_SPECIFIC(conv_fwd)(PyGpuArrayObject *input, PyGpuArrayObject *kerns,
     algo = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
 
   // Algo `small` does not work for a batch size > 2^16, with cuDNN >= V5.1.
-  // Issue should be resolved for cuDNN > V6.0.20.
-  if (cudnnGetVersion() <= 6020 &&
+  // Issue should be resolved for cuDNN > V6.0.
+  if (cudnnGetVersion() < 6100 &&
       algo == CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM &&
       PyGpuArray_DIM(input, 0) > 65536)
       algo = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;

--- a/theano/gpuarray/dnn_fwd.c
+++ b/theano/gpuarray/dnn_fwd.c
@@ -171,7 +171,7 @@ APPLY_SPECIFIC(conv_fwd)(PyGpuArrayObject *input, PyGpuArrayObject *kerns,
     algo = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
 
   // Algo `small` does not work for a batch size > 2^16, with cuDNN >= V5.1.
-  // Issue should have been resolved for cuDNN >= V6.0.20.
+  // Issue should be resolved for cuDNN > V6.0.20.
   if (cudnnGetVersion() <= 6020 &&
       algo == CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM &&
       PyGpuArray_DIM(input, 0) > 65536)

--- a/theano/gpuarray/tests/test_dnn.py
+++ b/theano/gpuarray/tests/test_dnn.py
@@ -1111,17 +1111,17 @@ def run_conv_small_batched_vs_multicall(inputs_shape, filters_shape, batch_sub):
 
 
 def test_batched_conv_small():
-    yield (run_conv_small_batched_vs_multicall, (65534, 2, 2, 2), (1, 2, 2, 2), 5)  # OK
-    yield (run_conv_small_batched_vs_multicall, (65535, 2, 2, 2), (1, 2, 2, 2), 5)  # OK
-    yield (run_conv_small_batched_vs_multicall, (65536, 2, 2, 2), (1, 2, 2, 2), 5)  # OK
-    yield (run_conv_small_batched_vs_multicall, (65537, 2, 2, 2), (1, 2, 2, 2), 5)  # ERROR
+    # OK
+    yield (run_conv_small_batched_vs_multicall, (65536, 2, 2, 2), (1, 2, 2, 2), 5)
+    # Should fail with cuDNN < V6020, but there's currently a workaround in `dnn_fwd.c` for that case.
+    yield (run_conv_small_batched_vs_multicall, (65537, 2, 2, 2), (1, 2, 2, 2), 5)
 
 
 def test_batched_conv3d_small():
-    yield (run_conv_small_batched_vs_multicall, (65534, 2, 2, 2, 2), (1, 2, 2, 2, 2), 5)  # OK
-    yield (run_conv_small_batched_vs_multicall, (65535, 2, 2, 2, 2), (1, 2, 2, 2, 2), 5)  # OK
-    yield (run_conv_small_batched_vs_multicall, (65536, 2, 2, 2, 2), (1, 2, 2, 2, 2), 5)  # OK
-    yield (run_conv_small_batched_vs_multicall, (65537, 2, 2, 2, 2), (1, 2, 2, 2, 2), 5)  # ERROR ALSO.
+    # OK
+    yield (run_conv_small_batched_vs_multicall, (65536, 2, 2, 2, 2), (1, 2, 2, 2, 2), 5)
+    # Should fail with cuDNN < V6020, but there's currently a workaround in `dnn_fwd.c` for that case.
+    yield (run_conv_small_batched_vs_multicall, (65537, 2, 2, 2, 2), (1, 2, 2, 2, 2), 5)
 
 
 def test_conv3d_fwd():


### PR DESCRIPTION
A PR to help fix #5985 and fix #6020 .

Currently, I have added two tests to reproduce the problem: one with 10 000 as batch size, and another with 70 000 as batch size (all other parameters are identical). Then the test with 70 000 inputs fails (see console output below).

Currently, I don't think that the problem is about strides or dimensions, as all these values for current tested inputs may be handled by a system integer (`int`). Still investigating.

@abergeron @lamblin @nouiz 

```
$ nosetests -xvs theano/gpuarray/tests/test_dnn.py:test_batched_conv_success
Using cuDNN version 6020 on context None
Mapped name None to device cuda: GeForce GTX TITAN X (0000:02:00.0)
theano.gpuarray.tests.test_dnn.test_batched_conv_success((10000, 4, 32, 32), (1, 4, 16, 16), 25, (3, 3)) ... Input size: 0.152587890625 Gb
Computing
Output shapes: (10000, 1, 6, 6) (1, 1, 6, 6)
ok

----------------------------------------------------------------------
Ran 1 test in 26.128s

OK
$ nosetests -xvs theano/gpuarray/tests/test_dnn.py:test_batched_conv_fail
Using cuDNN version 6020 on context None
Mapped name None to device cuda: GeForce GTX TITAN X (0000:02:00.0)
theano.gpuarray.tests.test_dnn.test_batched_conv_fail((70000, 4, 32, 32), (1, 4, 16, 16), 25, (3, 3)) ... Input size: 1.06811523438 Gb
Computing
Output shapes: (70000, 1, 6, 6) (1, 1, 6, 6)
ERROR

======================================================================
ERROR: theano.gpuarray.tests.test_dnn.test_batched_conv_fail((70000, 4, 32, 32), (1, 4, 16, 16), 25, (3, 3))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/u/boccoset/.conda/envs/boccosetEnv/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/u/boccoset/mila/dev/git/theano/theano/gpuarray/tests/test_dnn.py", line 1104, in run_conv_batched_vs_multicall
    utt.assert_allclose(res_batch[i], res_all[size - batch_sub + i], atol=1e-6, rtol=1e-6)
  File "/u/boccoset/mila/dev/git/theano/theano/tests/unittest_tools.py", line 357, in assert_allclose
    raise WrongValue(val1, val2, rtol, atol)
WrongValue: WrongValue
  expected    : [[[[ 262.81149292  257.28344727  257.68167114  263.76553345  253.07557678
     254.87948608]
   [ 255.46412659  260.05529785  258.79153442  265.90890503  256.80264282
     249.12014771]
   [ 255.78485107  260.87399292  254.5199585   256.53036499  253.32684326
     252.63471985]
   [ 253.66004944  252.29753113  260.47439575  261.97869873  253.92384338
     259.56750488]
   [ 262.41348267  259.84350586  261.61276245  260.75463867  256.12188721
     253.10206604]
   [ 259.37319946  258.40789795  261.78692627  259.37680054  262.13986206
     255.63438416]]]]
  value    : [[[ 245.11114502  244.91969299  243.5846405   253.72325134  254.38612366
    255.17477417]
  [ 253.94763184  244.61291504  254.25749207  252.80860901  259.48983765
    255.08586121]
  [ 249.11782837  248.26765442  248.66650391  253.08294678  257.47140503
    253.18663025]
  [ 247.57498169  251.08808899  248.44218445  251.96794128  255.5085144
    252.05444336]
  [ 250.04606628  249.66490173  249.98672485  252.85968018  253.4756012
    247.5184021 ]
  [ 249.64077759  250.12475586  249.40283203  250.69918823  257.88140869
    251.75737   ]]]
  Max Abs Diff:  17.7003
  Mean Abs Diff:  7.45197
  Median Abs Diff:  7.09004
  Std Abs Diff:  4.62775
  Max Rel Diff:  0.06735
  Mean Rel Diff:  0.0287206
  Median Rel Diff:  0.0275048
  Std Rel Diff:  0.0176318

  rtol, atol: 1e-06 1e-06


----------------------------------------------------------------------
Ran 1 test in 45.255s

FAILED (errors=1)
```