### PR TITLE
Fix elemwise ValueError message (printf formatting)

### DIFF
--- a/theano/tensor/elemwise_cgen.py
+++ b/theano/tensor/elemwise_cgen.py
@@ -100,7 +100,7 @@ def make_checks(loop_orders, dtypes, sub):
             check += """
             if (%%(lv%(j0)s)s_n%(x0)s != %%(lv%(j)s)s_n%(x)s)
             {
-                PyErr_Format(PyExc_ValueError, "Input dimension mis-match. (input[%%%%i].shape[%%%%i] = %%%%lli, input[%%%%i].shape[%%%%i] = %%%%lli)",
+                PyErr_Format(PyExc_ValueError, "Input dimension mis-match. (input[%%%%i].shape[%%%%i] = %%%%lld, input[%%%%i].shape[%%%%i] = %%%%lld)",
                    %(j0)s,
                    %(x0)s,
                    (long long int) %%(lv%(j0)s)s_n%(x0)s,


### PR DESCRIPTION
This is a tiny fix to the `Elemwise` "Input dimension mis-match" exception (on cpu). It tries to format `long long` values with `%lli`, but this format character [does not exist](https://docs.python.org/2/c-api/string.html#c.PyString_FromFormat). The error message then looks like this:
```
ValueError: Input dimension mis-match. (input[1].shape[1] = %lli, input[%i].shape[%i] = %lli)
```
`%lld` works better.