### PR TITLE
Add a DEBUG option for C code

### DIFF
--- a/doc/library/config.txt
+++ b/doc/library/config.txt
@@ -1058,6 +1058,12 @@ import theano and print the config variable, as in:
     reused by Theano. Automatic deletion of those c module 7 days
     after that time.
 
+.. attribute:: config.cmodule.debug
+
+    Bool value, default: ``False``
+
+    If True, define a DEBUG macro (if not exists) for any compiled C code.
+
 .. attribute:: config.traceback.limit
 
     Int value, default: 8

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -1139,6 +1139,11 @@ AddConfigVar('cmodule.age_thresh_use',
              IntParam(60 * 60 * 24 * 24, allow_override=False),
              in_c_key=False)
 
+AddConfigVar('cmodule.debug',
+             "If True, define a DEBUG macro (if not exists) for any compiled C code.",
+             BoolParam(False),
+             in_c_key=True)
+
 
 def default_blas_ldflags():
     global numpy

--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -910,6 +910,12 @@ class CLinker(link.Linker):
         The support code from Variables is added before the support code from Ops.This might contain duplicates.
         """
         ret = []
+        if config.cmodule.debug:
+            ret.append("""
+            #ifndef DEBUG
+            #define DEBUG
+            #endif
+            """)
         # generic support code
         for x in [y.type for y in self.variables] + [
                 y.op for y in self.node_order]:

--- a/theano/gof/type.py
+++ b/theano/gof/type.py
@@ -1165,7 +1165,7 @@ class EnumList(EnumType):
         assert len(kwargs) in (0, 1, 2), (type(self).__name__ +
                                           ': expected 0 to 2 extra parameters ("ctype", "cname").')
         ctype = kwargs.pop('ctype', 'int')
-        cname = kwargs.pop('cname', ctype)
+        cname = kwargs.pop('cname', None)
 
         for arg_rank, arg in enumerate(args):
             if isinstance(arg, (list, tuple)):
@@ -1187,7 +1187,9 @@ class EnumList(EnumType):
                 raise TypeError('%s: constant name already used ("%s").' % (type(self).__name__, constant_name))
             kwargs[constant_name] = constant_value
 
-        kwargs.update(ctype=ctype, cname=cname)
+        kwargs.update(ctype=ctype)
+        if cname is not None:
+            kwargs.update(cname=cname)
         super(EnumList, self).__init__(**kwargs)
 
 

--- a/theano/gpuarray/dnn_gw.c
+++ b/theano/gpuarray/dnn_gw.c
@@ -202,6 +202,15 @@ APPLY_SPECIFIC(conv_gw)(PyGpuArrayObject *input, PyGpuArrayObject *output,
         prev_top_dims[i] = PyGpuArray_DIM(output, i);
       }
     }
+
+    #ifdef DEBUG
+    char algorithm_name[128];
+    if (0 != theano_enum_to_string_cudnnConvolutionBwdFilterAlgo_t(algo, algorithm_name)) {
+        return 1;
+    };
+    // NB: This is printed only when algorithm is chosen at runtime.
+    fprintf(stderr, "(using %s) ", algorithm_name);
+    #endif
   }
 
   // The FFT implementation does not support strides, 1x1 filters or inputs


### PR DESCRIPTION
Discussed here: https://github.com/Theano/Theano/pull/5932#issuecomment-310209926

This PR adds a boolean Theano flag `cmodule.debug` (default `false`) used to activate a DEBUG mode for C code by adding a `DEBUG` macro at the top of any generated C code. The PR also uses this new option in an example to print runtime chosen algorithm for cuDNN backward filter convolution.

@lamblin @abergeron  @nouiz .