### PR TITLE
[Intel MKL] implement high performance convolution OP

### DIFF
--- a/theano/__init__.py
+++ b/theano/__init__.py
@@ -126,6 +126,13 @@ else:
         raise ImportError("The nose module is not installed."
                           " It is needed for Theano tests.")
 
+if config.device.startwith('cpu'):
+    try:
+        import theano.contrib.mkl
+    except (TypeError, NotImplementedError, RuntimeError) as e:
+        theano_logger.warning("Failed to import mkl module due to: %s" % str(e))
+
+
 if (config.device.startswith('cuda') or
         config.device.startswith('opencl') or
         config.init_gpu_device.startswith('cuda') or

--- a/theano/__init__.py
+++ b/theano/__init__.py
@@ -126,7 +126,7 @@ else:
         raise ImportError("The nose module is not installed."
                           " It is needed for Theano tests.")
 
-if config.device.startwith('cpu'):
+if config.device.startswith('cpu'):
     try:
         import theano.contrib.mkl
     except (TypeError, NotImplementedError, RuntimeError) as e:

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -184,7 +184,7 @@ AddConfigVar(
 # Currently, only support "mkl" option.
 # Plan to support other library such as mkl-dnn in future.
 AddConfigVar('mkl.lib',
-             "'mkl', use Intel MKL library for dnn primitive functionality.",
+             "'mkl', choose MKL as the default dnn library for CPU.",
              EnumStr("mkl"),
              in_c_key=False)
 

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -181,6 +181,18 @@ AddConfigVar(
     BoolParam(True, allow_override=False),
     in_c_key=False)
 
+AddConfigVar('mkl.lib',
+             "'mkl', use Intel MKL library for dnn primitive functionality.",
+             EnumStr("mkl"),
+             in_c_key=False)
+
+AddConfigVar('mkl.nn.enabled',
+             "'auto', use MKL dnn primitive if available, but silently fall back"
+             " to not using it if not present."
+             " If True and MKL dnn can not be used, raise an error."
+             " If False, disable MKL dnn",
+             EnumStr("auto", "True", "False"),
+             in_c_key=False)
 
 AddConfigVar('gpuarray.sync',
              """If True, every op will make sure its work is done before

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -181,6 +181,8 @@ AddConfigVar(
     BoolParam(True, allow_override=False),
     in_c_key=False)
 
+# Currently, only support "mkl" option.
+# Plan to support other library such as mkl-dnn in future.
 AddConfigVar('mkl.lib',
              "'mkl', use Intel MKL library for dnn primitive functionality.",
              EnumStr("mkl"),

--- a/theano/contrib/mkl/__init__.py
+++ b/theano/contrib/mkl/__init__.py
@@ -1,0 +1,256 @@
+from __future__ import absolute_import, print_function, division
+import os
+import errno
+import sys
+import logging
+import textwrap
+import stat
+import shutil
+
+from theano import config, gof, function, Mode
+from theano.gof import EquilibriumDB, SequenceDB
+from theano.gof.cmodule import Compiler, get_lib_extension, GCC_compiler
+from theano.gof.compilelock import get_lock, release_lock
+from theano.tensor.blas import ldflags
+from theano.contrib.mkl.mkl_helper import header_text
+
+_logger_name = 'theano.contrib.mkl'
+_logger = logging.getLogger(_logger_name)
+
+
+mkl_optimizer = EquilibriumDB(ignore_newtrees=False)
+mkl_seqopt = SequenceDB()
+
+
+def register_opt(*tags, **kwargs):
+    if any([not isinstance(t, str) for t in tags]):
+        raise RuntimeError("Bad call to register_opt."
+                           " All tags must be strings.", tags)
+
+    def f(local_opt):
+        name = (kwargs and kwargs.pop('name')) or local_opt.__name__
+        mkl_optimizer.register(name, local_opt, 'fast_run', 'fast_compile',
+                               'mkl', *tags, **kwargs)
+        return local_opt
+    return f
+
+
+class MKLVersion(gof.Op):
+    def c_header_dirs(self):
+        return ldflags(libs=False, include_dir=True)
+
+    def c_libraries(self):
+        return ldflags()
+
+    def c_lib_dirs(self):
+        return ldflags(libs=False, libs_dir=True)
+
+    def make_node(self):
+        return gof.Apply(self, [], [gof.Generic()()])
+
+    def c_support_code(self):
+        ccode = header_text()
+        ccode += """
+        #if PY_MAJOR_VERSION >= 3
+            #define PyInt_FromLong PyLong_FromLong
+        #endif
+        """
+        return ccode
+
+    def c_code(self, node, name, inputs, outputs, sub):
+        o = outputs[0]
+        return textwrap.dedent(
+            """
+            MKLVersion v;
+            mkl_get_version(&v);
+            %(o)s = PyInt_FromLong(atoi(v.Build));
+            """) % locals()
+
+    def c_code_cache_version(self):
+        # Not needed, but make it clear that we do not want to cache this.
+        return None
+
+
+def mkl_version():
+    """
+    Return the current mkl version (e.g., 20160701) we compile with.
+    While `0` indicate fail to get mkl version.
+    """
+    if mkl_version.v is None:
+        try:
+            f = function([], MKLVersion()(),
+                         Mode(optimizer=None),
+                         profile=False)
+            mkl_version.v = f()
+        except Exception as e:
+            _logger.error('Fail to get mkl version due to: %s', str(e))
+            mkl_version.v = 0
+    return mkl_version.v
+
+mkl_version.v = None
+
+
+def _dnn_is_able_to_link():
+    if _dnn_is_able_to_link.status is None:
+        preambule = """
+            #include <stdio.h>
+            #include <mkl_dnn.h>
+            """
+        preambule += textwrap.dedent(header_text())
+
+        body = textwrap.dedent(
+            """
+            dnnError_t err;
+            dnnLayout_t usr_layout = NULL;
+            size_t size[1] = {256};
+            size_t stride[1] = {1};
+
+            if ((err = dnnLayoutCreate_F32(&usr_layout, 1, size, stride)) != E_SUCCESS) {
+                fprintf(stderr, "Failed to create user layout with mkl: %s", err);
+                return (-1);
+            }
+            """)
+
+        if 'mklml_intel' in config.blas.ldflags:
+            params = ['-l', 'mklml_intel', '-l', 'iomp5']
+        elif 'mklml_gnu' in config.blas.ldflags:
+            params = ['-l', 'mklml_gnu', '-l', 'iomp5']
+        elif 'mkl_rt' in config.blas.ldflags:
+            params = ['-l', 'mkl_rt']
+        else:
+            params = []
+
+        compilation_ok, run_ok, out, err = Compiler._try_flags(
+            flag_list=params, preambule=preambule, body=body,
+            try_run=True, output=True, compiler=config.cxx,
+            comp_args=False)
+
+        if not (compilation_ok and run_ok):
+            mkl_available.msg = (
+                "Can not compile with MKL. We got this error: " +
+                str(err))
+
+        _dnn_is_able_to_link.status = run_ok
+
+    return _dnn_is_able_to_link.status
+
+_dnn_is_able_to_link.status = None
+
+
+def _dnn_is_enabled_by_user():
+    if config.device != "cpu":
+        if config.mkl.nn.enabled == "True":
+            raise RuntimeError("You're trying to use MKL, but the divice is "
+                               "not CPU. Either change device to CPU or "
+                               "disable MKL.")
+        else:
+            mkl_available.msg = "MKL is disabled since device is not CPU. " \
+                                "Set the device to 'CPU' if you want to use MKL."
+            return False
+
+    if config.mkl.lib != "mkl":
+        raise NotImplementedError("MKL lib only supports 'mkl' currently, "
+                                  "but got %s." % config.mkl.lib)
+
+    if config.mkl.nn.enabled == "False":
+        mkl_available.msg = "MKL is disabled by the 'mkl.nn.enabled' setting."
+        return False
+
+    return True
+
+
+def mkl_available():
+    # Check this status every time which allows user
+    # to change their setting in different stage of model
+    if _dnn_is_enabled_by_user() is not True:
+        return False
+
+    if _dnn_is_able_to_link() is not True:
+        if config.mkl.nn.enabled == "True":
+            raise RuntimeError("You enabled MKL, but we aren't able "
+                               "to use it, %s" % mkl_available.msg)
+        return False
+
+    return True
+
+mkl_available.msg = None
+
+
+if mkl_available():
+    mkl_path = os.path.abspath(os.path.split(__file__)[0])
+    mkl_ndarray_loc = os.path.join(config.compiledir, 'mkl_ndarray')
+    mkl_ndarray_so = os.path.join(
+        mkl_ndarray_loc, 'mkl_ndarray.' + get_lib_extension())
+    libmkl_ndarray_so = os.path.join(
+        mkl_ndarray_loc, 'libmkl_ndarray.' + get_lib_extension())
+
+    def try_import_mkl_ndarray():
+        mkl_files = ('mkl_ndarray.c', 'mkl_ndarray.h')
+
+        stat_times = [os.stat(os.path.join(mkl_path, mkl_file))[stat.ST_MTIME]
+                      for mkl_file in mkl_files]
+        date = max(stat_times)
+        if os.path.exists(mkl_ndarray_so):
+            if date >= os.stat(mkl_ndarray_so)[stat.ST_MTIME]:
+                return False
+
+        try:
+            sys.path.insert(0, config.compiledir)
+            import mkl_ndarray.mkl_ndarray  # noqa
+            del sys.path[0]
+        except ImportError:
+            return False
+        return True
+
+    compile_mkl_ndarray = not try_import_mkl_ndarray()
+
+    if compile_mkl_ndarray:
+        get_lock()
+        try:
+            if not try_import_mkl_ndarray():
+                try:
+                    code = open(os.path.join(mkl_path, 'mkl_ndarray.c')).read()
+                    if not os.path.exists(mkl_ndarray_loc):
+                        os.makedirs(mkl_ndarray_loc)
+                    compiler = GCC_compiler()
+                    preargs = compiler.compile_args()
+
+                    if 'mklml_intel' in config.blas.ldflags:
+                        mkl_lib = 'mklml_intel'
+                    elif 'mklml_gnu' in config.blas.ldflags:
+                        mkl_lib = 'mklml_gnu'
+                    else:
+                        mkl_lib = 'mkl_rt'
+                    compiler.compile_str('mkl_ndarray',
+                                         code,
+                                         location=mkl_ndarray_loc,
+                                         include_dirs=[mkl_path],
+                                         libs=[mkl_lib],
+                                         preargs=preargs,)
+
+                    from mkl_ndarray.mkl_ndarray import *  # noqa
+                except Exception as e:
+                    _logger.error('Failed to compile mkl_ndarray.c: %s', str(e))
+        finally:
+            release_lock()
+
+    def ok():
+        try:
+            open(libmkl_ndarray_so).close()
+            return True
+        except IOError:
+            return False
+
+    if not ok():
+        if sys.platform == "win32":
+            shutil.copyfile(mkl_ndarray_so, libmkl_ndarray_so)
+        else:
+            try:
+                os.symlink(mkl_ndarray_so, libmkl_ndarray_so)
+            except OSError as e:
+                if getattr(e, 'errno', None) != errno.EEXIST or not ok():
+                    raise
+
+    # Note: will remove comments when opt.py was submitted.
+    # from . import opt
+    # opt.optdb.add_tags('mkl_opt', 'fast_compile', 'fast_run')

--- a/theano/contrib/mkl/basic_ops.py
+++ b/theano/contrib/mkl/basic_ops.py
@@ -161,7 +161,7 @@ class U2IGrad(BaseConvertOp):
                                                      z_size,
                                                      z_stride), err);
 
-            if (!dnnLayoutCompare_%(precision)s(MKLNdarray_LAYOUT(%(gz)s),layout_user) {
+            if (!dnnLayoutCompare_%(precision)s(MKLNdarray_LAYOUT(%(gz)s), layout_user) {
                 CHECK_ERR( dnnConversionCreate_%(precision)s(&from_internal,
                                                              MKLNdarray_LAYOUT(%(gz)s),
                                                              layout_user), err);
@@ -256,10 +256,11 @@ class I2UGrad(BaseConvertOp):
             gz_stride[3] = gz_size[0] * gz_size[1] * gz_size[2];
 
             CHECK_ERR( dnnLayoutCreate_%(precision)s(&layout_user,
-                                                     DIMENSION, gz_size,
+                                                     DIMENSION,
+                                                     gz_size,
                                                      gz_stride), err);
 
-            if (!dnnLayoutCompare_%(precision)s(MKLNdarray_LAYOUT(%(z)s),layout_user)) {
+            if (!dnnLayoutCompare_%(precision)s(MKLNdarray_LAYOUT(%(z)s), layout_user)) {
                 CHECK_ERR( dnnConversionCreate_%(precision)s(&to_internal,
                                                              layout_user,
                                                              MKLNdarray_LAYOUT(%(z)s)), err);
@@ -273,7 +274,7 @@ class I2UGrad(BaseConvertOp):
                                                           PyArray_DATA(%(gz)s),
                                                           MKLNdarray_DATA(%(z)s)), err);
         } else {
-            memcpy((void*)MKLNdarray_DATA(%(z)s),(void*)PyArray_DATA(%(gz)s),%(z)s->data_size);
+            memcpy((void*)MKLNdarray_DATA(%(z)s),(void*)PyArray_DATA(%(gz)s), %(z)s->data_size);
         }
         first_run = 0;
         """ % sub

--- a/theano/contrib/mkl/basic_ops.py
+++ b/theano/contrib/mkl/basic_ops.py
@@ -1,0 +1,470 @@
+import theano.tensor as T
+from theano.gof import Apply, Op
+from theano.tensor.blas import ldflags
+from theano.tensor.nnet.abstract_conv import get_conv_output_shape
+from theano.contrib.mkl.mkl_helper import header_text
+from theano.contrib.mkl.mkl_type import MKLNdarrayType
+
+
+class MKLOp(Op):
+    def c_lib_dirs(self):
+        return ldflags(libs=False, libs_dir=True)
+
+    def c_libraries(self):
+        return ldflags()
+
+    def c_compile_args(self):
+        compile_args = ldflags(libs=False, flags=True)
+        compile_args += super(MKLOp, self).c_compile_args()
+        return compile_args
+
+    def c_support_code(self):
+        ccode = header_text()
+        ccode += """
+        #define DIMENSION  4
+
+        #define CHECK_ERR(f, err) \\
+            do { \\
+                (err) = (f); \\
+                if ((err) != E_SUCCESS) { \\
+                    printf("Error in file [%s:%d], err code (%d)", \\
+                           __FILE__, __LINE__, err); \\
+                    exit(1); \\
+                } \\
+            } while(0)
+        """
+
+        return ccode
+
+
+class BaseConvertOp(MKLOp):
+    def c_support_code_struct(self, node, name):
+        ccode = """
+        dnnError_t err;
+        int first_run;
+        void* internal_buf;
+        void* user_buf;
+        dnnLayout_t layout_internal;
+        dnnLayout_t layout_user;
+        dnnPrimitive_t to_internal;
+        dnnPrimitive_t from_internal;
+        dnnPrimitive_t primitive;
+        void *convert_resources[dnnResourceNumber];
+        size_t bottomSize[DIMENSION];
+        size_t bottomStride[DIMENSION];
+        """
+        return ccode
+
+    def c_init_code_struct(self, node, name, sub):
+        ccode = """
+        first_run = 1;
+        internal_buf = NULL;
+        user_buf = NULL;
+        layout_internal = NULL;
+        layout_user = NULL;
+        to_internal = NULL;
+        from_internal = NULL;
+        primitive = NULL;
+        """
+        return ccode
+
+    def c_code_cache_version(self):
+        return (1, 0)
+
+
+class I2U(BaseConvertOp):
+    __props__ = ()
+
+    def make_node(self, x):
+        assert isinstance(x.type, MKLNdarrayType)
+        return Apply(self, [x], [T.TensorType(broadcastable=x.broadcastable, dtype=x.dtype)()])
+
+    def grad(self, inp, grads):
+        x, = inp
+        gz, = grads
+
+        return [I2UGrad()(x, gz)]
+
+    def c_code(self, node, name, inp, out, sub):
+        x, = inp
+        z, = out
+
+        fail = sub['fail']
+
+        ccode = """
+            if (%(z)s) {
+                Py_XDECREF(%(z)s);
+            }
+            %(z)s = (PyArrayObject*)MKLNdarray_CreateArrayObj(%(x)s);
+            if (!%(z)s) {
+                %(fail)s;
+            }
+        """ % locals()
+
+        return ccode
+
+
+class U2IGrad(BaseConvertOp):
+    __props__ = ()
+
+    def make_node(self, x, gz):
+        out = x.type()
+        return Apply(self, [x, gz], [out])
+
+    def c_code(self, node, name, inp, out, sub):
+        x, gz, = inp
+        z, = out
+        sub['x'] = x
+        sub['gz'] = gz
+        sub['z'] = z
+        sub['name'] = U2IGrad.__name__
+        if 'float32' == node.inputs[0].type.dtype:
+            sub['precision'] = "F32"
+            sub['x_item_size'] = 4
+        elif "float64" == node.inputs[0].type.dtype:
+            sub['precision'] = "F64"
+            sub['x_item_size'] = 8
+        else:
+            raise TypeError("Type %s not implemented" %
+                            node.inputs[0].type.dtype)
+        ccode = """
+        int status = 0;
+        size_t z_size[4] = {0};
+        size_t z_stride[4] = {0};
+        int ndim = 0;
+        npy_intp dims[4] = {0};
+        if(NULL == %(z)s) {
+            dims[0] = MKLNdarray_DIMS(%(gz)s)[0];
+            dims[1] = MKLNdarray_DIMS(%(gz)s)[1];
+            dims[2] = MKLNdarray_DIMS(%(gz)s)[2];
+            dims[3] = MKLNdarray_DIMS(%(gz)s)[3];
+
+            %(z)s = (PyArrayObject*)PyArray_ZEROS(MKLNdarray_NDIM(%(gz)s),
+                                                  dims,
+                                                  MKLNdarray_TYPE(%(gz)s),
+                                                  0);
+            if(NULL == %(z)s) {
+                %(fail)s;
+            }
+        }
+
+        ndim = (int)MKLNdarray_NDIM(%(gz)s);
+        assert (ndim == DIMENSION);
+
+        for(int i=0; i<DIMENSION; i++) {
+            z_size[i] = (size_t)PyArray_DIMS(%(z)s)[ndim-i-1];
+            z_stride[i] = (size_t)PyArray_STRIDES(%(z)s)[ndim-i-1] / %(x_item_size)s;
+        }
+
+        //create usr layerout
+        if (NULL == layout_user) {
+            CHECK_ERR( dnnLayoutCreate_%(precision)s(&layout_user,
+                                                     ndim, z_size,
+                                                     z_stride), err);
+        }
+
+        if (! dnnLayoutCompare_%(precision)s(MKLNdarray_LAYOUT(%(gz)s),
+                                             layout_user)) {
+            if (NULL == from_internal) {
+                CHECK_ERR( dnnConversionCreate_%(precision)s(&from_internal,
+                                                             MKLNdarray_LAYOUT(%(gz)s),
+                                                             layout_user), err);
+            }
+
+            if (from_internal) {
+                CHECK_ERR( dnnConversionExecute_%(precision)s(from_internal,
+                                                              MKLNdarray_DATA(%(gz)s),
+                                                              PyArray_DATA(%(z)s)), err);
+            }
+        } else {
+            memcpy ((void*)PyArray_DATA(%(z)s), MKLNdarray_DATA(%(gz)s), PyArray_SIZE(%(z)s)*PyArray_ITEMSIZE(%(z)s));
+        }
+
+        """ % sub
+        return ccode
+
+
+class I2UGrad(BaseConvertOp):
+    __props__ = ()
+
+    def make_node(self, x, gz):
+        out = x.type()
+        return Apply(self, [x, gz], [out])
+
+    def c_code(self, node, name, inp, out, sub):
+        x, gz, = inp
+        z, = out
+        sub['x'] = x
+        sub['z'] = z
+        sub['gz'] = gz
+
+        if 'float32' == node.inputs[0].type.dtype:
+            sub['precision'] = "F32"
+            sub['x_item_size'] = 4
+            sub['type'] = "float"
+        elif "float64" == node.inputs[0].type.dtype:
+            sub['precision'] = "F64"
+            sub['x_item_size'] = 8
+            sub["type"] = "double"
+        else:
+            raise TypeError("Type %s not implemented" %
+                            node.inputs[0].type.dtype)
+
+        ccode = """
+        int status = 0;
+        int gz_ndim = 0;
+        size_t gz_size[4] = {0};
+        size_t gz_stride[4] = {0};
+
+        gz_size[0] = PyArray_DIMS(%(gz)s)[3];  //w
+        gz_size[1] = PyArray_DIMS(%(gz)s)[2];  //h
+        gz_size[2] = PyArray_DIMS(%(gz)s)[1];  //c
+        gz_size[3] = PyArray_DIMS(%(gz)s)[0];  //n
+        gz_stride[0] = 1;
+        gz_stride[1] = gz_size[0];
+        gz_stride[2] = gz_size[0] * gz_size[1];
+        gz_stride[3] = gz_size[0] * gz_size[1] * gz_size[2];
+
+        if (! (%(z)s
+            && MKLNdarray_Check((PyObject*)%(z)s)
+            && MKLNdarray_NDIM(%(z)s) == MKLNdarray_NDIM(%(x)s)
+            && MKLNdarray_DIMS(%(z)s)[0] == MKLNdarray_DIMS(%(x)s)[0]
+            && MKLNdarray_DIMS(%(z)s)[1] == MKLNdarray_DIMS(%(x)s)[1]
+            && MKLNdarray_DIMS(%(z)s)[2] == MKLNdarray_DIMS(%(x)s)[2]
+            && MKLNdarray_DIMS(%(z)s)[3] == MKLNdarray_DIMS(%(x)s)[3] )) {
+
+            if (%(z)s) Py_XDECREF(%(z)s);
+
+            %(z)s = (MKLNdarray*)MKLNdarray_New(MKLNdarray_NDIM(%(x)s), MKLNdarray_TYPE(%(x)s));
+            if (NULL == %(z)s) {
+                %(fail)s;
+            }
+
+            status = MKLNdarray_set_structure(%(z)s, MKLNdarray_NDIM(%(x)s), MKLNdarray_DIMS(%(x)s));
+            if (0 != status) {
+                %(fail)s;
+            }
+
+            status = MKLNdarray_copy_layout(%(z)s, %(x)s, MNDA_DATA);
+            if (0 != status) {
+                %(fail)s;
+            }
+
+            status = MKLNdarray_create_buffer_from_layout(%(z)s, MNDA_DATA);
+            if (0 != status) {
+                %(fail)s;
+            }
+        }
+
+        //create usr layerout of gz
+        if (NULL == layout_user) {
+            CHECK_ERR( dnnLayoutCreate_%(precision)s(&layout_user,
+                                                     DIMENSION, gz_size,
+                                                     gz_stride), err);
+        }
+
+        if (! dnnLayoutCompare_%(precision)s(MKLNdarray_LAYOUT(%(z)s),
+                                             layout_user)) {
+            if (NULL == to_internal) {
+                CHECK_ERR( dnnConversionCreate_%(precision)s(&to_internal,
+                                                            layout_user,
+                                                            MKLNdarray_LAYOUT(%(z)s)), err);
+            }
+            if (to_internal) {
+                CHECK_ERR( dnnConversionExecute_%(precision)s(to_internal,
+                                                              PyArray_DATA(%(gz)s),
+                                                              MKLNdarray_DATA(%(z)s)), err);
+            }
+        } else {
+        size_t nn = dnnLayoutGetMemorySize_%(precision)s(MKLNdarray_LAYOUT(%(z)s));
+        memcpy((void*)MKLNdarray_DATA(%(z)s),
+               (void*)PyArray_DATA(%(gz)s),
+               nn);
+        }
+        """ % sub
+        return ccode
+
+
+class U2IConv(BaseConvertOp):
+    __props__ = ('imshp', 'kshp', 'border_mode', 'subsample', 'filter_dilation')
+
+    def __init__(self, imshp=None, kshp=None, border_mode='valid', subsample=(1, 1), filter_dilation=(1, 1)):
+        self.border_mode = border_mode
+        self.subsample = tuple(subsample)
+        self.imshp = imshp
+        self.kshp = kshp
+        self.filter_dilation = filter_dilation
+
+    def make_node(self, x):
+        x = T.as_tensor_variable(x)
+        if x.type.ndim is not 4:
+            raise TypeError('U2IConv: input x should be an 4-dim tensor')
+        return Apply(self, [x], [MKLNdarrayType(broadcastable=x.type.broadcastable, dtype=x.dtype)()])
+
+    def grad(self, inp, grads):
+        x, = inp
+        gz, = grads
+        return [U2IGrad()(x, gz)]
+
+    def c_code(self, node, name, inp, out, sub):
+        x, = inp
+        dH, dW = self.subsample
+
+        if len(self.kshp) == 5:
+            grp, k_n, k_c, k_h, k_w = self.kshp
+            gkshp = [grp * k_n, grp * k_c, k_h, k_w]
+        else:
+            k_n, k_c, k_h, k_w = self.kshp
+            grp = 1
+            gkshp = self.kshp
+
+        if None in self.imshp:
+            i_n, i_c, i_h, i_w = 0, 0, 0, 0
+            o_n, o_c, o_h, o_w = 0, 0, 0, 0
+        else:
+            i_n, i_c, i_h, i_w = self.imshp
+            o_n, o_c, o_h, o_w = get_conv_output_shape(image_shape=self.imshp,
+                                                       kernel_shape=self.kshp,
+                                                       border_mode=self.border_mode,
+                                                       filter_dilation=self.filter_dilation,
+                                                       subsample=self.subsample)
+
+        if self.border_mode == 'valid':
+            padH, padW = (0, 0)
+        elif self.border_mode == 'full':
+            padH, padW = ((k_h - 1), (k_w - 1))
+        elif self.border_mode == 'half':
+            padH, padW = ((k_h / 2), (k_w / 2))
+        elif isinstance(self.border_mode, tuple):
+            padH, padW = self.border_mode
+        else:
+            raise ValueError("border_mode must have two elements")
+
+        z, = out
+
+        if 'float32' == node.inputs[0].type.dtype:
+            precision = 'F32'
+        elif 'float64' == node.inputs[0].type.dtype:
+            precision = 'F64'
+        else:
+            raise TypeError("Type %s is not supported!" %
+                            node.inputs[0].type.dtype)
+        fail = sub['fail']
+
+        ccode = """
+            npy_intp* x_dims = PyArray_DIMS(%(x)s);
+            int ndim = PyArray_NDIM(%(x)s);
+            int dtype = PyArray_TYPE(%(x)s);
+
+            if (1 == first_run) {
+                int convPadding[2];
+                size_t convStride[2], weightSize[5], weightStride[5], imageSize[4], imageStride[4], zSize[4], zStride[4];
+                convStride[0] = %(dW)s;
+                convStride[1] = %(dH)s;
+                convPadding[0] = -%(padW)s;
+                convPadding[1] = -%(padH)s;
+
+                imageSize[0] = %(i_w)s;  //w
+                imageSize[1] = %(i_h)s;  //h
+                imageSize[2] = %(i_c)s;  //c
+                imageSize[3] = %(i_n)s;  //n
+
+                if (0 == imageSize[0] || 0 == imageSize[1] || 0 == imageSize[2] || 0 == imageSize[3]) {
+                    imageSize[0] = x_dims[3];
+                    imageSize[1] = x_dims[2];
+                    imageSize[2] = x_dims[1];
+                    imageSize[3] = x_dims[0];
+                }
+
+                imageStride[0] = 1;
+                imageStride[1] = imageSize[0];
+                imageStride[2] = imageSize[0] * imageSize[1];
+                imageStride[3] = imageSize[0] * imageSize[1] * imageSize[2];
+
+                weightSize[0] = %(k_w)s;
+                weightSize[1] = %(k_h)s;
+                weightSize[2] = %(k_c)s;
+                weightSize[3] = %(k_n)s;
+                weightSize[4] = %(grp)s;
+                weightStride[0] = 1;
+                weightStride[1] = weightSize[0];
+                weightStride[2] = weightSize[0] * weightSize[1];
+                weightStride[3] = weightSize[0] * weightSize[1] * weightSize[2];
+                weightStride[4] = weightSize[0] * weightSize[1] * weightSize[2] * weightSize[3];
+
+                zSize[0] = %(o_w)s;
+                zSize[1] = %(o_h)s;
+                zSize[2] = %(o_c)s;
+                zSize[3] = %(o_n)s;
+
+                if (0 == zSize[0] || 0 == zSize[1] || 0 == zSize[2] || 0== zSize[3]) {
+                    zSize[0] = (imageSize[0] - 2 * convPadding[0] - weightSize[0]) / convStride[0] + 1;
+                    zSize[1] = (imageSize[1] - 2 * convPadding[1] - weightSize[1]) / convStride[1] + 1;
+                    zSize[2] = weightSize[3];
+                    zSize[3] = imageSize[3];
+                }
+
+                zStride[0] = 1;
+                zStride[1] = zSize[0];
+                zStride[2] = zSize[0] * zSize[1];
+                zStride[3] = zSize[0] * zSize[1] * zSize[2];
+
+                const int group = %(grp)s;
+                // create user layout
+                CHECK_ERR( dnnLayoutCreate_%(precision)s(&layout_user, DIMENSION, imageSize, imageStride), err );
+                // create convolution primitive
+                CHECK_ERR( dnnGroupsConvolutionCreateForward_%(precision)s(&primitive, NULL,
+                           dnnAlgorithmConvolutionDirect, group, DIMENSION, imageSize, zSize,
+                           weightSize, convStride, convPadding, dnnBorderZeros), err );
+            }
+
+            assert (ndim == DIMENSION);
+            size_t dims[DIMENSION] = {0};
+            for (int i = 0; i < ndim; i++) {
+                dims[i] = (size_t)x_dims[i];
+            }
+
+            if (!( %(z)s
+                && MKLNdarray_Check((PyObject*)%(z)s)
+                && MKLNdarray_NDIM(%(z)s) == ndim
+                && MKLNdarray_DIMS(%(z)s)[0] == x_dims[0]
+                && MKLNdarray_DIMS(%(z)s)[1] == x_dims[1]
+                && MKLNdarray_DIMS(%(z)s)[2] == x_dims[2]
+                && MKLNdarray_DIMS(%(z)s)[3] == x_dims[3]) ) {
+
+                if (%(z)s) Py_XDECREF(%(z)s);
+                %(z)s = (MKLNdarray*)MKLNdarray_New(ndim, dtype);
+                if (!%(z)s) {
+                    %(fail)s;
+                }
+
+                int status = MKLNdarray_set_structure(%(z)s, ndim, dims);
+                if (status != 0) {
+                    %(fail)s;
+                }
+
+                status = MKLNdarray_create_buffer_from_primitive(%(z)s, &primitive, dnnResourceSrc);
+                if (status != 0) {
+                    %(fail)s;
+                }
+            }
+
+            if (!dnnLayoutCompare_%(precision)s(layout_user, MKLNdarray_LAYOUT(%(z)s))) {
+                if (NULL == to_internal) {
+                    CHECK_ERR( dnnConversionCreate_%(precision)s(&to_internal,
+                                                                 layout_user,
+                                                                 MKLNdarray_LAYOUT(%(z)s)), err );
+                }
+            }
+
+            if (to_internal) {
+                CHECK_ERR( dnnConversionExecute_%(precision)s(to_internal,
+                                                              PyArray_DATA(%(x)s),
+                                                              MKLNdarray_DATA(%(z)s)), err );
+            } else {
+                memcpy(MKLNdarray_DATA(%(z)s), (void*)PyArray_DATA(%(x)s), %(z)s->data_size);
+            }
+
+            first_run = 0;
+        """ % locals()
+        return ccode

--- a/theano/contrib/mkl/mkl_conv.py
+++ b/theano/contrib/mkl/mkl_conv.py
@@ -1,0 +1,1507 @@
+"""
+contains an op for convolving input images with a set of weights by using MKL
+library, which is a free dnn library provided by Intel.
+"""
+from __future__ import absolute_import, print_function, division
+import theano
+from six import integer_types
+from theano import Apply
+from theano import gof
+from theano.tensor import as_tensor_variable, TensorType
+from theano.tensor.nnet.abstract_conv import get_conv_output_shape
+from theano.tensor.blas import ldflags
+from theano.contrib.mkl import mkl_helper, mkl_type
+
+
+class MKLConvBase(gof.Op):
+    __props__ = ('imshp', 'kshp', 'border_mode', 'subsample')
+
+    def __init__(self, imshp=None, kshp=None, border_mode="valid", subsample=(1, 1)):
+        if (not theano.config.blas.ldflags) or ('mkl' not in theano.config.blas.ldflags):
+            raise NotImplementedError("MKL Convolution requires MKL library.")
+
+        if isinstance(border_mode, int):
+            if border_mode < 0:
+                raise ValueError(
+                    'invalid border_mode {}, which must be a '
+                    'non-negative integer'.format(border_mode))
+            border_mode = (border_mode, border_mode)
+        if isinstance(border_mode, tuple):
+            if len(border_mode) != 2 or border_mode[0] < 0 or border_mode[1] < 0:
+                raise ValueError(
+                    'invalid border_mode {}, which must be a '
+                    'pair of non-negative integers'.format(border_mode))
+            pad_h, pad_w = map(int, border_mode)
+            border_mode = (pad_h, pad_w)
+        if not ((isinstance(border_mode, tuple) and min(border_mode) >= 0) or
+                border_mode in ('valid', 'full', 'half')):
+            raise ValueError(
+                'invalid border_mode {}, which must be either '
+                '"valid", "full", "half", an integer or a pair of'
+                ' integers'.format(border_mode))
+        self.border_mode = border_mode
+
+        if len(subsample) != 2:
+            raise ValueError("subsample must have two elements")
+        self.subsample = tuple(subsample)
+        self.imshp = imshp
+        self.kshp = kshp
+
+    def c_libraries(self):
+        return ldflags()
+
+    def c_compile_args(self):
+        compile_args = ldflags(libs=False, flags=True)
+        compile_args += super(MKLConvBase, self).c_compile_args()
+        return compile_args
+
+    def c_lib_dirs(self):
+        return ldflags(libs=False, libs_dir=True)
+
+    def c_header_dirs(self):
+        return ldflags(libs=False, include_dir=True)
+
+    def c_headers(self):
+        headers = ['<stdio.h>']
+        headers += super(MKLConvBase, self).c_headers()
+        return headers
+
+    def c_code_cache_version(self):
+        # raise this whenever modifying any of the support_code_files
+        return (1, 0, 1)
+
+    def c_support_code(self):
+        ccode = mkl_helper.header_text()
+        ccode += """
+            #define _MKL_DEBUG_ 0
+            #define dimension 4
+            #define CHECK_ERR(f, err) \\
+                do { \\
+                    (err) = (f); \\
+                    if ((err) != E_SUCCESS) { \\
+                        (PyExc_RuntimeError, "Error in file " \\
+                            "[%s:%d], err code (%d)", __FILE__, __LINE__, err); \\
+                    } \\
+                } while(0)
+        """
+        return ccode
+
+    def c_support_code_struct(self, node, name):
+        dtype = node.inputs[0].dtype
+        assert dtype in ('float32', 'float64')
+
+        sub = {}
+        if dtype == 'float32':
+            sub['dtype'] = 'float'
+            sub['precision'] = 'F32'
+        else:
+            sub['dtype'] = 'double'
+            sub['precision'] = 'F64'
+        sub['name'] = name
+
+        ccode = """
+            int first_run;
+            size_t imageSize[dimension]; //w, h, c, n
+            size_t imageStride[dimension];
+            size_t weightSize[dimension+1]; //w, h, c, n, group
+            size_t weightStride[dimension+1];
+            size_t zSize[dimension]; //w, h, c, n
+            size_t zStride[dimension];
+            size_t biasSize[1]; //w, h, c, n
+            size_t biasStride[1];
+            size_t groups;
+            size_t fdimension;
+
+            ////////// debug only //////////
+            size_t _image_size;
+            size_t _weight_size;
+            size_t _z_size;
+            ///////////////////////////////
+
+            size_t convStride[2];
+            int convPadding[2];
+
+            void *conv_res[dnnResourceNumber];
+            void *conv_res_bias[dnnResourceNumber];
+
+            void *image_buf;
+            void *image_buf_from_previous;
+            void *image_buf_to_previous;
+
+            void *z_buf;
+
+            void *weight_buf;
+            void *weight_buf_tmp;
+
+            void *bwdf2fwd_weight_buf;
+            void *bias_buf;
+            void *bias_buf_tmp;
+
+            void *gradz_buf;
+            void *gradz_buf_for_weight;
+            void *gradz_buf_for_bias;
+
+            dnnError_t err;
+            dnnPrimitive_t pConvolutionFwd;
+            dnnPrimitive_t pConvolutionBwdData;
+            dnnPrimitive_t pConvolutionBwdFilter;
+            dnnPrimitive_t pConvolutionBwdBias;
+
+            dnnPrimitive_t bwdf_weight_to_fwd_internal;
+            dnnPrimitive_t bwdf_weight_to_usr;
+            dnnPrimitive_t bwdd_weight_to_bwdd_internal;
+
+            dnnLayout_t bwdf_weight_internal_layout;
+            dnnLayout_t image_user_layout;
+            dnnLayout_t weight_usr_layout;
+            dnnLayout_t z_user_layout;
+            dnnLayout_t image_internal_layout;
+            dnnLayout_t *image_internal_layout_buf;
+            dnnLayout_t image_internal_layout_from_previous;
+            dnnLayout_t weight_internal_layout;
+            dnnLayout_t z_internal_layout;
+            dnnLayout_t gradz_internal_layout;
+            dnnLayout_t gradz_internal_layout_for_weight;
+            dnnLayout_t gradz_internal_layout_for_bias;
+            dnnLayout_t fwd_weight_internal_layout;
+
+            dnnLayout_t bias_internal_layout;
+            dnnLayout_t bias_usr_layout;
+
+            dnnPrimitive_t image_to_internal;
+            dnnPrimitive_t weight_to_internal;
+            dnnPrimitive_t z_to_internal;
+            dnnPrimitive_t weight_from_internal;
+            dnnPrimitive_t image_from_internal;
+            dnnPrimitive_t z_from_internal;
+            dnnPrimitive_t internal_to_internal_image;
+            dnnPrimitive_t gradz_to_internal;
+            dnnPrimitive_t gradz_to_internal_for_weight;
+            dnnPrimitive_t gradz_to_internal_for_bias;
+            dnnPrimitive_t bias_to_internal;
+            dnnPrimitive_t bias_from_internal;
+        """ % sub
+        return ccode
+
+    def c_init_code_struct(self, node, name, sub):
+        ccode = """
+            first_run = 1;
+            imageSize[0] = 0; //w, h, c, n
+            imageSize[1] = 0; //w, h, c, n
+            imageSize[2] = 0; //w, h, c, n
+            imageSize[3] = 0; //w, h, c, n
+
+            imageStride[0] = 0;
+            imageStride[1] = 0;
+            imageStride[2] = 0;
+            imageStride[3] = 0;
+
+            weightSize[0] = 0; //w, h, c, n, group
+            weightSize[1] = 0; //w, h, c, n, group
+            weightSize[2] = 0; //w, h, c, n, group
+            weightSize[3] = 0; //w, h, c, n, group
+            weightSize[4] = 0;
+
+            weightStride[0] = 0;
+            weightStride[1] = 0;
+            weightStride[2] = 0;
+            weightStride[3] = 0;
+            weightStride[4] = 0;
+
+            zSize[0] = 0; //w, h, c, n
+            zSize[1] = 0; //w, h, c, n
+            zSize[2] = 0; //w, h, c, n
+            zSize[3] = 0; //w, h, c, n
+
+            zStride[0] = 0;
+            zStride[1] = 0;
+            zStride[2] = 0;
+            zStride[3] = 0;
+
+            biasSize[0] = 0; //w, h, c, n
+            biasStride[0] = 0;
+
+            groups = 1;
+            fdimension = 0;
+
+            convStride[0] = 0;
+            convStride[1] = 0;
+            convPadding[0] = 0;
+            convPadding[1] = 0;
+
+            image_buf = NULL;
+            image_buf_from_previous = NULL;
+            image_buf_to_previous = NULL;
+
+            z_buf = NULL;
+
+            weight_buf = NULL;
+            weight_buf_tmp = NULL;
+
+            bwdf2fwd_weight_buf = NULL;
+            bias_buf = NULL;
+            bias_buf_tmp = NULL;
+
+            gradz_buf = NULL;
+            gradz_buf_for_weight = NULL;
+            gradz_buf_for_bias = NULL;
+
+            pConvolutionFwd = NULL;
+            pConvolutionBwdData = NULL;
+            pConvolutionBwdFilter = NULL;
+            pConvolutionBwdBias = NULL;
+
+            bwdf_weight_to_fwd_internal = NULL;
+            bwdf_weight_to_usr = NULL;
+            bwdd_weight_to_bwdd_internal = NULL;
+
+            bwdf_weight_internal_layout = NULL;
+            image_user_layout = NULL;
+            weight_usr_layout = NULL;
+            z_user_layout = NULL;
+            image_internal_layout = NULL;
+            image_internal_layout_buf = NULL;
+            image_internal_layout_from_previous = NULL;
+            weight_internal_layout = NULL;
+            z_internal_layout = NULL;
+            gradz_internal_layout = NULL;
+            gradz_internal_layout_for_weight = NULL;
+            gradz_internal_layout_for_bias = NULL;
+            fwd_weight_internal_layout = NULL;
+
+            bias_internal_layout = NULL;
+            bias_usr_layout = NULL;
+
+            image_to_internal = NULL;
+            weight_to_internal = NULL;
+            z_to_internal = NULL;
+            weight_from_internal = NULL;
+            image_from_internal = NULL;
+            z_from_internal = NULL;
+            internal_to_internal_image = NULL;
+            gradz_to_internal = NULL;
+            gradz_to_internal_for_weight = NULL;
+            gradz_to_internal_for_bias = NULL;
+            bias_to_internal = NULL;
+            bias_from_internal = NULL;
+        """
+        return ccode
+
+
+class Conv2D(MKLConvBase):
+    __props__ = ('imshp', 'kshp', 'border_mode', 'subsample', 'filter_flip', 'filter_dilation')
+
+    def __init__(self, imshp=None, kshp=None, border_mode='valid', subsample=(1, 1), filter_flip=False, filter_dilation=(1, 1)):
+        super(Conv2D, self).__init__(imshp=imshp, kshp=kshp, border_mode=border_mode, subsample=subsample)
+        self.filter_flip = filter_flip
+        self.filter_dilation = filter_dilation
+
+    def c_cleanup_code_struct(self, node, name):
+        if node.inputs[0].type.dtype == "float32":
+            precision = "F32"
+        elif node.inputs[0].type.dtype == "float64":
+            precision = "F64"
+
+        ccode = """
+            // release layout
+            if (image_internal_layout) {
+                dnnLayoutDelete_%(precision)s(image_internal_layout);
+                image_internal_layout = NULL;
+            }
+
+            if (weight_usr_layout) {
+                dnnLayoutDelete_%(precision)s(weight_usr_layout);
+                weight_internal_layout = NULL;
+            }
+
+            if (weight_internal_layout) {
+                dnnLayoutDelete_%(precision)s(weight_internal_layout);
+                weight_internal_layout = NULL;
+            }
+
+            if (bias_usr_layout) {
+                dnnLayoutDelete_%(precision)s(bias_usr_layout);
+                bias_usr_layout = NULL;
+            }
+
+            if (bias_internal_layout) {
+                dnnLayoutDelete_%(precision)s(bias_internal_layout);
+                bias_internal_layout = NULL;
+            }
+
+            // release primitive
+            if (pConvolutionFwd) {
+                dnnDelete_%(precision)s(pConvolutionFwd);
+                pConvolutionFwd = NULL;
+            }
+
+            if (internal_to_internal_image) {
+                dnnDelete_%(precision)s(internal_to_internal_image);
+                internal_to_internal_image = NULL;
+            }
+
+            if (weight_to_internal) {
+                dnnDelete_%(precision)s(weight_to_internal);
+                weight_to_internal = NULL;
+            }
+
+            if (bias_to_internal) {
+                dnnDelete_%(precision)s(bias_to_internal);
+                bias_to_internal = NULL;
+            }
+
+            // release buffer
+            if (image_buf) {
+                dnnReleaseBuffer_%(precision)s(image_buf);
+                image_buf = NULL;
+            }
+
+            if (weight_buf) {
+                dnnReleaseBuffer_%(precision)s(weight_buf);
+                weight_buf = NULL;
+            }
+
+            if (bias_buf) {
+                dnnReleaseBuffer_%(precision)s(bias_buf);
+                bias_buf = NULL;
+            }
+        """ % locals()
+        return ccode
+
+    def make_node(self, image, weight, bias=None):
+        if not isinstance(image.type, mkl_type.MKLNdarrayType):
+            raise TypeError('Conv2D: input image should be an instance of MKLNdarray')
+
+        weight = as_tensor_variable(weight)
+
+        if image.type.ndim != 4:
+            raise TypeError('Conv2D: image should be 4D tensor')
+        if weight.type.ndim not in (4, 5):
+            raise TypeError('Conv2D: weight should be 4D or 5D tensor')
+
+        if weight.type.ndim == 4:
+            broadcastable = [image.type.broadcastable[0], weight.type.broadcastable[0], False, False]
+        else:
+            broadcastable = [image.type.broadcastable[0], weight.type.broadcastable[1], False, False]
+
+        if bias is not None:
+            bias = as_tensor_variable(bias)
+            inputs = [image, weight, bias]
+        else:
+            inputs = [image, weight]
+        return Apply(self, inputs, [mkl_type.MKLNdarrayType(image.type.dtype, broadcastable)()])
+
+    def infer_shape(self, node, input_shape):
+        imshp = input_shape[0]
+        gkshp = input_shape[1]
+
+        if len(gkshp) == 5:
+            kshp = [gkshp[1] * gkshp[0], gkshp[2] * gkshp[0], gkshp[3], gkshp[4]]
+        else:
+            kshp = [gkshp[0], gkshp[1], gkshp[2], gkshp[3]]
+
+        res = get_conv_output_shape(imshp,
+                                    kshp,
+                                    self.border_mode,
+                                    self.subsample)
+        return [res]
+
+    def c_code(self, node, name, inp, out_, sub):
+        if len(inp) > 2:
+            image, weight, bias = inp
+        else:
+            image, weight = inp
+            bias = None
+
+        z, = out_
+
+        if None in self.kshp:
+            raise ValueError('Conv2D: None in kernel shape')
+
+        if None in self.imshp:
+            in_n, in_c, in_h, in_w = 0, 0, 0, 0
+            o_n, o_c, o_h, o_w = 0, 0, 0, 0
+        else:
+            in_n, in_c, in_h, in_w = self.imshp
+            o_n, o_c, o_h, o_w = get_conv_output_shape(self.imshp,
+                                                       self.kshp,
+                                                       self.border_mode,
+                                                       self.subsample)
+
+        if node.inputs[1].type.ndim == 5:
+            grp, k_n, k_c, k_h, k_w = self.kshp
+        else:
+            k_n, k_c, k_h, k_w = self.kshp
+            grp = 1
+
+        dH, dW = self.subsample
+
+        if self.border_mode == 'valid':
+            padH, padW = (0, 0)
+        elif self.border_mode == 'full':
+            padH, padW = ((k_h - 1), (k_w - 1))
+        elif self.border_mode == 'half':
+            padH, padW = ((k_h / 2), (k_w / 2))
+        elif isinstance(self.border_mode, tuple):
+            padH, padW = self.border_mode
+        else:
+            raise ValueError("border_mode must have two elements")
+
+        sub['image'] = image
+        sub['weight'] = weight
+        sub['z'] = z
+        sub['bias'] = bias
+
+        if bias is not None:
+            withBias = 1
+            sub['bias'] = bias
+        else:
+            withBias = 0
+        sub['withBias'] = withBias
+
+        if node.inputs[0].dtype == "float32":
+            sub['precision'] = 'F32'
+            sub['dtype'] = 'float'
+        elif node.inputs[0].dtype == "float64":
+            sub['precision'] = 'F64'
+            sub['dtype'] = 'double'
+
+        sub.update(locals())
+
+        if bias is None:
+            sub['bias'] = 'NULL'
+
+        ccode = """
+            int status = 0;
+            if (1 == first_run) {
+                convStride[0] = %(dW)s;
+                convStride[1] = %(dH)s;
+                convPadding[0] = -%(padW)s;
+                convPadding[1] = -%(padH)s;
+
+                imageSize[0] = %(in_w)s;  //w
+                imageSize[1] = %(in_h)s;  //h
+                imageSize[2] = %(in_c)s;  //c
+                imageSize[3] = %(in_n)s;  //n
+
+                if (0 == imageSize[0] || 0 == imageSize[1] || 0 == imageSize[2] || 0 == imageSize[3]) {
+                    imageSize[0] = MKLNdarray_DIMS(%(image)s)[3];
+                    imageSize[1] = MKLNdarray_DIMS(%(image)s)[2];
+                    imageSize[2] = MKLNdarray_DIMS(%(image)s)[1];
+                    imageSize[3] = MKLNdarray_DIMS(%(image)s)[0];
+                }
+
+                imageStride[0] = 1;
+                imageStride[1] = imageSize[0];
+                imageStride[2] = imageSize[0] * imageSize[1];
+                imageStride[3] = imageSize[0] * imageSize[1] * imageSize[2];
+
+                weightSize[0] = %(k_w)s;
+                weightSize[1] = %(k_h)s;
+                weightSize[2] = %(k_c)s;
+                weightSize[3] = %(k_n)s;
+                weightSize[4] = %(grp)s;
+
+                weightStride[0] = 1;
+                weightStride[1] = weightSize[0];
+                weightStride[2] = weightSize[0] * weightSize[1];
+                weightStride[3] = weightSize[0] * weightSize[1] * weightSize[2];
+                weightStride[4] = weightSize[0] * weightSize[1] * weightSize[2] * weightSize[3];
+
+                zSize[0] = %(o_w)s;
+                zSize[1] = %(o_h)s;
+                zSize[2] = %(o_c)s;
+                zSize[3] = %(o_n)s;
+
+                if (0 == zSize[0] || 0 == zSize[1] || 0 == zSize[2] || 0 == zSize[3]) {
+                    zSize[0] = (imageSize[0] - 2 * convPadding[0] - weightSize[0]) / convStride[0] + 1;
+                    zSize[1] = (imageSize[1] - 2 * convPadding[1] - weightSize[1]) / convStride[1] + 1;
+                    zSize[2] = weightSize[3];
+                    zSize[3] = imageSize[3];
+                }
+
+                zStride[0] = 1;
+                zStride[1] = zSize[0];
+                zStride[2] = zSize[0] * zSize[1];
+                zStride[3] = zSize[0] * zSize[1] * zSize[2];
+
+                if(%(withBias)s) {
+                    biasSize[0] = zSize[2];
+                    biasStride[0] = 1;
+                }
+
+                groups = %(grp)s;
+                fdimension = dimension + (groups != 1);
+
+                // Create conv forward primitive
+                if (%(withBias)s) {
+                    CHECK_ERR( dnnGroupsConvolutionCreateForwardBias_%(precision)s(&pConvolutionFwd, NULL,
+                               dnnAlgorithmConvolutionDirect, groups, dimension, imageSize,
+                               zSize, weightSize, convStride, convPadding, dnnBorderZeros), err );
+                    CHECK_ERR( dnnLayoutCreate_%(precision)s(&bias_usr_layout, 1, biasSize, biasStride), err );
+                    CHECK_ERR( dnnLayoutCreateFromPrimitive_%(precision)s(&bias_internal_layout,
+                                                                          pConvolutionFwd,
+                                                                          dnnResourceBias), err );
+
+                    if (!dnnLayoutCompare_%(precision)s(bias_usr_layout, bias_internal_layout)) {
+                        CHECK_ERR( dnnAllocateBuffer_%(precision)s((void**)&bias_buf,
+                                                                   bias_internal_layout), err );
+                        CHECK_ERR( dnnConversionCreate_%(precision)s(&bias_to_internal,
+                                                                     bias_usr_layout,
+                                                                     bias_internal_layout), err );
+                    } else {
+                        bias_to_internal = NULL;
+                        bias_buf = NULL;
+                    }
+                } else {
+                    CHECK_ERR( dnnGroupsConvolutionCreateForward_%(precision)s(&pConvolutionFwd, NULL,
+                               dnnAlgorithmConvolutionDirect, groups, dimension, imageSize,
+                               zSize, weightSize, convStride, convPadding, dnnBorderZeros), err );
+                }
+
+                // For internal weights
+                CHECK_ERR( dnnLayoutCreate_%(precision)s(&weight_usr_layout,
+                                                         fdimension,
+                                                         weightSize,
+                                                         weightStride), err );
+                CHECK_ERR( dnnLayoutCreateFromPrimitive_%(precision)s(&weight_internal_layout,
+                                                                      pConvolutionFwd,
+                                                                      dnnResourceFilter), err );
+                if (!dnnLayoutCompare_%(precision)s(weight_usr_layout, weight_internal_layout)) {
+                    CHECK_ERR( dnnAllocateBuffer_%(precision)s((void**)&weight_buf,
+                                                               weight_internal_layout), err );
+                    CHECK_ERR( dnnConversionCreate_%(precision)s(&weight_to_internal,
+                                                                 weight_usr_layout,
+                                                                 weight_internal_layout), err );
+                } else {
+                    weight_to_internal = NULL;
+                    weight_buf = NULL;
+                }
+
+                // For internal image
+                CHECK_ERR( dnnLayoutCreateFromPrimitive_%(precision)s(&image_internal_layout,
+                           pConvolutionFwd, dnnResourceSrc), err );
+                if (!dnnLayoutCompare_%(precision)s(MKLNdarray_LAYOUT(%(image)s), image_internal_layout)) {
+                    CHECK_ERR( dnnAllocateBuffer_%(precision)s((void**)&image_buf,
+                                                               image_internal_layout), err );
+                    CHECK_ERR( dnnConversionCreate_%(precision)s(&internal_to_internal_image,
+                                                                 MKLNdarray_LAYOUT(%(image)s),
+                                                                 image_internal_layout), err );
+                } else {
+                    internal_to_internal_image = NULL;
+                    image_buf = NULL;
+                }
+
+            }
+
+            if (! (%(z)s
+                && MKLNdarray_Check((PyObject*)%(z)s)
+                && MKLNdarray_NDIM(%(z)s) == MKLNdarray_NDIM(%(image)s)
+                && MKLNdarray_DIMS(%(z)s)[0] == MKLNdarray_DIMS(%(image)s)[0]
+                && MKLNdarray_DIMS(%(z)s)[1] == MKLNdarray_DIMS(%(image)s)[1]
+                && MKLNdarray_DIMS(%(z)s)[2] == MKLNdarray_DIMS(%(image)s)[2]
+                && MKLNdarray_DIMS(%(z)s)[3] == MKLNdarray_DIMS(%(image)s)[3] )) {
+
+                if (%(z)s) Py_XDECREF(%(z)s);
+
+                %(z)s = (MKLNdarray*)MKLNdarray_New(MKLNdarray_NDIM(%(image)s),
+                                                    MKLNdarray_TYPE(%(image)s));
+                if (! %(z)s) {
+                    %(fail)s;
+                }
+
+                size_t z_dims[4] = {zSize[3], zSize[2], zSize[1], zSize[0]};
+                status = MKLNdarray_set_structure(%(z)s, MKLNdarray_NDIM(%(image)s), z_dims);
+                if (status != 0) {
+                    %(fail)s;
+                }
+
+                // create dst layout and buffer in z
+                status = MKLNdarray_create_buffer_from_primitive(%(z)s, &pConvolutionFwd, dnnResourceDst);
+                if (status != 0) {
+                    %(fail)s;
+                }
+            }   // else reuse %(z)s
+
+            if (internal_to_internal_image) {
+                CHECK_ERR( dnnConversionExecute_%(precision)s(internal_to_internal_image,
+                                                              MKLNdarray_DATA(%(image)s),
+                                                              image_buf), err );
+                conv_res[dnnResourceSrc] = image_buf;
+            } else {
+                conv_res[dnnResourceSrc] = MKLNdarray_DATA(%(image)s);
+            }
+
+            if (weight_to_internal) {
+                CHECK_ERR( dnnConversionExecute_%(precision)s(weight_to_internal,
+                                                              (%(dtype)s*)PyArray_DATA(%(weight)s),
+                                                              weight_buf), err );
+                conv_res[dnnResourceFilter] = weight_buf;
+            } else {
+                conv_res[dnnResourceFilter] = (void*)PyArray_DATA(%(weight)s);
+            }
+
+            if(%(withBias)s) {
+                if (bias_to_internal) {
+                    CHECK_ERR( dnnConversionExecute_%(precision)s(bias_to_internal,
+                                                                  (%(dtype)s*)PyArray_DATA(%(bias)s),
+                                                                  bias_buf), err );
+                    conv_res[dnnResourceBias] = bias_buf;
+                } else {
+                    conv_res[dnnResourceBias] = (void*)PyArray_DATA(%(bias)s);
+                }
+            } else {
+                conv_res[dnnResourceBias] = NULL;
+            }
+
+            conv_res[dnnResourceDst] = MKLNdarray_DATA(%(z)s);
+            //Execute convolution forward pass
+            CHECK_ERR( dnnExecute_%(precision)s(pConvolutionFwd, (void**)conv_res), err );
+
+            first_run = 0;
+        """ % sub
+        return ccode
+
+    def grad(self, inp, grads):
+        if len(inp) > 2:
+            image, weights, bias = inp
+        else:
+            image, weights = inp
+            bias = None
+
+        gz, = grads
+        d_images = ConvGradInputs(border_mode=self.border_mode,
+                                  subsample=self.subsample,
+                                  imshp=self.imshp,
+                                  kshp=self.kshp,
+                                  filter_flip=self.filter_flip)(image, weights, gz)
+
+        dlist = ConvGradWeights(border_mode=self.border_mode,
+                                subsample=self.subsample,
+                                imshp=self.imshp,
+                                kshp=self.kshp,
+                                filter_flip=self.filter_flip)(image, weights, gz, bias)
+
+        if bias is None:
+            d_weights = dlist
+            return d_images, d_weights
+        else:
+            d_weights, d_bias = dlist
+            return d_images, d_weights, d_bias
+
+
+class ConvGradInputs(MKLConvBase):
+    __props__ = ('imshp', 'kshp', 'border_mode', 'subsample', 'filter_flip', 'filter_dilation')
+
+    def __init__(self, imshp=None, kshp=None, border_mode='valid', subsample=(1, 1), filter_flip=True, filter_dilation=(1, 1)):
+        super(ConvGradInputs, self).__init__(imshp=imshp, kshp=kshp, border_mode=border_mode, subsample=subsample)
+        self.filter_flip = filter_flip
+        self.filter_dilation = filter_dilation
+
+    def c_cleanup_code_struct(self, node, name):
+        if node.inputs[0].type.dtype == "float32":
+            precision = "F32"
+        elif node.inputs[0].type.dtype == "float64":
+            precision = "F64"
+        ccode = """
+            // release layout
+            if (weight_usr_layout) {
+                dnnLayoutDelete_%(precision)s(weight_usr_layout);
+                weight_usr_layout = NULL;
+            }
+
+            if (weight_internal_layout) {
+                dnnLayoutDelete_%(precision)s(weight_internal_layout);
+                weight_internal_layout = NULL;
+            }
+
+            if (gradz_internal_layout) {
+                dnnLayoutDelete_%(precision)s(gradz_internal_layout);
+                gradz_internal_layout = NULL;
+            }
+
+            if (image_internal_layout) {
+                dnnLayoutDelete_%(precision)s(image_internal_layout);
+                image_internal_layout = NULL;
+            }
+
+            // release primitive
+            if (pConvolutionBwdData) {
+                dnnDelete_%(precision)s(pConvolutionBwdData);
+                pConvolutionBwdData = NULL;
+            }
+
+            if (weight_to_internal) {
+                dnnDelete_%(precision)s(weight_to_internal);
+                weight_to_internal = NULL;
+            }
+
+            if (gradz_to_internal) {
+                dnnDelete_%(precision)s(gradz_to_internal);
+                gradz_to_internal = NULL;
+            }
+
+            if (internal_to_internal_image) {
+                dnnDelete_%(precision)s(internal_to_internal_image);
+                internal_to_internal_image = NULL;
+            }
+
+            // release buffer
+            if (weight_buf) {
+                dnnReleaseBuffer_%(precision)s(weight_buf);
+                weight_buf = NULL;
+            }
+
+            if (gradz_buf) {
+                dnnReleaseBuffer_%(precision)s(gradz_buf);
+                gradz_buf = NULL;
+            }
+
+            if (image_buf) {
+                dnnReleaseBuffer_%(precision)s(image_buf);
+                image_buf = NULL;
+            }
+        """ % locals()
+        return ccode
+
+    def make_node(self, image, weight, gradz):
+        if not isinstance(image.type, mkl_type.MKLNdarrayType) or image.type.ndim != 4:
+            raise TypeError('ConvGradInputs: input image should be 4-dim MKLNdarray')
+
+        if not isinstance(gradz.type, mkl_type.MKLNdarrayType) or gradz.type.ndim != 4:
+            raise TypeError('ConvGradInputs: input gradz should be 4-dim MKLNdarray')
+
+        weight = as_tensor_variable(weight)
+        if weight.type.ndim not in [4, 5]:
+            raise TypeError('ConvGradInputs: weight should be 4D or 5D tensor')
+
+        if weight.type.ndim == 4:
+            broadcastable = [gradz.type.broadcastable[0], weight.type.broadcastable[1], False, False]
+        else:
+            broadcastable = [gradz.type.broadcastable[0], weight.type.broadcastable[2], False, False]
+
+        return Apply(self, [image, weight, gradz], [mkl_type.MKLNdarrayType(image.type.dtype, broadcastable)()])
+
+    def c_code(self, node, name, inp, out_, sub):
+        image, weights, gradz = inp
+        imagegrad, = out_
+
+        if None in self.kshp:
+            raise ValueError('ConvGradInputs: None in kernel shape')
+
+        if node.inputs[1].type.ndim == 5:
+            tshp = [self.kshp[1] * self.kshp[0], self.kshp[2] * self.kshp[0], self.kshp[3], self.kshp[4]]
+        else:
+            tshp = [self.kshp[0], self.kshp[1], self.kshp[2], self.kshp[3]]
+
+        if None in self.imshp:
+            in_n, in_c, in_h, in_w = 0, 0, 0, 0
+            o_n, o_c, o_h, o_w = 0, 0, 0, 0
+        else:
+            in_n, in_c, in_h, in_w = self.imshp
+            outshp = get_conv_output_shape(self.imshp, tshp, self.border_mode, self.subsample)
+            o_n, o_c, o_h, o_w = outshp
+
+        if node.inputs[1].type.ndim == 5:
+            grp, k_n, k_c, k_h, k_w = self.kshp
+        else:
+            grp = 1
+            k_n, k_c, k_h, k_w = self.kshp
+
+        dH, dW = self.subsample
+
+        if self.border_mode == 'valid':
+            padH, padW = (0, 0)
+        elif self.border_mode == 'full':
+            padH, padW = ((k_h - 1), (k_w - 1))
+        elif self.border_mode == 'half':
+            padH, padW = ((k_h / 2), (k_w / 2))
+        elif isinstance(self.border_mode, tuple):
+            padH, padW = self.border_mode
+        else:
+            raise ValueError("border_mode must have two elements")
+
+        sub['image'] = image
+        sub['imagegrad'] = imagegrad
+        sub['weight'] = weights
+        sub['gradz'] = gradz
+
+        if node.inputs[0].type.dtype == "float32":
+            sub['precision'] = 'F32'
+            sub['dtype'] = 'float'
+        elif node.inputs[0].type.dtype == "float64":
+            sub['precision'] = 'F64'
+            sub['dtype'] = 'double'
+        sub.update(locals())
+
+        ccode = """
+            int status = 0;
+            if (1 == first_run) {
+                convStride[0] = %(dW)s;
+                convStride[1] = %(dH)s;
+
+                convPadding[0] = -%(padW)s;
+                convPadding[1] = -%(padH)s;
+
+                imageSize[0] = %(in_w)s;  //w
+                imageSize[1] = %(in_h)s;  //h
+                imageSize[2] = %(in_c)s;  //c
+                imageSize[3] = %(in_n)s;  //n
+
+                if (0 == imageSize[0] || 0 == imageSize[1] || 0 == imageSize[2] || 0 == imageSize[3]) {
+                    imageSize[0] = MKLNdarray_DIMS(%(image)s)[3];
+                    imageSize[1] = MKLNdarray_DIMS(%(image)s)[2];
+                    imageSize[2] = MKLNdarray_DIMS(%(image)s)[1];
+                    imageSize[3] = MKLNdarray_DIMS(%(image)s)[0];
+                }
+
+                imageStride[0] = 1;
+                imageStride[1] = imageSize[0];
+                imageStride[2] = imageSize[0] * imageSize[1];
+                imageStride[3] = imageSize[0] * imageSize[1] * imageSize[2];
+
+                weightSize[0] = %(k_w)s;
+                weightSize[1] = %(k_h)s;
+                weightSize[2] = %(k_c)s;
+                weightSize[3] = %(k_n)s;
+                weightSize[4] = %(grp)s;
+                weightStride[0] = 1;
+                weightStride[1] = weightSize[0];
+                weightStride[2] = weightSize[0] * weightSize[1];
+                weightStride[3] = weightSize[0] * weightSize[1] * weightSize[2];
+                weightStride[4] = weightSize[0] * weightSize[1] * weightSize[2] * weightSize[3];
+
+                zSize[0] = %(o_w)s;
+                zSize[1] = %(o_h)s;
+                zSize[2] = %(o_c)s;
+                zSize[3] = %(o_n)s;
+
+                if (0 == zSize[0] || 0 == zSize[1] || 0 == zSize[2] || 0 == zSize[3]) {
+                    zSize[0] = (imageSize[0] - 2 * convPadding[0] - weightSize[0]) / convStride[0] + 1;
+                    zSize[0] = (imageSize[1] - 2 * convPadding[1] - weightSize[1]) / convStride[1] + 1;
+                    zSize[0] = weightSize[3];
+                    zSize[0] = imageSize[3];
+                }
+
+                zStride[0] = 1;
+                zStride[1] = zSize[0];
+                zStride[2] = zSize[0] * zSize[1];
+                zStride[3] = zSize[0] * zSize[1] * zSize[2];
+
+                groups = %(grp)s;
+                fdimension = dimension + (groups != 1);
+
+                // Create conv gradInput primitive
+                CHECK_ERR( dnnGroupsConvolutionCreateBackwardData_%(precision)s(&pConvolutionBwdData, NULL,
+                           dnnAlgorithmConvolutionDirect, groups, dimension, imageSize,
+                           zSize, weightSize, convStride, convPadding, dnnBorderZeros), err );
+
+                // For internal weight
+                CHECK_ERR( dnnLayoutCreateFromPrimitive_%(precision)s(&weight_internal_layout,
+                           pConvolutionBwdData, dnnResourceFilter), err );
+                CHECK_ERR( dnnLayoutCreate_%(precision)s(&weight_usr_layout, fdimension, weightSize, weightStride), err);
+                if (!dnnLayoutCompare_%(precision)s(weight_usr_layout, weight_internal_layout)) {
+                    CHECK_ERR( dnnAllocateBuffer_%(precision)s((void**)&weight_buf, weight_internal_layout), err);
+                    CHECK_ERR( dnnConversionCreate_%(precision)s(&weight_to_internal,
+                                                                 weight_usr_layout,
+                                                                 weight_internal_layout), err );
+                } else {
+                    weight_to_internal = NULL;
+                    weight_buf = NULL;
+                }
+
+                // For internal diff dst (gradz)
+                CHECK_ERR( dnnLayoutCreateFromPrimitive_%(precision)s(&gradz_internal_layout,
+                                                                      pConvolutionBwdData,
+                                                                      dnnResourceDiffDst), err);
+                if (!dnnLayoutCompare_%(precision)s(gradz_internal_layout, MKLNdarray_LAYOUT(%(gradz)s) )) {
+                   CHECK_ERR( dnnAllocateBuffer_%(precision)s((void**)&gradz_buf, gradz_internal_layout), err );
+                   CHECK_ERR( dnnConversionCreate_%(precision)s(&gradz_to_internal,
+                                                                MKLNdarray_LAYOUT(%(gradz)s),
+                                                                gradz_internal_layout), err );
+                } else {
+                    gradz_to_internal = NULL;
+                    gradz_buf = NULL;
+                }
+
+                // For internal diff src (grad image)
+                // need convert grad image from internal layout to layout of input image
+                // so they can be added for update
+                CHECK_ERR( dnnLayoutCreateFromPrimitive_%(precision)s(&image_internal_layout,
+                           pConvolutionBwdData, dnnResourceDiffSrc), err );
+                if (! dnnLayoutCompare_%(precision)s(MKLNdarray_LAYOUT(%(image)s), image_internal_layout)) {
+                    CHECK_ERR( dnnAllocateBuffer_%(precision)s((void**)image_buf, image_internal_layout), err);
+                    CHECK_ERR( dnnConversionCreate_%(precision)s(&internal_to_internal_image,
+                                                                 image_internal_layout,
+                                                                 MKLNdarray_LAYOUT(%(image)s)), err);
+                } else {
+                    image_to_internal = NULL;
+                    image_buf = NULL;
+                }
+            }
+
+            if (! (%(imagegrad)s
+                && MKLNdarray_Check((PyObject*)%(imagegrad)s)
+                && MKLNdarray_NDIM(%(imagegrad)s) == MKLNdarray_NDIM(%(image)s)
+                && MKLNdarray_DIMS(%(imagegrad)s)[0] == MKLNdarray_DIMS(%(image)s)[0]
+                && MKLNdarray_DIMS(%(imagegrad)s)[1] == MKLNdarray_DIMS(%(image)s)[1]
+                && MKLNdarray_DIMS(%(imagegrad)s)[2] == MKLNdarray_DIMS(%(image)s)[2]
+                && MKLNdarray_DIMS(%(imagegrad)s)[3] == MKLNdarray_DIMS(%(image)s)[3])) {
+
+                if (%(imagegrad)s) Py_XDECREF(%(imagegrad)s);
+
+                %(imagegrad)s = (MKLNdarray*)MKLNdarray_New(MKLNdarray_NDIM(%(image)s),
+                                                            MKLNdarray_TYPE(%(image)s));
+                if (! %(imagegrad)s) {
+                    %(fail)s;
+                }
+
+                status = MKLNdarray_set_structure(%(imagegrad)s,
+                                                  MKLNdarray_NDIM(%(image)s),
+                                                  MKLNdarray_DIMS(%(image)s));
+                if (status != 0) {
+                    %(fail)s;
+                }
+
+                status = MKLNdarray_copy_layout(%(imagegrad)s, %(image)s, MNDA_DATA);
+                if (status != 0) {
+                    %(fail)s;
+                }
+
+                status = MKLNdarray_create_buffer_from_layout(%(imagegrad)s, MNDA_DATA);
+                if (status != 0) {
+                    %(fail)s;
+                }
+            }   // else reuse %(imagegrad)s
+
+            if (weight_to_internal) {
+                CHECK_ERR( dnnConversionExecute_%(precision)s(weight_to_internal,
+                                                              PyArray_DATA(%(weight)s),
+                                                              weight_buf), err );
+                conv_res[dnnResourceFilter] = weight_buf;
+            } else {
+                conv_res[dnnResourceFilter] = PyArray_DATA(%(weight)s);
+            }
+
+            if (gradz_to_internal) {
+                CHECK_ERR( dnnConversionExecute_%(precision)s(gradz_to_internal,
+                                                              MKLNdarray_DATA(%(gradz)s),
+                                                              gradz_buf), err );
+                conv_res[dnnResourceDiffDst] = gradz_buf;
+            } else {
+                conv_res[dnnResourceDiffDst] = MKLNdarray_DATA(%(gradz)s);
+            }
+
+            if (internal_to_internal_image) {
+                conv_res[dnnResourceDiffSrc] = image_buf;
+            } else {
+                conv_res[dnnResourceDiffSrc] = MKLNdarray_DATA(%(imagegrad)s);
+            }
+
+            CHECK_ERR( dnnExecute_%(precision)s(pConvolutionBwdData, (void**)conv_res), err );
+            if (internal_to_internal_image) {
+                CHECK_ERR (dnnConversionExecute_%(precision)s(internal_to_internal_image,
+                                                              image_buf,
+                                                              MKLNdarray_DATA(%(imagegrad)s)), err );
+            }
+
+           first_run = 0;
+        """ % sub
+        return ccode
+
+
+class ConvGradWeights(MKLConvBase):
+    __props__ = ('imshp', 'kshp', 'border_mode', 'subsample', 'filter_flip', 'filter_dilation')
+
+    def __init__(self, imshp=None, kshp=None, border_mode='valid', subsample=(1, 1), filter_flip=False, filter_dilation=(1, 1)):
+        super(ConvGradWeights, self).__init__(imshp=imshp, kshp=kshp, border_mode=border_mode, subsample=subsample)
+        self.filter_flip = filter_flip
+        self.filter_dilation = filter_dilation
+
+    def make_node(self, image, weight, gradz, bias=None):
+        if not isinstance(image.type, mkl_type.MKLNdarrayType) or image.type.ndim is not 4:
+            raise TypeError('ConvGradWeights: input image should be 4-dim MKLNdarray')
+
+        if not isinstance(gradz.type, mkl_type.MKLNdarrayType) or gradz.type.ndim is not 4:
+            raise TypeError('ConvGradWeights: input gradz should be 4-dim MKLNdarray')
+
+        weight = as_tensor_variable(weight)
+        if weight.type.ndim not in (4, 5):
+            raise TypeError('ConvGradWeights: input weight should be 4D or 5D tensor')
+
+        if weight.type.ndim == 4:
+            weightbt = [gradz.type.broadcastable[1], image.type.broadcastable[1], False, False]
+        else:
+            weightbt = [False, gradz.type.broadcastable[1], image.type.broadcastable[1], False, False]
+
+        dtype = image.type.dtype
+        if bias is not None:
+            bias = as_tensor_variable(bias)
+            inputs = [image, weight, gradz, bias]
+            biasbt = [gradz.type.broadcastable[1]]
+            outputs = [TensorType(dtype, weightbt)(), TensorType(dtype, biasbt)()]
+        else:
+            inputs = [image, weight, gradz]
+            outputs = [TensorType(dtype, weightbt)()]
+
+        return Apply(self, inputs, outputs)
+
+    def c_code(self, node, name, inp, out_, sub):
+        if len(inp) > 3:
+            image, weight, gradz, bias = inp
+            weightgrad, biasgrad = out_
+        else:
+            image, weight, gradz = inp
+            bias = None
+            weightgrad, = out_
+
+        if None in self.kshp:
+            raise ValueError('ConvGradWeights: None in kernel shape')
+
+        if node.inputs[1].type.ndim == 5:
+            grp, k_n, k_c, k_h, k_w = self.kshp
+            tshp = [self.kshp[1] * self.kshp[0], self.kshp[2] * self.kshp[0], self.kshp[3], self.kshp[4]]
+        else:
+            k_n, k_c, k_h, k_w = self.kshp
+            grp = 1
+            tshp = [self.kshp[0], self.kshp[1], self.kshp[2], self.kshp[3]]
+
+        if None in self.imshp:
+            in_n, in_c, in_h, in_w = 0, 0, 0, 0
+            o_n, o_c, o_h, o_w = 0, 0, 0, 0
+        else:
+            in_n, in_c, in_h, in_w = self.imshp
+            outshp = get_conv_output_shape(self.imshp, tshp, self.border_mode, self.subsample)
+            o_n, o_c, o_h, o_w = outshp
+
+        if bias is not None:
+            sub['bias'] = bias
+            sub['biasgrad'] = biasgrad
+            withBias = 1
+        else:
+            withBias = 0
+        sub['withBias'] = withBias
+
+        dH, dW = self.subsample
+        if self.border_mode == 'valid':
+            padH, padW = (0, 0)
+        elif self.border_mode == 'full':
+            padH, padW = ((k_h - 1), (k_w - 1))
+        elif self.border_mode == 'half':
+            padH, padW = ((k_h / 2), (k_w / 2))
+        elif isinstance(self.border_mode, tuple):
+            padH, padW = self.border_mode
+        else:
+            raise ValueError("border_mode must have two elements")
+
+        sub['image'] = image
+        sub['weight'] = weight
+        sub['weightgrad'] = weightgrad
+        sub['gradz'] = gradz
+
+        if node.inputs[0].dtype == "float32":
+            sub['precision'] = 'F32'
+            sub['dtype'] = 'float'
+        elif node.inputs[0].dtype == "float64":
+            sub['precision'] = 'F64'
+            sub['dtype'] = 'double'
+        sub.update(locals())
+
+        if bias is None:
+            sub['bias'] = 'NULL'
+            sub['biasgrad'] = 'NULL'
+
+        ccode = """
+            int status = 0;
+            if (1 == first_run) {
+                convStride[0] = %(dW)s;
+                convStride[1] = %(dH)s;
+                convPadding[0] = -%(padW)s;
+                convPadding[1] = -%(padH)s;
+
+                imageSize[0] = %(in_w)s;  //w
+                imageSize[1] = %(in_h)s;  //h
+                imageSize[2] = %(in_c)s;  //c
+                imageSize[3] = %(in_n)s;  //n
+
+                if (0 == imageSize[0] || 0 == imageSize[1] || 0 == imageSize[2] || 0 == imageSize[3]) {
+                    imageSize[0] = MKLNdarray_DIMS(%(image)s)[3];
+                    imageSize[1] = MKLNdarray_DIMS(%(image)s)[2];
+                    imageSize[2] = MKLNdarray_DIMS(%(image)s)[1];
+                    imageSize[3] = MKLNdarray_DIMS(%(image)s)[0];
+                }
+
+                imageStride[0] = 1;
+                imageStride[1] = imageSize[0];
+                imageStride[2] = imageSize[0] * imageSize[1];
+                imageStride[3] = imageSize[0] * imageSize[1] * imageSize[2];
+
+                weightSize[0] = %(k_w)s;
+                weightSize[1] = %(k_h)s;
+                weightSize[2] = %(k_c)s;
+                weightSize[3] = %(k_n)s;
+                weightSize[4] = %(grp)s;
+                weightStride[0] = 1;
+                weightStride[1] = weightSize[0];
+                weightStride[2] = weightSize[0] * weightSize[1];
+                weightStride[3] = weightSize[0] * weightSize[1] * weightSize[2];
+                weightStride[4] = weightSize[0] * weightSize[1] * weightSize[2] * weightSize[3];
+
+                zSize[0] = %(o_w)s;
+                zSize[1] = %(o_h)s;
+                zSize[2] = %(o_c)s;
+                zSize[3] = %(o_n)s;
+
+                if (0 == zSize[0] || 0 == zSize[1] || 0 == zSize[2] || 0 == zSize[3]) {
+                    zSize[0] = (imageSize[0] - 2 * convPadding[0] - weightSize[0]) / convStride[0] + 1;
+                    zSize[1] = (imageSize[1] - 2 * convPadding[1] - weightSize[1]) / convStride[1] + 1;
+                    zSize[2] = weightSize[3];
+                    zSize[3] = imageSize[3];
+                }
+
+                zStride[0] = 1;
+                zStride[1] = zSize[0];
+                zStride[2] = zSize[0] * zSize[1];
+                zStride[3] = zSize[0] * zSize[1] * zSize[2];
+
+                if( %(withBias)s ) {
+                    biasSize[0] = zSize[2];
+                    biasStride[0] = 1;
+                }
+
+                groups = %(grp)s;
+                fdimension = dimension + (groups != 1);
+
+                // Create conv backward primitive
+                CHECK_ERR( dnnGroupsConvolutionCreateBackwardFilter_%(precision)s(&pConvolutionBwdFilter, NULL,
+                           dnnAlgorithmConvolutionDirect, groups, dimension, imageSize,
+                           zSize, weightSize, convStride, convPadding, dnnBorderZeros), err );
+
+                // For internal weight
+                CHECK_ERR( dnnLayoutCreateFromPrimitive_%(precision)s(&bwdf_weight_internal_layout,
+                           pConvolutionBwdFilter, dnnResourceDiffFilter), err );
+
+                CHECK_ERR( dnnLayoutCreate_%(precision)s(&weight_usr_layout,
+                                                         fdimension,
+                                                         weightSize,
+                                                         weightStride), err);
+
+                if ( !dnnLayoutCompare_%(precision)s(weight_usr_layout, weight_internal_layout)) {
+                    CHECK_ERR( dnnAllocateBuffer_%(precision)s((void**)&weight_buf,
+                                                               weight_internal_layout), err );
+                    CHECK_ERR( dnnConversionCreate_%(precision)s(&weight_from_internal,
+                                                                 weight_internal_layout,
+                                                                 weight_usr_layout), err );
+                } else {
+                    weight_from_internal = NULL;
+                    weight_buf = NULL;
+                }
+
+                // For internal image
+                CHECK_ERR( dnnLayoutCreateFromPrimitive_%(precision)s(&image_internal_layout,
+                           pConvolutionBwdFilter, dnnResourceSrc), err );
+
+                if ( !dnnLayoutCompare_%(precision)s(image_internal_layout, MKLNdarray_LAYOUT(%(image)s))) {
+                    CHECK_ERR( dnnAllocateBuffer_%(precision)s((void**)&image_buf,
+                                                               image_internal_layout), err );
+                    CHECK_ERR( dnnConversionCreate_%(precision)s(&internal_to_internal_image,
+                                                                 MKLNdarray_LAYOUT(%(image)s),
+                                                                 image_internal_layout), err );
+                } else {
+                    internal_to_internal_image = NULL;
+                    image_buf = NULL;
+                }
+
+                // For internal gradz
+                CHECK_ERR( dnnLayoutCreateFromPrimitive_%(precision)s(&gradz_internal_layout_for_weight,
+                           pConvolutionBwdFilter, dnnResourceDiffDst), err );
+
+                if ( !dnnLayoutCompare_%(precision)s(gradz_internal_layout_for_weight,
+                                                     MKLNdarray_LAYOUT(%(gradz)s))) {
+                    CHECK_ERR( dnnAllocateBuffer_%(precision)s((void**)&gradz_buf_for_weight,
+                                                               gradz_internal_layout_for_weight), err );
+                    CHECK_ERR( dnnConversionCreate_%(precision)s(&gradz_to_internal_for_weight,
+                                                                 MKLNdarray_LAYOUT(%(gradz)s),
+                                                                 gradz_internal_layout_for_weight), err );
+                } else {
+                    gradz_to_internal_for_weight = NULL;
+                    gradz_buf_for_weight = NULL;
+                }
+
+                if( %(withBias)s ) {
+                    CHECK_ERR( dnnGroupsConvolutionCreateBackwardBias_%(precision)s(&pConvolutionBwdBias, NULL,
+                                dnnAlgorithmConvolutionDirect, groups, dimension, zSize), err );
+
+                    CHECK_ERR( dnnLayoutCreateFromPrimitive_%(precision)s(&bias_internal_layout,
+                               pConvolutionBwdBias, dnnResourceDiffBias), err );
+
+                    CHECK_ERR( dnnLayoutCreate_%(precision)s(&bias_usr_layout, 1, biasSize, biasStride), err );
+
+                    if ( !dnnLayoutCompare_%(precision)s(bias_usr_layout, bias_internal_layout)) {
+                        CHECK_ERR( dnnAllocateBuffer_%(precision)s((void**)&bias_buf, bias_internal_layout), err);
+                        CHECK_ERR( dnnConversionCreate_%(precision)s(&bias_from_internal,
+                                                                     bias_internal_layout,
+                                                                     bias_usr_layout), err);
+                    } else {
+                        bias_from_internal = NULL;
+                        bias_buf = NULL;
+                    }
+
+                    CHECK_ERR( dnnLayoutCreateFromPrimitive_%(precision)s(&gradz_internal_layout_for_bias,
+                               pConvolutionBwdBias, dnnResourceDiffDst), err );
+
+                    if ( !dnnLayoutCompare_%(precision)s(gradz_internal_layout_for_bias,
+                                                         MKLNdarray_LAYOUT(%(gradz)s))) {
+                        CHECK_ERR( dnnAllocateBuffer_%(precision)s((void**)&gradz_buf_for_bias,
+                                                                   gradz_internal_layout_for_bias), err );
+                        CHECK_ERR( dnnConversionCreate_%(precision)s(&gradz_to_internal_for_bias,
+                                                                     MKLNdarray_LAYOUT(%(gradz)s),
+                                                                     gradz_internal_layout_for_bias), err );
+                    } else {
+                        gradz_to_internal_for_bias = NULL;
+                        gradz_buf_for_bias = NULL;
+                    }
+                }
+            }
+
+            //// Prepare weightgrad array
+            if ( !(%(weightgrad)s) ) {
+                %(weightgrad)s = (PyArrayObject*)PyArray_ZEROS(PyArray_NDIM(%(weight)s),
+                                                               PyArray_DIMS(%(weight)s),
+                                                               PyArray_TYPE(%(weight)s),
+                                                               0);
+                if (NULL == %(weightgrad)s) {
+                    %(fail)s;
+                }
+            }
+            """ % sub
+
+        if bias is not None:
+            ccode += """
+            if ( !%(biasgrad)s) {
+                %(biasgrad)s = (PyArrayObject*)PyArray_ZEROS(PyArray_NDIM(%(bias)s),
+                                                             PyArray_DIMS(%(bias)s),
+                                                             PyArray_TYPE(%(bias)s),
+                                                             0);
+                if (NULL == %(biasgrad)s) {
+                    %(fail)s;
+                }
+            }
+            """ % sub
+
+        ccode += """
+            // set conv_rest for computing gradweight
+            if (internal_to_internal_image) {
+                CHECK_ERR( dnnConversionExecute_%(precision)s(internal_to_internal_image,
+                                                              MKLNdarray_DATA(%(image)s),
+                                                              image_buf), err );
+                conv_res[dnnResourceSrc] = image_buf;
+            } else {
+                conv_res[dnnResourceSrc] = MKLNdarray_DATA(%(image)s);
+            }
+
+            if (gradz_to_internal_for_weight) {
+                CHECK_ERR( dnnConversionExecute_%(precision)s(gradz_to_internal_for_weight,
+                                                              MKLNdarray_DATA(%(gradz)s),
+                                                              gradz_buf_for_weight), err );
+                conv_res[dnnResourceDiffDst] = gradz_buf_for_weight;
+            } else {
+                conv_res[dnnResourceDiffDst] = MKLNdarray_DATA(%(gradz)s);
+            }
+
+            if (weight_from_internal) {
+                conv_res[dnnResourceDiffFilter] = weight_buf;
+            } else {
+                conv_res[dnnResourceDiffFilter] = PyArray_DATA(%(weightgrad)s);
+            }
+
+            CHECK_ERR( dnnExecute_%(precision)s(pConvolutionBwdFilter, (void**)conv_res), err );
+
+            if (weight_from_internal) {
+                CHECK_ERR( dnnConversionExecute_%(precision)s(weight_from_internal,
+                                                              weight_buf,
+                                                              PyArray_DATA(%(weightgrad)s)), err );
+            }
+
+            if (%(withBias)s) {
+                // set conv_res_bias for computing gradbias
+                if (gradz_to_internal_for_bias) {
+                    CHECK_ERR( dnnConversionExecute_%(precision)s(gradz_to_internal_for_bias,
+                                                                  MKLNdarray_DATA(%(gradz)s),
+                                                                  gradz_buf_for_bias), err );
+                    conv_res_bias[dnnResourceDiffDst] = gradz_buf_for_bias;
+                } else {
+                    conv_res_bias[dnnResourceDiffDst] = MKLNdarray_DATA(%(gradz)s);
+                }
+
+                if (bias_from_internal) {
+                    conv_res_bias[dnnResourceDiffBias] = bias_buf;
+                } else {
+                    conv_res_bias[dnnResourceDiffBias] = PyArray_DATA(%(biasgrad)s);
+                }
+
+                //Execute convolution gradbias pass
+                CHECK_ERR( dnnExecute_%(precision)s(pConvolutionBwdBias, (void**)conv_res_bias), err );
+
+                if (bias_from_internal) {
+                    CHECK_ERR( dnnConversionExecute_%(precision)s(bias_from_internal,
+                                                                  bias_buf,
+                                                                  PyArray_DATA(%(biasgrad)s)), err );
+                }
+            }
+
+            first_run = 0;
+        """ % sub
+        return ccode
+
+
+class AbstractConvGroup(gof.Op):
+    __props__ = ('imshp', 'kshp', 'subsample', 'border_mode', 'filter_flip', 'filter_dilation', 'group')
+
+    def __init__(self,
+                 imshp=None, kshp=None, subsample=(1, 1),
+                 border_mode='valid', filter_flip=False,
+                 filter_dilation=(1, 1), group=1):
+
+        super(AbstractConvGroup, self).__init__()
+        imshp = tuple(imshp) if imshp else (None, ) * 4
+        kshp = tuple(kshp) if kshp else (None, ) * 4
+
+        if len(subsample) != 2:
+            raise ValueError('subsample must have two elements')
+        subsample = tuple(subsample)
+
+        if len(filter_dilation) != 2:
+            raise ValueError('filter_dilation must have two elements')
+        filter_dilation = tuple(filter_dilation)
+
+        if isinstance(border_mode, integer_types):
+            border_mode = (border_mode, border_mode)
+        if isinstance(border_mode, tuple):
+            pad_h, pad_w = map(int, border_mode)
+            border_mode = (pad_h, pad_w)
+        if border_mode == (0, 0):
+            border_mode = 'valid'
+        if not ((isinstance(border_mode, tuple) and min(border_mode) >= 0) or
+                border_mode in ('valid', 'full', 'half')):
+            raise ValueError(
+                'invalid border_mode {}, which must be either '
+                '"valid", "full", "half", an integer or a pair of'
+                ' integers'.format(border_mode))
+
+        self.imshp = imshp
+        self.kshp = kshp
+        self.subsample = subsample
+        self.border_mode = border_mode
+        self.filter_flip = filter_flip
+        self.filter_dilation = filter_dilation
+        self.group = group
+        if not (isinstance(group, integer_types) and group > 0):
+            raise ValueError('invalid group {}, which mush be a positive integer.'.format(group))
+
+    def make_node(self, image, weight, bias=None):
+        image = as_tensor_variable(image)
+        weight = as_tensor_variable(weight)
+
+        if image.type.ndim != 4:
+            raise TypeError('Input image should be a 4-dim tensor.')
+
+        if self.group is 1:
+            assert weight.type.ndim == 4
+            broadcastable = [image.type.broadcastable[0], weight.type.broadcastable[0], False, False]
+        else:
+            assert weight.type.ndim == 5
+            broadcastable = [image.type.broadcastable[0], weight.type.broadcastable[1], False, False]
+
+        dtype = image.type.dtype
+
+        if bias is not None:
+            bias = as_tensor_variable(bias)
+            inputs = [image, weight, bias]
+        else:
+            inputs = [image, weight]
+        return gof.Apply(self, inputs, [TensorType(dtype, broadcastable)()])
+
+    def grad(self, inp, grads):
+        assert len(inp) in [2, 3]
+
+        if len(inp) is 3:
+            image, weight, bias, = inp
+        else:
+            image, weight, = inp
+            bias = None
+
+        gz, = grads
+        grad_out = AbstractConvGroupGrad(imshp=self.imshp,
+                                         kshp=self.kshp,
+                                         subsample=self.subsample,
+                                         border_mode=self.border_mode,
+                                         filter_flip=self.filter_flip,
+                                         filter_dilation=self.filter_dilation,
+                                         group=self.group)(image, gz, weight, bias)
+        if len(grad_out) > 2:
+            grad_image, grad_weight, grad_bias, = grad_out
+            return grad_image, grad_weight, grad_bias
+        else:
+            grad_image, grad_weight, = grad_out
+            return grad_image, grad_weight
+
+    def perform(self, node, inp, out):
+        if len(inp) == 2:
+            image, weight = inp
+        else:
+            image, weight, bias = inp
+        z, = out
+
+
+class AbstractConvGroupGrad(gof.Op):
+    __props__ = ('imshp', 'kshp', 'subsample', 'border_mode', 'filter_flip', 'filter_dilation', 'group')
+
+    def __init__(self,
+                 imshp=None, kshp=None, subsample=(1, 1),
+                 border_mode='valid', filter_flip=False,
+                 filter_dilation=(1, 1), group=1):
+
+        super(AbstractConvGroupGrad, self).__init__()
+        self.imshp = imshp
+        self.kshp = kshp
+        self.subsample = subsample
+        self.border_mode = border_mode
+        self.filter_flip = filter_flip
+        self.filter_dilation = filter_dilation
+        self.group = group
+
+    def make_node(self, image, gz, weight, bias=None):
+        if image.type.ndim != 4:
+            raise TypeError('Input image should be a 4-dim tensor.')
+
+        if self.group is 1:
+            assert weight.type.ndim == 4
+            w_broadcastable = [gz.type.broadcastable[1], image.type.broadcastable[1], False, False]
+            i_broadcastable = [gz.type.broadcastable[0], weight.type.broadcastable[1], False, False]
+        else:
+            assert weight.type.ndim == 5
+            w_broadcastable = [False, gz.type.broadcastable[1], image.type.broadcastable[1], False, False]
+            i_broadcastable = [gz.type.broadcastable[0], weight.type.broadcastable[2], False, False]
+
+        dtype = weight.type.dtype
+
+        if bias is not None:
+            bias = as_tensor_variable(bias)
+            inputs = [image, gz, weight, bias]
+            b_broadcastable = [gz.type.broadcastable[1]]
+            outputs = [TensorType(dtype, i_broadcastable)(), TensorType(dtype, w_broadcastable)(),
+                       TensorType(dtype, b_broadcastable)()]
+        else:
+            inputs = [image, gz, weight]
+            outputs = [TensorType(dtype, i_broadcastable)(), TensorType(dtype, w_broadcastable)()]
+
+        return gof.Apply(self, inputs, outputs)
+
+    def perform(self, node, inp, out):
+        if len(inp) == 3:
+            image, gz, weight, = inp
+            grad_image, grad_weight, = out
+        else:
+            image, gz, weight, bias, = inp
+            grad_image, grad_weight, grad_bias, = out

--- a/theano/contrib/mkl/mkl_helper.py
+++ b/theano/contrib/mkl/mkl_helper.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import, print_function, division
+
+
+def header_text():
+    """
+        C header for mkl dnn primitive interface,
+        Build date: 20170209
+    """
+    header = """
+    extern "C"
+    {
+        /* MKL Version type */
+        typedef
+        struct {
+            int    MajorVersion;
+            int    MinorVersion;
+            int    UpdateVersion;
+            char * ProductStatus;
+            char * Build;
+            char * Processor;
+            char * Platform;
+        } MKLVersion;
+
+        void    MKL_Get_Version(MKLVersion *ver); /* Returns information about the version of the Intel MKL software */
+        #define mkl_get_version             MKL_Get_Version
+    }
+    """
+    return header

--- a/theano/contrib/mkl/mkl_ndarray.c
+++ b/theano/contrib/mkl/mkl_ndarray.c
@@ -1,0 +1,1780 @@
+#include <Python.h>
+#include <structmember.h>
+#include <numpy/arrayobject.h>
+#include <stdlib.h>
+#include "mkl_ndarray.h"
+
+
+int MKLNdarray_Check(const PyObject *ob);
+int MKLNdarray_CopyFromArray(MKLNdarray *self, PyArrayObject *obj);
+PyObject* MKLNdarray_New(int nd, int typenum);
+
+
+/*
+ * This function is called in MKLNdarray_dealloc.
+ *
+ * Release all allocated buffer and layout in input self.
+ *
+ * If buffer/layout is reference of another MKLNdarray, decrease
+ * the reference count of base MKLNdarray.
+ */
+static int
+MKLNdarray_uninit(MKLNdarray *self) {
+    int rval = 0;
+
+    // self is a view
+    if (NULL != self->base) {
+        self->data_size = 0;
+        self->workspace_size = 0;
+        self->nd = -1;
+        self->dtype = -1;
+        Py_DECREF(self->base);
+        self->base = NULL;
+        rval = 0;
+
+    } else {
+        if (MNDA_FLOAT64 == self->dtype) {  // for float64
+            if (self->private_data) {
+                rval = dnnReleaseBuffer_F64(self->private_data);
+
+                if (E_SUCCESS != rval) {
+                    PyErr_Format(PyExc_RuntimeError,
+                                 "MKLNdarray_uninit: fail to release data: %d, line: %d",
+                                 rval, __LINE__);
+                }
+                self->private_data = NULL;
+            }
+
+            if (self->private_layout) {
+                rval = dnnLayoutDelete_F64(self->private_layout);
+
+                if (E_SUCCESS != rval) {
+                    PyErr_Format(PyExc_RuntimeError,
+                                 "MKLNdarray_uninit: fail to release layout: %d, line: %d",
+                                 rval, __LINE__);
+                }
+                self->private_layout = NULL;
+            }
+
+            if (self->private_workspace) {
+                rval = dnnReleaseBuffer_F64(self->private_workspace);
+
+                if (E_SUCCESS != rval) {
+                    PyErr_Format(PyExc_RuntimeError,
+                                 "MKLNdarray_uninit: fail to release workspace: %d, line: %d",
+                                 rval, __LINE__);
+                }
+                self->private_workspace = NULL;
+            }
+
+            if (self->private_layout_ws) {
+                rval = dnnLayoutDelete_F64(self->private_layout_ws);
+
+                if (E_SUCCESS != rval) {
+                    PyErr_Format(PyExc_RuntimeError,
+                                 "MKLNdarray_uninit: fail to release workspace layout: %d, line: %d",
+                                 rval, __LINE__);
+                }
+                self->private_layout_ws = NULL;
+            }
+        } else {  // for float32
+            if (self->private_data) {
+                rval = dnnReleaseBuffer_F32(self->private_data);
+
+                if (E_SUCCESS != rval) {
+                    PyErr_Format(PyExc_RuntimeError,
+                                 "MKLNdarray_uninit: fail to release data: %d, line: %d",
+                                 rval, __LINE__);
+                }
+                self->private_data = NULL;
+            }
+
+            if (self->private_layout) {
+                rval = dnnLayoutDelete_F32(self->private_layout);
+
+                if (E_SUCCESS != rval) {
+                    PyErr_Format(PyExc_RuntimeError,
+                                 "MKLNdarray_uninit: fail to release layout: %d, line: %d",
+                                 rval, __LINE__);
+                }
+                self->private_layout = NULL;
+            }
+
+            if (self->private_workspace) {
+                rval = dnnReleaseBuffer_F32(self->private_workspace);
+
+                if (E_SUCCESS != rval) {
+                    PyErr_Format(PyExc_RuntimeError,
+                                 "MKLNdarray_uninit: fail to release workspace: %d, line: %d",
+                                 rval, __LINE__);
+                }
+                self->private_workspace = NULL;
+            }
+
+            if (self->private_layout_ws) {
+                rval = dnnLayoutDelete_F32(self->private_layout_ws);
+
+                if (E_SUCCESS != rval) {
+                    PyErr_Format(PyExc_RuntimeError,
+                                 "MKLNdarray_uninit: fail to release workspace layout: %d, line: %d",
+                                 rval, __LINE__);
+                }
+                self->private_layout_ws = NULL;
+            }
+        }
+
+        self->data_size = 0;
+        self->workspace_size = 0;
+        self->nd = -1;
+        self->dtype = -1;
+    }
+
+    return rval;
+}
+
+
+/*
+ * type: tp_dealloc
+ *
+ * This function will be called by Py_DECREF when object's reference count is reduced to zero.
+ * DON'T call this function directly.
+ *
+ */
+static void
+MKLNdarray_dealloc(MKLNdarray *self) {
+    if (Py_REFCNT(self) > 1) {
+        printf("WARNING: MKLNdarray_dealloc called when there is still active reference to it.\n");
+    }
+    if (NULL != self) {
+        MKLNdarray_uninit(self);
+        Py_TYPE(self)->tp_free((PyObject*)self);
+    }
+}
+
+
+/*
+ * type:tp_new
+ *
+ * This function is used to create an instance of object.
+ * Be first called when do a = MKLNdarray() in python code.
+ *
+ */
+static PyObject*
+MKLNdarray_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
+    MKLNdarray* self = NULL;
+    self = (MKLNdarray*)(type->tp_alloc(type, 0));
+
+    if (NULL != self) {
+        self->base              = NULL;
+        self->nd                = -1;
+        self->dtype             = -1;
+        self->private_workspace = NULL;
+        self->private_data      = NULL;
+        self->private_layout    = NULL;
+        self->private_layout_ws = NULL;
+        self->data_size         = 0;
+        self->workspace_size    = 0;
+
+        memset((void*)(self->user_structure), 0, 2 * MNDA_MAX_NDIM * sizeof (size_t));
+    } else {
+        PyErr_SetString(PyExc_MemoryError, "MKLNdarray_new: fail to create a new instance \n");
+        return NULL;
+    }
+    return (PyObject*)self;
+}
+
+
+/*
+ * type:tp_init
+ *
+ * This function is called after MKLNdarray_new.
+ *
+ * Initialize an instance. like __init__() in python code.
+ *
+ * args: need input a PyArrayObject here.
+ *
+ */
+static int
+MKLNdarray_init(MKLNdarray *self, PyObject *args, PyObject *kwds) {
+    PyObject* arr = NULL;
+
+    if (!PyArg_ParseTuple(args, "O", &arr))
+        return -1;
+
+    if (!PyArray_Check(arr)) {
+        PyErr_SetString(PyExc_TypeError, "MKLNdarray_init: PyArrayObject arg required");
+        return -1;
+    }
+
+    // do type conversion here. PyArrayObject -> MKLNdarray
+    int rval = -1;
+    if (NULL != self) {
+        rval = MKLNdarray_CopyFromArray(self, (PyArrayObject*)arr);
+        return rval;
+    } else {
+        PyErr_SetString(PyExc_RuntimeError, "MKLNdarray_init: input MKLNdarray* self is NULL");
+        return -1;
+    }
+}
+
+
+/*
+ * type:tp_repr
+ *
+ * Return a string or a unicode object. like repr() in python code.
+ *
+ */
+PyObject* MKLNdarray_repr(PyObject *self) {
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError, "MKLNdarray_repr: input PyObject* self is NULL");
+        return NULL;
+    }
+
+    MKLNdarray* object = (MKLNdarray*)self;
+    char cstr[64]; // 64 chars is enough for a string.
+    sprintf(cstr, "ndim=%d, dtype=%s", object->nd, MNDA_TYPE[object->dtype]);
+    PyObject* out = PyString_FromFormat("%s%s%s", "MKLNdarray(", cstr, ")");
+
+#if PY_MAJOR_VERSION >= 3
+    PyObject* out2 = PyObject_Str(out);
+    Py_DECREF(out);
+    return out2;
+#else
+    return out;
+#endif
+}
+
+
+/*
+ * Get dims in user_structure.
+ *
+ * A pointer is returned.
+ *
+ */
+const size_t*
+MKLNdarray_DIMS(const MKLNdarray *self) {
+    if (NULL != self) {
+        return self->user_structure;
+    } else {
+        return NULL;
+    }
+}
+
+
+/*
+ * Get strides in user_structure.
+ *
+ * A pointer is returned. stride has a self->nd offset n user_structure
+ *
+ */
+const size_t*
+MKLNdarray_STRIDES(const MKLNdarray *self) {
+    if (NULL != self) {
+        return self->user_structure + self->nd;
+    } else {
+        return NULL;
+    }
+}
+
+
+/*
+ * Get ndim.
+ *
+ * An integer is returned.
+ *
+ */
+int MKLNdarray_NDIM(const MKLNdarray *self) {
+    if (NULL != self) {
+        return self->nd;
+    } else {
+        return -1;
+    }
+}
+
+
+/*
+ * Get dtype.
+ *
+ * An integer is returned.
+ *
+ */
+int MKLNdarray_TYPE(const MKLNdarray *self) {
+    if (NULL != self) {
+        return self->dtype;
+    } else {
+        return -1;
+    }
+}
+
+
+/*
+ * Get address of private_data.
+ *
+ * An void* pointer is returned.
+ *
+ */
+void*
+MKLNdarray_DATA(const MKLNdarray *self) {
+    if (NULL != self) {
+        return self->private_data;
+    } else {
+        return NULL;
+    }
+}
+
+
+/*
+ * Get address of private_workspace.
+ *
+ * An void* pointer is returned.
+ *
+ */
+void*
+MKLNdarray_WORKSPACE(const MKLNdarray *self) {
+    if (NULL != self) {
+        return self->private_workspace;
+    } else {
+        return NULL;
+    }
+}
+
+
+/*
+ * Get address of private_layout.
+ *
+ * An dnnLayout_t* pointer is returned.
+ *
+ */
+dnnLayout_t
+MKLNdarray_LAYOUT(const MKLNdarray *self) {
+    if (NULL != self) {
+        return self->private_layout;
+    } else {
+        return NULL;
+    }
+}
+
+
+/*
+ * Create private layout and buffer for a MKLNdarray according to input primitive.
+ *
+ * If res_type is dnnResourceWorkspace, private_workspace will be allocated for MKLNdarray.
+ *
+ */
+int MKLNdarray_create_buffer_from_primitive(MKLNdarray *self, const dnnPrimitive_t *prim, dnnResourceType_t res_type) {
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_create_buffer_from_primitive:\
+                        input MKLNdarray* self is NULL");
+        return -1;
+    }
+    if (self->nd < 0 || (MNDA_FLOAT32 != self->dtype && MNDA_FLOAT64 != self->dtype)) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_create_buffer_from_primitive:\
+                        Can't create layout and buffer for an uninitialized MKLNdarray");
+        return -1;
+    }
+
+    if (NULL == prim) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_create_buffer_from_primitive:\
+                        Can't create layout and buffer with an empty primtive");
+        return -1;
+    }
+
+    int status = 0;
+    if (MNDA_FLOAT64 == self->dtype) {  // for float64
+        if (dnnResourceWorkspace == res_type) {
+            if (NULL != self->private_workspace || NULL != self->private_layout_ws) {
+                PyErr_SetString(PyExc_RuntimeError,
+                                "MKLNdarray_create_buffer_from_primitive: Can't create buffer for workspace repeatly");
+                return -1;
+            }
+
+            status = dnnLayoutCreateFromPrimitive_F64(&(self->private_layout_ws), *prim, res_type);
+            if (E_SUCCESS != status || NULL == self->private_layout_ws) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "MKLNdarray_create_buffer_from_primitive: Create layout for workspace failed: %d, line: %d",
+                             status, __LINE__);
+                return -1;
+            }
+
+            status = dnnAllocateBuffer_F64(&(self->private_workspace), self->private_layout_ws);
+            if (E_SUCCESS != status || NULL == self->private_workspace) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "MKLNdarray_create_buffer_from_primitive: Create buffer for workspace failed: %d, line: %d",
+                             status, __LINE__);
+                return -1;
+            }
+
+            self->workspace_size = dnnLayoutGetMemorySize_F64(self->private_layout_ws);
+
+        } else {
+            if (NULL != self->private_layout || NULL != self->private_data) {
+                PyErr_SetString(PyExc_RuntimeError,
+                                "MKLNdarray_create_buffer_from_primitive: Can't create layout or buffer for MKLNdarray repeatly");
+                return -1;
+            }
+
+            status = dnnLayoutCreateFromPrimitive_F64(&(self->private_layout), *prim, res_type);
+            if (E_SUCCESS != status || NULL == self->private_layout) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "MKLNdarray_create_buffer_from_primitive: Create private layout failed: %d, line: %d",
+                             status, __LINE__);
+                return -1;
+            }
+
+            status = dnnAllocateBuffer_F64(&(self->private_data), self->private_layout);
+            if (E_SUCCESS != status || NULL == self->private_data) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "MKLNdarray_create_buffer_from_primitive: Create private data failed: %d, line: %d",
+                             status, __LINE__);
+                return -1;
+            }
+            self->data_size = dnnLayoutGetMemorySize_F64(self->private_layout);
+        }
+    } else {  // for float32
+        if (dnnResourceWorkspace == res_type) {
+            if (NULL != self->private_workspace || NULL != self->private_layout_ws) {
+                PyErr_SetString(PyExc_RuntimeError,
+                                "MKLNdarray_create_buffer_from_primitive: Can't create buffer for workspace repeatly");
+                return -1;
+            }
+
+            status = dnnLayoutCreateFromPrimitive_F32(&(self->private_layout_ws), *prim, res_type);
+            if (E_SUCCESS != status || NULL == self->private_layout_ws) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "MKLNdarray_create_buffer_from_primitive: Create layout for workspace failed: %d, line: %d",
+                             status, __LINE__);
+                return -1;
+            }
+
+            status = dnnAllocateBuffer_F32(&(self->private_workspace), self->private_layout_ws);
+            if (E_SUCCESS != status || NULL == self->private_workspace) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "MKLNdarray_create_buffer_from_primitive: Create buffer for workspace failed: %d, line: %d",
+                             status, __LINE__);
+                return -1;
+            }
+
+            self->workspace_size = dnnLayoutGetMemorySize_F32(self->private_layout_ws);
+
+        } else {
+            if (NULL != self->private_layout || NULL != self->private_data) {
+                PyErr_SetString(PyExc_RuntimeError,
+                                "MKLNdarray_create_buffer_from_primitive: Can't create layout or buffer for MKLNdarray repeatly");
+                return -1;
+            }
+
+            status = dnnLayoutCreateFromPrimitive_F32(&(self->private_layout), *prim, res_type);
+            if (E_SUCCESS != status || NULL == self->private_layout) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "MKLNdarray_create_buffer_from_primitive: Create private layout failed: %d, line: %d",
+                             status, __LINE__);
+                return -1;
+            }
+
+            status = dnnAllocateBuffer_F32(&(self->private_data), self->private_layout);
+            if (E_SUCCESS != status || NULL == self->private_data) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "MKLNdarray_create_buffer_from_primitive: Create private data failed: %d, line: %d",
+                             status, __LINE__);
+                return -1;
+            }
+            self->data_size = dnnLayoutGetMemorySize_F32(self->private_layout);
+        }
+    }
+    return 0;
+}
+
+
+/*
+ * In this function a plain layout is created for self according to user_structure.
+ *
+ * A private_data buffer is allocated for self according to the plain layout.
+ *
+ */
+int MKLNdarray_create_buffer_from_structure(MKLNdarray *self) {
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_create_buffer_from_structure: input MKLNdarray* self is NULL");
+        return -1;
+    }
+    if (self->nd <= 0) {
+        PyErr_Format(PyExc_RuntimeError,
+                     "MKLNdarray_create_buffer_from_structure:\
+                     Can't create mkl dnn layout and allocate buffer for a %d dimension MKLNdarray",
+                     self->nd);
+        return -1;
+    }
+
+    size_t ndim = self->nd;
+
+    if (self->private_layout || self->private_data) {
+        PyErr_Format(PyExc_RuntimeError,
+                     "MKLNdarray_create_buffer_from_structure:\
+                     MKL layout and buffer have been allocated for %p \n", self);
+        return -1;
+    }
+
+    size_t mkl_size[MNDA_MAX_NDIM] = {0};
+    size_t mkl_stride[MNDA_MAX_NDIM] = {0};
+
+    // nchw -> whcn
+    for (int i = 0; i < self->nd; i++) {
+        mkl_size[i] = (MKLNdarray_DIMS(self))[self->nd - i - 1];
+        mkl_stride[i] = (MKLNdarray_STRIDES(self))[self->nd - i -1];
+    }
+
+    // float64
+    if (MNDA_FLOAT64 == self->dtype) {
+        int status = dnnLayoutCreate_F64(&(self->private_layout),
+                                         ndim,
+                                         mkl_size,
+                                         mkl_stride);
+        if (E_SUCCESS != status || NULL == self->private_layout) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "MKLNdarray_create_buffer_from_structure: Call dnnLayoutCreate_F64 failed: %d",
+                         status);
+            return -1;
+        }
+
+        status = dnnAllocateBuffer_F64(&(self->private_data), self->private_layout);
+        if (E_SUCCESS != status || NULL == self->private_data) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "MKLNdarray_create_buffer_from_structure: Call dnnAllocateBuffer_F64 failed: %d",
+                         status);
+            return -1;
+        }
+        self->data_size = dnnLayoutGetMemorySize_F64(self->private_layout);
+
+    } else {  // float32
+        int status = dnnLayoutCreate_F32(&(self->private_layout),
+                                         ndim,
+                                         mkl_size,
+                                         mkl_stride);
+        if (E_SUCCESS != status || NULL == self->private_layout) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "MKLNdarray_create_buffer_from_structure: Call dnnLayoutCreate_F32 failed: %d",
+                         status);
+            return -1;
+        }
+
+        status = dnnAllocateBuffer_F32(&(self->private_data), self->private_layout);
+        if (E_SUCCESS != status || NULL == self->private_data) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "MKLNdarray_create_buffer_from_structure: Call dnnAllocateBuffer_F32 failed: %d",
+                         status);
+            return -1;
+        }
+        self->data_size = dnnLayoutGetMemorySize_F32(self->private_layout);
+    }
+
+    return 0;
+}
+
+
+/*
+ * Sometimes, we need to allocate private_data buffer for a MKLNdarray from its
+ * private_layout.
+ *
+ */
+int MKLNdarray_create_buffer_from_layout(MKLNdarray *self, int type) {
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_create_buffer_from_layout: input MKLNdarray* self is NULL");
+        return -1;
+    }
+
+    dnnLayout_t layout = NULL;
+    void** buffer = NULL;
+    size_t* data_size = NULL;
+
+    if (MNDA_DATA == type) {
+        layout = self->private_layout;
+        buffer = &(self->private_data);
+        data_size = &(self->data_size);
+
+    } else if (MNDA_WORKSPACE == type) {
+        layout = self->private_layout_ws;
+        buffer = &(self->private_workspace);
+        data_size = &(self->workspace_size);
+
+    } else {
+        PyErr_Format(PyExc_ValueError,
+                     "MKLNdarray_create_buffer_from_layout: input type (%d) is not spported",
+                     type);
+        return -1;
+    }
+
+    if (NULL == layout) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_create_buffer_from_layout: layout is NULL");
+        return -1;
+    }
+
+    if (NULL != (*buffer)) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_create_buffer_from_layout: buffer is already allocated");
+        return -1;
+    }
+
+    int status = 0;
+    if (MNDA_FLOAT64 == self->dtype) {
+        status = dnnAllocateBuffer_F64(buffer, layout);
+        if (E_SUCCESS != status || NULL == (*buffer)) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "MKLNdarray_create_buffer_from_layout: Call dnnAllocateBuffer_F64 failed: %d",
+                         status);
+            return -1;
+        }
+        (*data_size) = dnnLayoutGetMemorySize_F64(layout);
+    } else {  // float32
+        status = dnnAllocateBuffer_F32(buffer, layout);
+        if (E_SUCCESS != status || NULL == (*buffer)) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "MKLNdarray_create_buffer_from_layout: Call dnnAllocateBuffer_F32 failed: %d",
+                         status);
+            return -1;
+        }
+        (*data_size) = dnnLayoutGetMemorySize_F32(layout);
+    }
+    return 0;
+}
+
+
+/*
+ * If we want to create a MKLNdarray with a same private_layout from another
+ * MKLNdarray. We serialize the private_layout into a temporary buffer, and
+ * deserialize the buffer into a new layout.
+ *
+ * Copy layout from other to self.
+ *
+ * type: MNDA_DATA: copy private_layout
+ *       MNDA_WORKSPACE: copy private_layout_ws
+ *
+ */
+int MKLNdarray_copy_layout(MKLNdarray *self, MKLNdarray *other, int type) {
+    if (NULL == self || NULL == other) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_copy_layout: input MKLNdarray* self or other is NULL");
+        return -1;
+    }
+
+    if (self == other) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_copy_layout: source is same with destination");
+        return -1;
+    }
+
+    assert (self->nd == other->nd);
+    assert (self->dtype == other->dtype);
+
+    dnnLayout_t* src_layout = NULL;
+    dnnLayout_t* dst_layout = NULL;
+
+    if (MNDA_DATA == type) {
+        assert (NULL != other->private_layout);
+
+        src_layout = &(other->private_layout);
+        dst_layout = &(self->private_layout);
+
+        if (self->private_layout) {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "MKLNdarray_copy_layout: layout is already exsited");
+            return -1;
+        }
+
+    } else if (MNDA_WORKSPACE == type) {
+        assert (NULL != other->private_layout_ws);
+
+        src_layout = &(other->private_layout_ws);
+        dst_layout = &(self->private_layout_ws);
+
+        if (self->private_layout_ws) {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "MKLNdarray_copy_layout: layout is already exsited");
+            return -1;
+        }
+
+    } else {
+        PyErr_Format(PyExc_ValueError,
+                     "MKLNdarray_copy_layout: input type (%d) is not supported",
+                     type);
+        return -1;
+    }
+
+    int status = 0;
+    void* layout_buf = NULL;
+    if (MNDA_FLOAT64 == self->dtype) {
+        layout_buf = (void*)malloc(dnnLayoutSerializationBufferSize_F64());
+        if (NULL == layout_buf) {
+            PyErr_SetString(PyExc_MemoryError,
+                            "MKLNdarray_copy_layout: alloc buffer for layout failed");
+            return -1;
+        }
+
+        status = dnnLayoutSerialize_F64(*src_layout, layout_buf);
+        if (E_SUCCESS != status) {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "MKLNdarray_copy_layout: serialize layout failed");
+
+            if (layout_buf) {
+                free (layout_buf);
+                layout_buf = NULL;
+            }
+            return -1;
+        }
+
+        status = dnnLayoutDeserialize_F64(dst_layout, layout_buf);
+        if (E_SUCCESS != status) {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "MKLNdarray_copy_layout: deserialize layout failed");
+
+            if (layout_buf) {
+                free (layout_buf);
+                layout_buf = NULL;
+            }
+            return -1;
+        }
+    } else {  // MNDA_FLOAT32
+        layout_buf = (void*)malloc(dnnLayoutSerializationBufferSize_F32());
+        if (NULL == layout_buf) {
+            PyErr_SetString(PyExc_MemoryError,
+                            "MKLNdarray_copy_layout: alloc buffer for layout failed");
+            return -1;
+        }
+
+        status = dnnLayoutSerialize_F32(*src_layout, layout_buf);
+        if (E_SUCCESS != status) {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "MKLNdarray_copy_layout: serialize layout failed");
+
+            if (layout_buf) {
+                free (layout_buf);
+                layout_buf = NULL;
+            }
+            return -1;
+        }
+
+        status = dnnLayoutDeserialize_F32(dst_layout, layout_buf);
+        if (E_SUCCESS != status) {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "MKLNdarray_copy_layout: deserialize layout failed");
+
+            if (layout_buf) {
+                free (layout_buf);
+                layout_buf = NULL;
+            }
+            return -1;
+        }
+    }
+
+    if (layout_buf) {
+        free (layout_buf);
+        layout_buf = NULL;
+    }
+    return 0;
+}
+
+
+/*
+ * Set user_structure for self.
+ *
+ * nd: number of dimension. nd should <= MNDA_MAX_NDIM (16).
+ *
+ * dims: dimension info
+ *
+ */
+int MKLNdarray_set_structure(MKLNdarray *self, int nd, const size_t *dims) {
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_set_structure: input MKLNdarray* self is NULL");
+        return -1;
+    }
+
+    if (NULL == dims) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_set_structure: input dims is NULL");
+        return -1;
+    }
+
+    if (nd > MNDA_MAX_NDIM) {
+        PyErr_Format(PyExc_ValueError,
+                     "MKLNdarray does not support a %d-dim array. Try array which ndim is <= %d",
+                     nd, MNDA_MAX_NDIM);
+        return -1;
+    }
+
+    self->user_structure[0] = dims[0];
+    self->user_structure[2 * nd - 1] = 1;
+    for (int i = 1; i < nd; i++) {
+        // nchw
+        self->user_structure[i] = dims[i];
+        // chw, hw, w, 1
+        self->user_structure[2 * nd - 1 - i] = self->user_structure[2 * nd - i] * dims[nd - i];
+    }
+
+    return 0;
+}
+
+
+/*
+ * Copy/construct a plain MKLNdarray with dada/structure from a PyArrayObject.
+ *
+ * Check the dtype and ndim of PyArrayObject: float32 or float64; ndim <= 16.
+ *
+ */
+int MKLNdarray_CopyFromArray(MKLNdarray *self, PyArrayObject *obj) {
+    if (NULL == self || NULL == obj) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_CopyFromArray: input self or obj is NULL");
+        return -1;
+    }
+
+    int ndim = PyArray_NDIM(obj);
+    npy_intp* d = PyArray_DIMS(obj);
+    int typenum = PyArray_TYPE(obj);
+
+    if (NPY_FLOAT32 != typenum && NPY_FLOAT64 != typenum) {
+        PyErr_SetString(PyExc_TypeError,
+                        "MKLNdarray_CopyFromArray: can only copy from float/double arrays");
+        return -1;
+    }
+
+    if (ndim < 0 || ndim > MNDA_MAX_NDIM) {
+        PyErr_Format(PyExc_ValueError,
+                     "MKLNdarray does not support a %d-dim array. Try array which ndim is <= %d",
+                     ndim, MNDA_MAX_NDIM);
+        return -1;
+    }
+
+    self->dtype = typenum;
+    self->nd = ndim;
+
+    PyArrayObject* py_src = (PyArrayObject*)PyArray_ContiguousFromAny((PyObject*)obj, typenum, self->nd, self->nd);
+    if (!py_src) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_CopyFromArray: fail to cast obj to contiguous array");
+        return -1;
+    }
+
+    size_t dims[MNDA_MAX_NDIM] = {0};
+    size_t user_size = 1;
+
+    for (int i = 0; i < ndim; i++) {
+        dims[i] = (size_t)d[i];
+        user_size *= dims[i];
+    }
+
+    int err = MKLNdarray_set_structure(self, ndim, dims);
+    if (err < 0) {
+        Py_DECREF(py_src);
+        return err;
+    }
+
+    // prepare user layout and mkl buffer
+    err = MKLNdarray_create_buffer_from_structure(self);
+    if (err < 0) {
+        Py_DECREF(py_src);
+        return err;
+    }
+
+    // copy data to mkl buffer
+    size_t element_size = (size_t)PyArray_ITEMSIZE(py_src);
+    memcpy((void*)self->private_data, (void*)PyArray_DATA(py_src), user_size * element_size);
+    Py_DECREF(py_src);
+    return 0;
+}
+
+
+/*
+ * Create a MKLNdarray object according to input dims and typenum.
+ *
+ * Set all elements to zero.
+ *
+ * n: number of dimension
+ * dims: dimension info
+ *
+ */
+PyObject* MKLNdarray_create_with_zeros(int n, const size_t *dims, int typenum) {
+    size_t total_elements = 1;
+    if (n < 0 || n > MNDA_MAX_NDIM) {
+        PyErr_Format(PyExc_ValueError,
+                     "MKLNdarray does not support a %d-dim array. Try array which ndim is <= %d",
+                     n, MNDA_MAX_NDIM);
+        return NULL;
+    }
+
+    if (NULL == dims) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_create_with_zeros: input dims is NULL");
+        return NULL;
+    }
+
+    for (int i = 0; i < n; i++) {
+        if (dims[i] != 0 && total_elements > (SIZE_MAX / dims[i])) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "Can't store in size_t for the bytes requested %llu * %llu",
+                         (unsigned long long)total_elements,
+                         (unsigned long long)dims[i]);
+            return NULL;
+        }
+        total_elements *= dims[i];
+    }
+
+    // total_elements now contains the size of the array
+    size_t max = 0;
+    if (MNDA_FLOAT64 == typenum)
+        max = SIZE_MAX / sizeof (double);
+    else
+        max = SIZE_MAX / sizeof (float);
+
+    if (total_elements > max) {
+        PyErr_Format(PyExc_RuntimeError,
+                     "Can't store in size_t for the bytes requested %llu",
+                     (unsigned long long)total_elements);
+        return NULL;
+    }
+
+    size_t total_size = 0;
+    if (MNDA_FLOAT64 == typenum)
+        total_size = total_elements * sizeof (double);
+    else
+        total_size = total_elements * sizeof (float);
+
+    MKLNdarray* rval = (MKLNdarray*)MKLNdarray_New(n, typenum);
+    if (!rval) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_create_with_zeros: call to New failed");
+        return NULL;
+    }
+
+    if (MKLNdarray_set_structure(rval, n, dims)) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_create_with_zeros: syncing structure to mkl failed.");
+        Py_DECREF(rval);
+        return NULL;
+    }
+
+    if (MKLNdarray_create_buffer_from_structure(rval)) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarrya_create_with_zeros: create buffer from structure failed.");
+        Py_DECREF(rval);
+        return NULL;
+    }
+    // Fill with zeros
+    memset(rval->private_data, 0, rval->data_size);
+    return (PyObject*)rval;
+}
+
+
+/*
+ * Get shape info of a MKLNdarray instance.
+ *
+ * Register in MKLNdarray_getset
+ *
+ * Return a tuple contains dimension info.
+ */
+static PyObject*
+MKLNdarray_get_shape(MKLNdarray *self, void *closure) {
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_get_shape: input MKLNdarray* self is NULL");
+        return NULL;
+    }
+
+    if (self->nd < 0 || self->dtype < 0) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_get_shape: MKLNdarray not initialized");
+        return NULL;
+    }
+
+    PyObject* rval = PyTuple_New(self->nd);
+    if (NULL == rval) {
+        return NULL;
+    }
+
+    for (int i = 0; i < self->nd; i++) {
+        if (PyTuple_SetItem(rval, i, PyInt_FromLong(MKLNdarray_DIMS(self)[i]))) {
+            Py_XDECREF(rval);
+            return NULL;
+        }
+    }
+
+    return rval;
+}
+
+
+/*
+ * Get dtype info of a MKLNdarray instance.
+ *
+ * Register in MKLNdarray_getset
+ *
+ * Return a string: 'float32' or 'float64'.
+ *
+ */
+static PyObject*
+MKLNdarray_get_dtype(MKLNdarray *self, void *closure) {
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_get_dtype: input MKLNdarray* self is NULL");
+        return NULL;
+    }
+
+    if (self->nd < 0 || self->dtype < 0) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_get_dtype: MKLNdarray not initialized");
+        return NULL;
+    }
+
+    PyObject * rval = PyString_FromFormat("%s", MNDA_TYPE[self->dtype]);
+    return rval;
+}
+
+
+/*
+ * Get ndim info of a MKLNdarray instance.
+ *
+ * Register in MKLNdarray_getset
+ *
+ * Return a integer number. If self is not initialized, -1 will be returned.
+ *
+ */
+static PyObject*
+MKLNdarray_get_ndim(MKLNdarray *self, void *closure) {
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_get_ndim: input MKLNdarray* self is NULL");
+        return NULL;
+    } else {
+        return PyInt_FromLong(self->nd);
+    }
+}
+
+
+/*
+ * Get size info of a MKLNdarray instance.
+ *
+ * Register in MKLNdarray_getset
+ *
+ * Return a integer number.
+ *
+ */
+static PyObject*
+MKLNdarray_get_size(MKLNdarray *self, void *closure) {
+    size_t total_element = 1;
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_get_size: input MKLNdarray* self is NULL");
+        return NULL;
+    }
+
+    if (self->nd <= 0) {
+        total_element = 0;
+    } else {
+        for (int i = 0; i < self->nd; i++) {
+            total_element *= MKLNdarray_DIMS(self)[i];
+        }
+    }
+    return PyInt_FromLong(total_element);
+}
+
+
+/*
+ * Get base info of a MKLNdarray instance.
+ *
+ * Register in MKLNdarray_getset
+ *
+ * Return a PyObject.
+ *
+ */
+static PyObject*
+MKLNdarray_get_base(MKLNdarray *self, void *closure) {
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_get_base: input MKLNdarray* self is NULL");
+        return NULL;
+    }
+
+    PyObject * base = self->base;
+    if (!base) {
+        base = Py_None;
+    }
+
+    Py_INCREF(base);
+    return base;
+}
+
+
+/*
+ * Create a PyArrayObject from a MKLNdarray.
+ */
+PyObject* MKLNdarray_CreateArrayObj(MKLNdarray *self) {
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_CreateArrayObj: input MKLNdarray* self is NULL");
+        return NULL;
+    }
+
+    if (self->nd < 0 ||
+        NULL == self->private_data ||
+        NULL == self->private_layout) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_CreateArrayObj: Can't convert from an uninitialized MKLNdarray");
+        return NULL;
+    }
+
+    npy_intp npydims[MNDA_MAX_NDIM] = {0};
+    for (int i = 0; i < self->nd; i++) {
+        npydims[i] = (npy_intp)(MKLNdarray_DIMS(self)[i]);
+    }
+
+    PyArrayObject* rval = NULL;
+    if (MNDA_FLOAT64 == self->dtype) {
+        // float64
+        rval = (PyArrayObject*)PyArray_SimpleNew(self->nd, npydims, NPY_FLOAT64);
+    } else {
+        // float32
+        rval = (PyArrayObject*)PyArray_SimpleNew(self->nd, npydims, NPY_FLOAT32);
+    }
+
+    if (!rval) {
+        return NULL;
+    }
+
+    void* rval_data = PyArray_DATA(rval);
+    dnnLayout_t layout_user = NULL;
+    int status = -1;
+    dnnPrimitive_t primitive = NULL;
+
+    size_t mkl_size[MNDA_MAX_NDIM] = {0};
+    size_t mkl_stride[MNDA_MAX_NDIM] = {0};
+
+    // nchw -> whcn
+    for (int i = 0; i < self->nd; i++) {
+        mkl_size[i] = (MKLNdarray_DIMS(self))[self->nd - i - 1];
+        mkl_stride[i] = (MKLNdarray_STRIDES(self))[self->nd - i -1];
+    }
+
+    if (MNDA_FLOAT64 == self->dtype) { // float64
+        status = dnnLayoutCreate_F64(&layout_user,
+                                     self->nd,
+                                     mkl_size,
+                                     mkl_stride);
+
+        if (E_SUCCESS != status || NULL == layout_user) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "MKLNdarray_CreateArrayObj: dnnLayoutCreate_F64 failed: %d, line: %d",
+                         status, __LINE__);
+            Py_DECREF(rval);
+            return NULL;
+        }
+
+        if (!dnnLayoutCompare_F64(self->private_layout, layout_user)) {
+            status = dnnConversionCreate_F64(&primitive, self->private_layout, layout_user);
+            if (E_SUCCESS != status || NULL == primitive) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "MKLNdarray_CreateArrayObj: dnnConversionCreate_F64 failed: %d, line: %d",
+                             status, __LINE__);
+                Py_DECREF(rval);
+                if (NULL != layout_user) {
+                    dnnLayoutDelete_F64(layout_user);
+                    layout_user = NULL;
+                }
+                return NULL;
+            }
+
+            status = dnnConversionExecute_F64(primitive, (void*)self->private_data, (void*)rval_data);
+            if (E_SUCCESS != status) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "MKLNdarray_CreateArrayObj: dnnConversionExecute_F64 failed: %d, line: %d",
+                             status, __LINE__);
+                Py_DECREF(rval);
+                if (NULL != layout_user) {
+                    dnnLayoutDelete_F64(layout_user);
+                    layout_user = NULL;
+                }
+                if (NULL != primitive) {
+                    dnnDelete_F64(primitive);
+                    primitive = NULL;
+                }
+                return NULL;
+            }
+        } else {
+            memcpy((void*)rval_data, (void*)self->private_data, PyArray_SIZE(rval) * sizeof (double));
+        }
+
+        if (NULL != layout_user) {
+            dnnLayoutDelete_F64(layout_user);
+            layout_user = NULL;
+        }
+        if (NULL != primitive) {
+            dnnDelete_F64(primitive);
+            primitive = NULL;
+        }
+
+    } else {  // float32
+        status = dnnLayoutCreate_F32(&layout_user,
+                                     self->nd,
+                                     mkl_size,
+                                     mkl_stride);
+
+        if (E_SUCCESS != status || NULL == layout_user) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "MKLNdarray_CreateArrayObj: dnnLayoutCreate_F32 failed: %d, line: %d",
+                         status, __LINE__);
+            Py_DECREF(rval);
+            return NULL;
+        }
+
+        if (!dnnLayoutCompare_F32(self->private_layout, layout_user)) {
+            status = dnnConversionCreate_F32(&primitive, self->private_layout, layout_user);
+            if (E_SUCCESS != status || NULL == primitive) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "MKLNdarray_CreateArrayObj: dnnConversionCreate_F32 failed: %d, line: %d",
+                             status, __LINE__);
+                Py_DECREF(rval);
+                if (NULL != layout_user) {
+                    dnnLayoutDelete_F32(layout_user);
+                    layout_user = NULL;
+                }
+                return NULL;
+            }
+
+            status = dnnConversionExecute_F32(primitive, (void*)self->private_data, (void*)rval_data);
+            if (E_SUCCESS != status) {
+                PyErr_Format(PyExc_RuntimeError,
+                             "MKLNdarray_CreateArrayObj: dnnConversionExecute_F32 failed: %d, line: %d",
+                             status, __LINE__);
+                Py_DECREF(rval);
+                if (NULL != layout_user) {
+                    dnnLayoutDelete_F32(layout_user);
+                    layout_user = NULL;
+                }
+                if (NULL != primitive) {
+                    dnnDelete_F32(primitive);
+                    primitive = NULL;
+                }
+                return NULL;
+            }
+        } else {
+            memcpy((void*)rval_data, (void*)self->private_data, PyArray_SIZE(rval) * sizeof (float));
+        }
+
+        if (NULL != layout_user) {
+            dnnLayoutDelete_F32(layout_user);
+            layout_user = NULL;
+        }
+        if (NULL != primitive) {
+            dnnDelete_F32(primitive);
+            primitive = NULL;
+        }
+    }
+
+    return (PyObject*)rval;
+}
+
+
+/*
+ * Create a new MKLNdarray instance and set all elements to zero.
+ * This function will be called when do MKLNdarray.zeros(shape, typenum) in python code.
+ *
+ * shape: a tuple contains shape info. length of shape should <= MNDA_MAX_NDIM
+ * typenum: MNDA_FLOAT32, MNDA_FLOAT64. MNDA_FLOAT32 by default.
+ *
+ * This function will call MKLNdarray_create_with_zeros to do detailed processing.
+ *
+ */
+PyObject* MKLNdarray_Zeros(PyObject *_unused, PyObject *args) {
+    if (!args) {
+        PyErr_SetString(PyExc_TypeError, "MKLNdarray_Zeros: function takes at least 1 argument");
+        return NULL;
+    }
+
+    PyObject* shape = NULL;
+    int typenum = -1;
+
+    if (!PyArg_ParseTuple(args, "Oi", &shape, &typenum)) {
+        PyErr_SetString(PyExc_RuntimeError, "MKLNdarray_Zeros: PyArg_ParseTuple failed \n");
+        return NULL;
+    }
+
+    if ((MNDA_FLOAT32 != typenum) && (MNDA_FLOAT64 != typenum)) {
+        typenum = MNDA_FLOAT32;
+    }
+
+    if (!PySequence_Check(shape)) {
+        PyErr_SetString(PyExc_TypeError, "shape argument must be a sequence");
+        return NULL;
+    }
+
+    int shplen = PySequence_Length(shape);
+    if (shplen <= 0 || shplen > MNDA_MAX_NDIM) {
+        PyErr_Format(PyExc_TypeError, "length of shape argument must be 1 ~ %d",
+                     MNDA_MAX_NDIM);
+        return NULL;
+    }
+
+    size_t newdims[MNDA_MAX_NDIM] = {0};
+    for (int i = shplen -1; i >= 0; i--) {
+        PyObject* shp_el_obj = PySequence_GetItem(shape, i);
+        if (NULL == shp_el_obj) {
+            PyErr_SetString(PyExc_RuntimeError, "MKLNdarray_Zeros: index out of bound in sequence");
+            return NULL;
+        }
+
+        int shp_el = PyInt_AsLong(shp_el_obj);
+        Py_DECREF(shp_el_obj);
+
+        if (shp_el < 0) {
+            PyErr_SetString(PyExc_ValueError,
+                            "MKLNdarray_Zeros: shape must contain only non-negative values for size of a dimension");
+            return NULL;
+        }
+        newdims[i] = (size_t)shp_el;
+    }
+
+    PyObject* rval = MKLNdarray_create_with_zeros(shplen, newdims, typenum);
+    return (PyObject*)rval;
+}
+
+
+size_t MKLNdarray_get_memory_size(const MKLNdarray* self, int type)
+{
+    if (!self) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "MKLNdarray_get_memory_size: input is NULL");
+        return 0;
+    }
+
+    if ((MNDA_DATA != type) && (MNDA_WORKSPACE != type)) {
+        PyErr_Format(PyExc_ValueError,
+                     "MKLNdarray_get_memory_size: input type (%d) is not support",
+                     type);
+        return 0;
+    }
+
+    size_t data_size = 0;
+    const dnnLayout_t* layout = NULL;
+    if (MNDA_DATA == type) {
+        if (NULL != self->private_layout) {
+            layout = &(self->private_layout);
+        }
+        else
+            return 0;
+    } else {
+        if (NULL != self->private_layout_ws) {
+            layout = &(self->private_layout_ws);
+        }
+        else
+            return 0;
+    }
+
+    if (MNDA_FLOAT64 == self->dtype) {
+        data_size = dnnLayoutGetMemorySize_F64(*layout);
+    } else {
+        data_size = dnnLayoutGetMemorySize_F32(*layout);
+    }
+
+    return data_size;
+}
+
+
+/*
+ * Create a view for input MKLNdarray.
+ *
+ * The view has same nd/dtype/user_structure with input MKLNdarray.
+ *
+ * The view's layout and data buffer are pointed to those of input.
+ *
+ */
+MKLNdarray* MKLNdarray_View(const MKLNdarray *self) {
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError, "MKLNdarray_View: input is NULL");
+        return NULL;
+    }
+
+    MKLNdarray *rval = (MKLNdarray*)MKLNdarray_New(self->nd, self->dtype);
+    if (!rval) {
+        rval = NULL;
+    } else {
+        int ret = MKLNdarray_set_structure(rval, self->nd, MKLNdarray_DIMS(self));
+        if (0 != ret) {
+            Py_DECREF(rval);
+            rval = NULL;
+        } else {
+            rval->data_size = 0;
+            rval->workspace_size = 0;
+
+            PyObject *orig_base = (PyObject*)self;
+            while (orig_base &&
+                   MKLNdarray_Check(orig_base) &&
+                   ((MKLNdarray*)orig_base)->base) {
+                orig_base = ((MKLNdarray*)orig_base)->base;
+            }
+
+            rval->base              = orig_base;
+            rval->private_layout    = ((MKLNdarray*)orig_base)->private_layout;
+            rval->private_data      = ((MKLNdarray*)orig_base)->private_data;
+            rval->private_layout_ws = ((MKLNdarray*)orig_base)->private_layout_ws;
+            rval->private_workspace = ((MKLNdarray*)orig_base)->private_workspace;
+            Py_INCREF(orig_base);
+        }
+    }
+    return (MKLNdarray*)rval;
+}
+
+
+/*
+ * This function creates a new MKLNdarray with same nd/dtype/user_structure with
+ * input MKLNdarray, and copies layout and data buffer from input MKLndarray to
+ * the new MKLNdarray.
+ */
+MKLNdarray * MKLNdarray_Copy(MKLNdarray *self) {
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError, "MKLNdarray_Copy: input is NULL");
+        return NULL;
+    }
+
+    MKLNdarray *rval = (MKLNdarray*)MKLNdarray_New(self->nd, self->dtype);
+    if (!rval || (-1 == self->nd)) {
+        PyErr_SetString(PyExc_RuntimeError,
+                "MKLNdarray_Copy: fail to new MKLNdarray");
+
+        Py_XDECREF(rval);
+        return NULL;
+    }
+
+    int ret = MKLNdarray_set_structure(rval, self->nd, MKLNdarray_DIMS(self));
+    if (ret) {
+        Py_DECREF(rval);
+        return NULL;
+    }
+
+    assert (self->nd == rval->nd);
+
+    if (self->private_layout) {
+        ret = MKLNdarray_copy_layout(rval, self, MNDA_DATA);
+        if (ret) {
+            Py_DECREF(rval);
+            return NULL;
+        }
+    }
+
+    size_t data_size = 0;
+    if (rval->private_layout && self->private_data) {
+        ret = MKLNdarray_create_buffer_from_layout(rval, MNDA_DATA);
+        if (ret) {
+            Py_DECREF(rval);
+            return NULL;
+        }
+        data_size = MKLNdarray_get_memory_size(rval, MNDA_DATA);
+        memcpy(rval->private_data, self->private_data, data_size);
+    }
+
+    if (self->private_layout_ws) {
+        ret = MKLNdarray_copy_layout(rval, self, MNDA_WORKSPACE);
+        if (ret) {
+            Py_DECREF(rval);
+            return NULL;
+        }
+    }
+
+    if (rval->private_layout_ws && self->private_workspace) {
+        ret = MKLNdarray_create_buffer_from_layout(rval, MNDA_WORKSPACE);
+        if (ret) {
+            Py_DECREF(rval);
+            return NULL;
+        }
+        data_size = MKLNdarray_get_memory_size(rval, MNDA_WORKSPACE);
+        memcpy (rval->private_workspace, self->private_workspace, data_size);
+    }
+
+    return rval;
+}
+
+
+PyObject * MKLNdarray_DeepCopy(MKLNdarray *self, PyObject *memo) {
+    assert (PyDict_Check(memo));
+    PyObject *selfkey = PyInt_FromLong((long)self);
+
+    assert (selfkey);
+
+    if (PyDict_Contains(memo, selfkey)) {
+        PyObject *rval = PyDict_GetItem(memo, selfkey);
+        Py_DECREF(selfkey);
+        Py_XINCREF(rval);
+        return rval;
+    } else {
+        PyObject* rval = (PyObject*)MKLNdarray_Copy(self);
+        if (NULL == rval) {
+            Py_DECREF(selfkey);
+            return NULL;
+        }
+
+        if (PyDict_SetItem(memo, selfkey, rval)) {
+            Py_DECREF(rval);
+            Py_DECREF(selfkey);
+            return NULL;
+        }
+
+        Py_DECREF(selfkey);
+        return rval;
+    }
+}
+
+/*
+ * type:tp_methods
+ * Describe methos of a type. ml_name/ml_meth/ml_flags/ml_doc.
+ * ml_name: name of method
+ * ml_meth: PyCFunction, point to the C implementation
+ * ml_flags: indicate how the call should be constructed
+ * ml_doc: docstring
+ *
+ */
+static PyMethodDef MKLNdarray_methods[] = {
+    {"__array__",
+        (PyCFunction)MKLNdarray_CreateArrayObj, METH_VARARGS,
+        "Copy from MKL to a numpy ndarray."},
+
+    {"zeros",
+        (PyCFunction)MKLNdarray_Zeros, METH_STATIC | METH_VARARGS,
+        "Create a new MklNdarray with specified shape, filled ith zeros."},
+
+    {"__copy__",
+        (PyCFunction)MKLNdarray_View, METH_NOARGS,
+        "Create a shallow copy of this object. used by module copy"},
+
+    {"__deepcopy__",
+        (PyCFunction)MKLNdarray_DeepCopy, METH_O,
+        "Create a copy of this obejct"},
+
+    {"copy",
+        (PyCFunction)MKLNdarray_Copy, METH_NOARGS,
+        "Create a copy of this object"},
+
+    {"view",
+        (PyCFunction)MKLNdarray_View, METH_NOARGS,
+        "Return an alias of this ndarray"},
+
+    {NULL, NULL, 0, NULL}  /* Sentinel */
+};
+
+
+/* type:tp_members
+ * Describe attributes of a type. name/type/offset/flags/doc.
+ */
+static PyMemberDef MKLNdarray_members[] = {
+    {NULL}      /* Sentinel */
+};
+
+
+/*
+ * type:tp_getset
+ * get/set attribute of instances of this type. name/getter/setter/doc/closure
+ *
+ */
+static PyGetSetDef MKLNdarray_getset[] = {
+    {"shape",
+        (getter)MKLNdarray_get_shape,
+        NULL,
+        "shape of this ndarray (tuple)",
+        NULL},
+
+    {"dtype",
+        (getter)MKLNdarray_get_dtype,
+        NULL,
+        "the dtype of the element.",
+        NULL},
+
+    {"size",
+        (getter)MKLNdarray_get_size,
+        NULL,
+        "the number of elements in this object.",
+        NULL},
+
+    {"ndim",
+        (getter)MKLNdarray_get_ndim,
+        NULL,
+        "the number of dimensions in this objec.",
+        NULL},
+
+    {"base",
+        (getter)MKLNdarray_get_base,
+        NULL,
+        "if this ndarray is a view, base is the original ndarray.",
+        NULL},
+
+    {NULL, NULL, NULL, NULL}  /* Sentinel*/
+};
+
+
+/*
+ * type object.
+ * If you want to define a new object type, you need to create a new type object.
+ *
+ */
+static PyTypeObject MKLNdarrayType = {
+#if PY_MAJOR_VERSION >= 3
+    PyVarObject_HEAD_INIT(NULL, 0)
+#else
+    PyObject_HEAD_INIT(NULL)
+    0,                         /*ob_size*/
+#endif
+    "MKLNdarray",              /*tp_name*/
+    sizeof(MKLNdarray),        /*tp_basicsize*/
+    0,                         /*tp_itemsize*/
+    (destructor)MKLNdarray_dealloc, /*tp_dealloc*/
+    0,                         /*tp_print*/
+    0,                         /*tp_getattr*/
+    0,                         /*tp_setattr*/
+    0,                         /*tp_compare*/
+    MKLNdarray_repr,           /*tp_repr*/
+    0,                         /*tp_as_number*/
+    0,                         /*tp_as_sequence*/
+    0,                         /*tp_as_mapping*/
+    0,                         /*tp_hash */
+    0,                         /*tp_call*/
+    0,                         /*tp_str*/
+    0,                         /*tp_getattro*/
+    0,                         /*tp_setattro*/
+    0,                         /*tp_as_buffer*/
+#if PY_MAJOR_VERSION >= 3
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+#else
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_CHECKTYPES, /*tp_flags*/
+#endif
+    "MKLNdarray objects",      /*tp_doc */
+    0,                         /*tp_traverse*/
+    0,                         /*tp_clear*/
+    0,                         /*tp_richcompare*/
+    0,                         /*tp_weaklistoffset*/
+    0,                         /*tp_iter*/
+    0,                         /*tp_iternext*/
+    MKLNdarray_methods,        /*tp_methods*/
+    MKLNdarray_members,        /*tp_members*/
+    MKLNdarray_getset,         /*tp_getset*/
+    0,                         /*tp_base*/
+    0,                         /*tp_dict*/
+    0,                         /*tp_descr_get*/
+    0,                         /*tp_descr_set*/
+    0,                         /*tp_dictoffset*/
+    (initproc)MKLNdarray_init, /*tp_init*/
+    0,                         /*tp_alloc*/
+    MKLNdarray_new,            /*tp_new*/
+};
+
+
+/*
+ * Check an input is an instance of MKLNdarray or not.
+ * Same as PyArray_Check
+ *
+ */
+int MKLNdarray_Check(const PyObject *ob) {
+    return ((Py_TYPE(ob) == &MKLNdarrayType) ? 1 : 0);
+}
+
+
+/*
+ * Try to new a MKLNdarray instance.
+ * This function is different from MKLNdarray_new which is set for tp_new.
+ *
+ * MKLNdarray_new is call by python when python has allocate memory for it already.
+ * MKLNdarray_New will be called manually in C/C++ code, so we need to call tp_alloc manually.
+ *
+ */
+PyObject*
+MKLNdarray_New(int nd, int typenum) {
+    if (nd < 0 || nd > MNDA_MAX_NDIM) {
+        PyErr_Format(PyExc_ValueError,
+                     "MKLNdarray_New: not support a %d-dim array. Try array which ndim is <= %d. line: %d",
+                     nd, MNDA_MAX_NDIM, __LINE__);
+        return NULL;
+    }
+
+    MKLNdarray* self = (MKLNdarray*)(MKLNdarrayType.tp_alloc(&MKLNdarrayType, 0));
+    if (NULL == self) {
+        PyErr_SetString(PyExc_RuntimeError, "MKLNdarray_New: failed to allocate self");
+        return NULL;
+    }
+    self->base              = NULL;
+    self->nd                = nd;
+    self->dtype             = typenum;
+    self->private_data      = NULL;
+    self->private_workspace = NULL;
+    self->data_size         = 0;
+    self->workspace_size    = 0;
+    self->private_layout    = NULL;
+    self->private_layout_ws = NULL;
+    memset((void*)(self->user_structure), 0, 2 * MNDA_MAX_NDIM * sizeof (size_t));
+
+    return (PyObject*)self;
+}
+
+
+/*
+ * Declare methods belong to this module but not in MKLNdarray.
+ * Used in module initialization function.
+ *
+ * Users can access these methods by module.method_name() after they have imported this module.
+ *
+ */
+static PyMethodDef module_methods[] = {
+    {NULL, NULL, 0, NULL}   /* Sentinel */
+};
+
+
+#if PY_MAJOR_VERSION == 3
+static struct PyModuleDef mkl_ndarray_moduledef =
+{
+    PyModuleDef_HEAD_INIT,
+    "mkl_ndarray",
+    "MKL implementation of a numpy ndarray-like object.",
+    -1,
+    module_methods
+};
+
+PyMODINIT_FUNC
+PyInit_mkl_ndarray(void)
+#else
+PyMODINIT_FUNC
+initmkl_ndarray(void)
+#endif
+{
+    import_array();
+    PyObject* m = NULL;
+
+    if (PyType_Ready(&MKLNdarrayType) < 0) {
+#if PY_MAJOR_VERSION == 3
+        return NULL;
+#else
+        return;
+#endif
+    }
+
+    // add attribute to MKLNdarrayType
+    // if user has import MKLNdarrayType already, they can get typenum of float32 and float64
+    // by MKLNdarray.float32 or MKLNdarray.float64
+    PyDict_SetItemString(MKLNdarrayType.tp_dict, "float32", PyInt_FromLong(MNDA_FLOAT32));
+    PyDict_SetItemString(MKLNdarrayType.tp_dict, "float64", PyInt_FromLong(MNDA_FLOAT64));
+#if PY_MAJOR_VERSION == 3
+    m = PyModule_Create(&mkl_ndarray_moduledef);
+#else
+    m = Py_InitModule3("mkl_ndarray", module_methods, "MKL implementation of a numpy ndarray-like object.");
+#endif
+    if (NULL == m) {
+#if PY_MAJOR_VERSION == 3
+        return NULL;
+#else
+        return;
+#endif
+    }
+    Py_INCREF(&MKLNdarrayType);
+    PyModule_AddObject(m, "MKLNdarray", (PyObject*)&MKLNdarrayType);
+#if PY_MAJOR_VERSION == 3
+    return m;
+#else
+    return;
+#endif
+}

--- a/theano/contrib/mkl/mkl_ndarray.h
+++ b/theano/contrib/mkl/mkl_ndarray.h
@@ -1,0 +1,98 @@
+#ifndef _MKL_NDARRAY_H_
+#define _MKL_NDARRAY_H_
+
+#include <numpy/arrayobject.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "mkl_dnn.h"
+#include "theano_mod_helper.h"
+
+#ifndef SIZE_MAX
+#define SIZE_MAX ((size_t)(-1))
+#endif
+
+#ifndef Py_TYPE
+#define Py_TYPE(o) ((o)->ob_type)
+#endif
+
+// MNDA stands for MklNDArray
+#define MNDA_MAX_NDIM   (16)
+#define MNDA_DATA       (0)
+#define MNDA_WORKSPACE  (1)
+#define MNDA_FLOAT32    (11)
+#define MNDA_FLOAT64    (12)
+
+// Placeholder for dtype name. Only support FP32 and FP64 currently.
+// Other types will be supported in future.
+char* MNDA_TYPE[] = {"", "", "", "", "", "", "", "",
+                     "", "", "", "float32", "float64", ""};
+
+#if PY_MAJOR_VERSION >= 3
+// Py3k treats all ints as longs. This one is not caught by npy_3kcompat.h.
+#define PyNumber_Int PyNumber_Long
+
+#include "numpy/npy_3kcompat.h"
+
+// Py3k strings are unicode, these mimic old functionality.
+//
+// NOTE: npy_3kcompat.h replaces PyString_X with PyBytes_X, which breaks
+// compatibility with some functions returning text.
+#define PyString_Check PyUnicode_Check
+#define PyString_FromString PyUnicode_FromString
+#define PyString_AsString PyUnicode_AsUTF8
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#define PyString_Size PyUnicode_GET_SIZE
+#define PyInt_FromSize_t PyLong_FromSize_t
+
+// Python 3 expects a PyObject* as the first argument to PySlice_GetIndicesEx().
+#define SLICE_CAST(x) (x)
+#else
+// Python 2 expects a PySliceObject* as the first argument to PySlice_GetIndicesEx().
+#define SLICE_CAST(x) ((PySliceObject*)(x))
+#endif // end #if PY_MAJOR_VERSION >= 3
+
+
+/**
+ * MKLNdarray: wrapper for MKL private data and layout
+ * This is a Python type.
+ */
+typedef struct __MKLNdarray__{
+
+    PyObject_HEAD
+    PyObject * base;        // reference for private_layout/data/workspace
+
+    /* Type-specific fields go here. */
+    int         nd;                                 // the number of dimensions of the tensor, maximum is 16 (MNDA_MAX_NDIM).
+    int         dtype;                              // an integer type number is given here.
+    size_t      data_size;                          // the number of bytes allocated for private_data
+    size_t      workspace_size;                     // the number of bytes allocated for private_workspace
+    size_t      user_structure[2 * MNDA_MAX_NDIM];  // user layout: [size0, size1, ..., stride0, stride1, ..., 0, 0].
+    dnnLayout_t private_layout;                     // layout instance create by MKL APIs
+    void*       private_data;                       // data buffer
+    dnnLayout_t private_layout_ws;                  // layout for workspace
+    void*       private_workspace;                  // computation workspace for forward and backward
+}MKLNdarray;
+
+
+MOD_PUBLIC int MKLNdarray_Check(const PyObject* ob);
+MOD_PUBLIC PyObject* MKLNdarray_New(int nd, int typenum);
+MOD_PUBLIC int MKLNdarray_CopyFromArray(MKLNdarray* self, PyArrayObject* obj);
+MOD_PUBLIC int MKLNdarray_set_structure(MKLNdarray* self, int nd, const size_t* dims);
+MOD_PUBLIC PyObject* MKLNdarray_CreateArrayObj(MKLNdarray* self);
+
+MOD_PUBLIC void* MKLNdarray_DATA(const MKLNdarray* self);
+MOD_PUBLIC void* MKLNdarray_WORKSPACE(const MKLNdarray* self);
+MOD_PUBLIC dnnLayout_t MKLNdarray_LAYOUT(const MKLNdarray* self);
+MOD_PUBLIC const size_t* MKLNdarray_DIMS(const MKLNdarray* self);
+MOD_PUBLIC const size_t* MKLNdarray_STRIDES(const MKLNdarray* self);
+MOD_PUBLIC int MKLNdarray_NDIM(const MKLNdarray* self);
+MOD_PUBLIC int MKLNdarray_TYPE(const MKLNdarray* self);
+
+MOD_PUBLIC int MKLNdarray_create_buffer_from_primitive(MKLNdarray *self,
+                                                       const dnnPrimitive_t *prim,
+                                                       dnnResourceType_t res_type);
+MOD_PUBLIC int MKLNdarray_copy_layout(MKLNdarray *self, MKLNdarray *other, int type);
+MOD_PUBLIC int MKLNdarray_create_buffer_from_layout(MKLNdarray *self, int type);
+MOD_PUBLIC int MKLNdarray_create_buffer_from_structure(MKLNdarray *self);
+
+#endif

--- a/theano/contrib/mkl/mkl_type.py
+++ b/theano/contrib/mkl/mkl_type.py
@@ -1,0 +1,401 @@
+from __future__ import absolute_import, print_function, division
+import os
+import numpy
+from six import StringIO
+
+import theano
+from theano import Type, Variable, config, tensor
+from theano.tensor.var import _tensor_py_operators
+
+try:
+    import mkl_ndarray
+    import mkl_ndarray.mkl_ndarray as mkl
+
+    try:
+        mkl_ndarray.__file__
+    except AttributeError:
+        from theano.gof.cmodule import get_lib_extension
+        mkl_ndarray.__file__ = os.path.join(mkl_ndarray.__path__._path[0], 'mkl_ndarray.' + get_lib_extension())
+except ImportError:
+    mkl = None
+
+
+class _operators(_tensor_py_operators):
+    dtype = property(lambda s: s.type.dtype)
+    broadcastable = property(lambda s: s.type.broadcastable)
+    ndim = property(lambda s: s.type.ndim)
+
+
+class MKLNdarrayVariable(_operators, Variable):
+    """
+    See Also
+    --------
+    Variable
+
+    """
+    pass
+
+
+class MKLNdarrayType(Type):
+    """
+    The type that represents an array on CPU with MKL supoorts.
+
+    The `dtype` indicates what scalar data type the elements of
+    variables of this type will be.
+
+    The `broadcastable` indicates whether each dimension is broadcastable
+    or not (to be broadcastable a dimension must always be of length 1)
+
+    The `context_name` is the name of the context. For similar interface
+    with the new back-end for GPU.
+
+    `name` for the type that will be used in printouts.
+
+    """
+    Variable = MKLNdarrayVariable
+    Constant = None
+    SharedVariable = None
+    broadcastable = None
+
+    ndim = property(lambda self: len(self.broadcastable), doc='number of dimensions')
+
+    def __init__(self, dtype, broadcastable, name=None):
+        self.dtype = str(dtype)
+        if self.dtype == 'floatX':
+            self.dtype = config.floatX
+
+        if self.dtype not in ('float32', 'float64'):
+            raise TypeError('%s only supports float32/float64 for now.'
+                            'Tried using dtype %s for variable %s' %
+                            (self.__class__.__name__, dtype, name))
+
+        self.typenum = 11 if dtype is 'float32' else 12
+        self.broadcastable = tuple(bool(b) for b in broadcastable)
+        self.name = name
+        self.dtype_specs()
+
+    def clone(self, dtype=None, broadcastable=None):
+        if broadcastable is None:
+            broadcastable = self.broadcastable
+
+        if dtype is None:
+            dtype = self.dtype
+
+        return self.__class__(dtype=dtype, broadcastable=broadcastable, name=self.name)
+
+    def filter(self, data, strict=False, allow_downcast=None):
+        """
+        Since it is not support currently to cast layout from FP32 to FP64, we
+        don't do up or down cast in this function for now. It means that it is
+        always strict for all input data.
+
+        """
+        # TODO: we will add up and down cast code here when the low level APIs
+        # support that.
+        if not isinstance(data, mkl.MKLNdarray):
+            raise TypeError('%s expected a MKLNdarray object.' % self,
+                            data, type(data))
+
+        if data.dtype != self.dtype:
+            raise TypeError(('%s expected a MKLNdarray object with'
+                            'dtype=%s (got %s).') % (self, self.dtype, data.dtype))
+
+        if data.ndim != self.ndim:
+            raise TypeError('Wrong number of dimensions: expected %s,'
+                            'got %s with shape %s.' % (self.ndim, data.ndim, data.shape))
+
+        shp = data.shape
+        for i, b in enumerate(self.broadcastable):
+            if b and shp[i] != 1:
+                raise TypeError('None-unit value on shape on a broadcastable'
+                                ' dimension.', shp, self.broadcastable)
+
+        return data
+
+    def filter_variable(self, other, allow_convert=True):
+        raise NotImplementedError('MKLNdarrayType filter_variable')
+
+    @staticmethod
+    def values_eq(a, b):
+        return tensor.TensorType.values_eq(numpy.asarray(a), numpy.asarray(b))
+
+    @staticmethod
+    def values_eq_approx(a, b, allow_remove_inf=False, allow_remove_nan=False,
+                         rtol=None, atol=None):
+        return tensor.TensorType.values_eq_approx(
+            numpy.asarray(a),
+            numpy.asarray(b),
+            allow_remove_inf=allow_remove_inf,
+            allow_remove_nan=allow_remove_nan,
+            rtol=rtol, atol=atol
+        )
+
+    def dtype_specs(self):
+        """
+        Return a tuple (python type, c type, numpy typenum) that corresponds
+        to self.dtype.
+
+        This function is used internally as part of C code generation.
+
+        """
+        try:
+            return {'float32': (float, 'npy_float32', 'NPY_FLOAT32'),
+                    'float64': (float, 'npy_float64', 'NPY_FLOAT64'),
+                    'uint8': (int, 'npy_uint8', 'NPY_UINT8'),
+                    'int8': (int, 'npy_int8', 'NPY_INT8'),
+                    'uint16': (int, 'npy_uint16', 'NPY_UINT16'),
+                    'int16': (int, 'npy_int16', 'NPY_INT16'),
+                    'uint32': (int, 'npy_uint32', 'NPY_UINT32'),
+                    'int32': (int, 'npy_int32', 'NPY_INT32'),
+                    'uint64': (int, 'npy_uint64', 'NPY_UINT64'),
+                    'int64': (int, 'npy_int64', 'NPY_INT64'),
+                    'complex128': (complex, 'theano_complex128',
+                                   'NPY_COMPLEX128'),
+                    'complex64': (complex, 'theano_complex64',
+                                  'NPY_COMPLEX64')}[self.dtype]
+        except KeyError:
+            raise TypeError("Unsupported dtype for %s: %s" %
+                            (self.__class__.__name__, self.dtype))
+
+    def __eq__(self, other):
+        """
+        Compare True if other is the same kind of MKLNdarrayType.
+
+        """
+        return (type(self) == type(other) and
+                self.dtype == other.dtype and
+                self.broadcastable == other.broadcastable)
+
+    def __hash__(self):
+        """
+        Hash equal for same kinds of MKLNdarrayType.
+
+        """
+        return hash((type(self), self.dtype, self.broadcastable))
+
+    def make_variable(self, name=None):
+        """
+        Return a 'MKLNdarrayVariable' with this type.
+
+        Parameters
+        ----------
+        name: str
+            A pretty name to identify this 'Variable' when printing and
+            debugging.
+
+        """
+        return self.Variable(self, name=name)
+
+    def __str__(self):
+        if self.name:
+            return self.name
+        else:
+            b = self.broadcastable
+            named_broadcastable = {tuple(): 'scalar',
+                                   (False,): 'vector',
+                                   (False, True): 'col',
+                                   (True, False): 'row',
+                                   (False, False): 'matix'}
+            if b in named_broadcastable:
+                bcast = named_broadcastable[b]
+            elif any(b):
+                bcast = str(b)
+            else:
+                bcast = '%iD' % len(b)
+            return 'MKLNdarrayType(%s, %s)' % (self.dtype, bcast)
+
+    def __repr__(self):
+        return str(self)
+
+    def c_declare(self, name, sub, check_input=True):
+        """
+        Declare variables which will be used in C code.
+        """
+        return """
+        MKLNdarray * %(name)s;
+        """ % locals()
+
+    def c_init(self, name, sub):
+        """
+        Init variables declared in c_declare.
+        """
+        return """
+        %(name)s = NULL;
+        """ % locals()
+
+    def c_extract(self, name, sub, check_input=True):
+        sio = StringIO()
+        fail = sub['fail']
+        nd = self.ndim
+        print("""
+        assert (py_%(name)s->ob_refcnt >= 2);
+
+        if (py_%(name)s == Py_None) {
+            PyErr_SetString(PyExc_ValueError, "expected a MKLNdarray, not None");
+            %(fail)s
+        }
+
+        if (MKLNdarray_Check(py_%(name)s)) {
+            %(name)s = (MKLNdarray*)py_%(name)s;
+            assert (%(name)s);
+            Py_INCREF(%(name)s);
+        }
+        """ % locals(), file=sio)
+
+        return sio.getvalue()
+
+    def c_cleanup(self, name, sub):
+        """
+        Add cleanup code here.
+        """
+        return """
+        if (%(name)s) {
+            Py_XDECREF(%(name)s);
+            %(name)s = NULL;
+        }
+        """ % locals()
+
+    def c_sync(self, name, sub):
+        """
+        When the computations are done, transfer the variables from the C
+        structure we put them in to the destination Python object. This will
+        only be called for the outputs.
+        """
+        return """
+        if (NULL == %(name)s) {
+            Py_XDECREF(py_%(name)s);
+            py_%(name)s = Py_None;
+            Py_INCREF(py_%(name)s);
+        } else {
+            if (py_%(name)s != (PyObject*)%(name)s) {
+                Py_XDECREF(py_%(name)s);
+                py_%(name)s = (PyObject*)%(name)s;
+                Py_INCREF(py_%(name)s);
+            }
+            assert(py_%(name)s->ob_refcnt);
+        }
+        """ % locals()
+
+    def c_headers(self):
+        return ['mkl_ndarray.h']
+
+    def c_header_dirs(self):
+        ret = [os.path.dirname(mkl_ndarray.__file__), os.path.dirname(__file__)]
+        return ret
+
+    def c_lib_dirs(self):
+        ret = [os.path.dirname(mkl_ndarray.__file__)]
+        return ret
+
+    def c_libraries(self):
+        return ['mkl_ndarray']
+
+    def c_code_cache_version(self):
+        return (1, 0, 1)
+
+    def c_compile_args(self):
+        return ['-Wl,-R' + os.path.dirname(mkl_ndarray.__file__)]
+
+    def get_shape_info(self, obj):
+        return obj.shape
+
+    def get_size(self, shape_info):
+        """
+        If shape_info is given, return memory size of all data,
+        else size of single element is returned.
+        """
+        if shape_info:
+            return numpy.prod(shape_info) * numpy.dtype(self.dtype).itemsize
+        else:
+            return numpy.dtype(self.dtype).itemsize
+
+
+# expandable_types: can add an extra dimension and for which Scan can deal with.
+# TODO: further check with MKLNdarrayType to support that.
+# theano.compile.ops.expandable_types += (MKLNdarrayType,)
+
+# Register C code for ViewOp on CudaNdarrayType
+theano.compile.register_view_op_c_code(
+    MKLNdarrayType,
+    """
+    Py_XDECREF(%(oname)s);
+    %(oname)s = %(iname)s;
+    Py_XINCREF(%(oname)s);
+    """,
+    version=(1,))
+
+theano.compile.register_shape_c_code(
+    MKLNdarrayType,
+    """
+    npy_intp shape[] = {MKLNdarray_NDIM(%(iname)s)};
+    if (%(oname)s == NULL || (PyArray_DIMS(%(oname)s)[0] != shape[0])) {
+        Py_XDECREF(%(oname)s);
+        %(oname)s = (PyArrayObject*)PyArray_SimpleNew(1, shape, NPY_INT64);
+    }
+
+    for (int i=0; i<shape[0]; i++) {
+        ((npy_int64*)PyArray_GETPTR1(%(oname)s, i))[0] = MKLNdarray_DIMS(%(iname)s)[i];
+    }
+    """,
+    version=(1,))
+
+theano.compile.register_shape_i_c_code(
+    MKLNdarrayType,
+    """
+    if (!%(oname)s)
+        $(oname)s = (PyArrayObject*)PyArray_ZEROS(0, NULL, NPY_INT64, 0);
+    ((npy_int64*)PyArray_DATA(%(oname)s))[0] = MKLNdarray_DIMS(%(iname)s)[%(i)s]
+    """,
+    """
+    if (%(i)s >= MKLNdarray_NDIM(%(iname)s)) {
+        PyErr_SetString(PyExc_TypeError, "Number of dimensions lower than expected");
+        %(fail)s;
+    }
+    """,
+    version=(1,))
+
+theano.compile.register_deep_copy_op_c_code(
+    MKLNdarrayType,
+    """
+    Py_XDECREF(%(oname)s);
+    %(oname)s = (MKLNdarray*)MKLNdarray_Copy(%(iname)s);
+
+    if (!%(oname)s) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "DeepCopyOp: copy failed");
+        %(fail)s;
+    }
+    """,
+    version=(1,))
+
+
+theano.compile.register_specify_shape_c_code(
+    MKLNdarrayType,
+    """
+    if (MKLNdarray_NDIM(%(iname)s) != PyArray_DIMS(%(shape)s)[0]) {
+        PyErr_Format(PyExc_AssertionError,
+                     "SpecifyShape: vector of shape has %%d elements,"
+                     " but the input has %%d dimensions.",
+                     PyArray_DIMS(%(shape)s)[0],
+                     MKLNdarray_NDIM(%(iname)s));
+        %(fail)s;
+    }
+
+    for (int i = 0; i < MKLNdarray_NDIM(%(iname)s); i++) {
+        dtype_%(shape)s shp = ((dtype_%(shape)s*)PyArray_GETPTR1(%(shape)s,
+                                                                 i))[0];
+        if (MKLNdarray_DIMS(%(iname)s)[i] != shp) {
+            PyErr_Format(PyExc_AssertionError,
+                         "SpecifyShape: dim %%d of input has shape %%d,"
+                         " expected %%d.",
+                         i, MKLNdarray_DIMS(%(iname)s)[i],
+                         shp);
+            %(fail)s;
+        }
+    }
+
+    Py_XDECREF(%(oname)s);
+    %(oname)s = %(iname)s;
+    Py_XINCREF(%(oname)s);
+    """,
+    version=(1,))

--- a/theano/contrib/mkl/opt.py
+++ b/theano/contrib/mkl/opt.py
@@ -1,0 +1,168 @@
+from __future__ import absolute_import, print_function, division
+import theano
+from theano.compile import optdb
+from theano.gof import local_optimizer
+from theano.contrib.mkl import mkl_optimizer, register_opt, mkl_seqopt, mkl_available
+from theano.contrib.mkl.basic_ops import U2IGrad, I2U, I2UGrad, U2IConv
+from theano.contrib.mkl import mkl_conv
+
+from theano.tensor.nnet.abstract_conv import (AbstractConv2d,
+                                              AbstractConv2d_gradWeights,
+                                              AbstractConv2d_gradInputs)
+
+import logging
+
+_logger = logging.getLogger('theano.contrib.mkl.opt')
+
+# global OPT
+optdb.register('mkl_opt', mkl_seqopt, 0.09, 'mkl')
+
+# local OPT
+mkl_seqopt.register('mkl_local_optimizations', mkl_optimizer, 20,
+                    'fast_run', 'fast_compile', 'mkl')
+
+
+@local_optimizer([AbstractConv2d])
+def local_Conv2D_mkl(node):
+    if not mkl_available():
+        return
+
+    if not isinstance(node.op, AbstractConv2d):
+        return
+
+    if node.op.filter_dilation != (1, 1):
+        return
+
+    if node.inputs[1].type.ndim != 4 and node.inputs[1].type.ndim != 5:
+        return
+
+    if None in node.op.kshp:
+        return
+
+    try:
+        image, weight = node.inputs
+        image_internal = U2IConv(imshp=node.op.imshp,
+                                 kshp=node.op.kshp,
+                                 subsample=node.op.subsample,
+                                 border_mode=node.op.border_mode,
+                                 filter_dilation=node.op.filter_dilation)(image)
+        convOut = mkl_conv.Conv2D(imshp=node.op.imshp,
+                                  kshp=node.op.kshp,
+                                  border_mode=node.op.border_mode,
+                                  subsample=node.op.subsample,
+                                  filter_flip=node.op.filter_flip,
+                                  filter_dilation=node.op.filter_dilation)(image_internal, weight)
+        z_user = I2U()(convOut)
+        reval = z_user
+        return [reval]
+    except Exception as e:
+        msg = ('Failed to apply local opt to Op %s. '
+               'Exception message: %s\n') % (node.op, str(e))
+        _logger.warning(msg)
+        return
+
+
+@local_optimizer([AbstractConv2d_gradInputs])
+def local_ConvGradInputs_mkl(node):
+    if not mkl_available():
+        return
+
+    if not isinstance(node.op, AbstractConv2d_gradInputs):
+        return
+
+    if node.inputs[1].type.ndim != 4 and node.inputs[1].type.ndim != 5:
+        return
+
+    if node.op.filter_dilation != (1, 1):
+        return
+
+    if None in node.op.kshp:
+        return
+
+    try:
+        weight, gz, zshp = node.inputs
+        image = node.inputs[2].owner.inputs[0].owner.inputs[0]
+        image_internal = U2IConv(imshp=node.op.imshp,
+                                 kshp=node.op.kshp,
+                                 subsample=node.op.subsample,
+                                 border_mode=node.op.border_mode,
+                                 filter_dilation=node.op.filter_dilation)(image)
+        convOut = mkl_conv.Conv2D(imshp=node.op.imshp,
+                                  kshp=node.op.kshp,
+                                  border_mode=node.op.border_mode,
+                                  subsample=node.op.subsample,
+                                  filter_flip=node.op.filter_flip,
+                                  filter_dilation=node.op.filter_dilation)(image_internal, weight)
+        gz_internal = I2UGrad()(convOut, gz)
+        gradImage = mkl_conv.ConvGradInputs(border_mode=node.op.border_mode,
+                                            subsample=node.op.subsample,
+                                            imshp=node.op.imshp,
+                                            kshp=node.op.kshp)(image_internal, weight, gz_internal)
+        gradImage_user = U2IGrad()(image, gradImage)
+        rval = gradImage_user
+        return [rval]
+    except Exception as e:
+        msg = ('Failed to apply local opt to Op %s. '
+               'Exception message: %s\n') % (node.op, str(e))
+        _logger.warning(msg)
+        return
+
+
+@local_optimizer([AbstractConv2d_gradWeights])
+def local_ConvGradWeights_mkl(node):
+
+    if not mkl_available():
+        return
+
+    if not isinstance(node.op, AbstractConv2d_gradWeights):
+        return
+
+    if node.inputs[1].type.ndim != 4 and node.inputs[1].type.ndim != 5:
+        return
+
+    if node.op.filter_dilation != (1, 1):
+        return
+
+    if None in node.op.kshp:
+        return
+
+    try:
+        image, gz, zshp = node.inputs
+        weight = node.inputs[2].owner.inputs[0].owner.inputs[0]
+        image_internal = U2IConv(imshp=node.op.imshp,
+                                 kshp=node.op.kshp,
+                                 subsample=node.op.subsample,
+                                 border_mode=node.op.border_mode,
+                                 filter_dilation=node.op.filter_dilation)(image)
+        convOut = mkl_conv.Conv2D(imshp=node.op.imshp,
+                                  kshp=node.op.kshp,
+                                  border_mode=node.op.border_mode,
+                                  subsample=node.op.subsample,
+                                  filter_flip=node.op.filter_flip,
+                                  filter_dilation=node.op.filter_dilation)(image_internal, weight)
+        gz_internal = I2UGrad()(convOut, gz)
+        gradWeight = mkl_conv.ConvGradWeights(border_mode=node.op.border_mode,
+                                              subsample=node.op.subsample,
+                                              imshp=node.op.imshp,
+                                              kshp=node.op.kshp)(image_internal, weight, gz_internal)
+        rval = gradWeight
+        return [rval]
+    except Exception as e:
+        msg = ('Failed to apply local opt to Op %s. '
+               'Exception message: %s\n') % (node.op, str(e))
+        _logger.warning(msg)
+        return
+
+
+conv_groupopt = theano.gof.optdb.LocalGroupDB()
+conv_groupopt.__name__ = "mkl_conv_opts"
+register_opt()(conv_groupopt)
+
+# MKL-based convolution, using the same group with theano.tensor.nnet.opt to avoid dumlicating GEMM functions
+# It can be disabled by excluding 'conv_mkl'.
+conv_groupopt.register('local_Conv2D_mkl', local_Conv2D_mkl, 20,
+                       'conv_mkl', 'fast_compile', 'fast_run')
+conv_groupopt.register('local_ConvGradInputs_mkl', local_ConvGradInputs_mkl, 20,
+                       'conv_mkl', 'fast_compile', 'fast_run')
+conv_groupopt.register('local_ConvGradWeights_mkl', local_ConvGradWeights_mkl, 20,
+                       'conv_mkl', 'fast_compile', 'fast_run')

--- a/theano/contrib/mkl/tests/test_conv.py
+++ b/theano/contrib/mkl/tests/test_conv.py
@@ -1,0 +1,182 @@
+import theano
+from theano import tensor as T
+from theano.tensor.nnet import conv2d
+from theano.contrib import mkl
+from theano.contrib.mkl.basic_ops import U2IConv, I2U
+from theano.contrib.mkl.mkl_conv import Conv2D
+
+import unittest
+import numpy
+from nose.plugins.skip import SkipTest
+
+numpy.random.seed(123)
+
+if not mkl.mkl_available:
+    raise SkipTest('Optional package MKL disabled')
+
+if theano.config.mode == 'FAST_COMPILE':
+    mode_with_mkl = theano.compile.mode.get_mode('FAST_RUN').including('mkl')
+    mode_without_mkl = theano.compile.mode.get_mode('FAST_RUN').excluding('mkl')
+else:
+    mode_with_mkl = theano.compile.mode.get_default_mode().including('mkl')
+    mode_without_mkl = theano.compile.mode.get_default_mode().excluding('mkl')
+
+
+class test_mkl_conv_forward(unittest.TestCase):
+    def test_conv_U2I(self):
+        images = T.dtensor4('inputs')
+        a_internal = U2IConv(imshp=(12, 3, 256, 256),
+                             kshp=(12, 3, 3, 3))(images)
+        out = I2U()(a_internal)
+
+        fopt = theano.function([images], out, mode=mode_with_mkl)
+        ival = numpy.random.rand(12, 3, 256, 256).astype(numpy.float64)
+        assert numpy.allclose(fopt(ival), ival)
+
+    def test_conv_no_bias(self):
+        images = T.dtensor4('inputs')
+        weights = T.dtensor4('weights')
+
+        images_internal = U2IConv(imshp=(12, 3, 256, 256), kshp=(12, 3, 3, 3))(images)
+        convOut_internal = Conv2D(imshp=(12, 3, 256, 256), kshp=(12, 3, 3, 3), filter_flip=False)(images_internal, weights)
+        convOut_user = I2U()(convOut_internal)
+
+        ival = numpy.random.rand(12, 3, 256, 256).astype(numpy.float64)
+        wval = numpy.random.rand(12, 3, 3, 3).astype(numpy.float64)
+
+        fopt = theano.function(inputs=[images, weights], outputs=convOut_user, mode=mode_with_mkl)
+        new_out = fopt(ival, wval)
+
+        convOut = conv2d(images, weights, input_shape=(12, 3, 256, 256), filter_shape=(12, 3, 3, 3), filter_flip=False)
+        fori = theano.function(inputs=[images, weights], outputs=convOut, mode=mode_without_mkl)
+        old_out = fori(ival, wval)
+
+        assert str(fopt.maker.fgraph.toposort()) != str(fori.maker.fgraph.toposort())
+        assert numpy.allclose(old_out, new_out)
+
+    def test_conv_with_bias(self):
+        images = T.dtensor4('inputs')
+        weights = T.dtensor4('weights')
+        bias = T.dvector('bias')
+
+        ishape = [(8, 3, 256, 256), (16, 3, 256, 256), (32, 3, 256, 256), (64, 3, 256, 256)]
+        wshape = [(8, 3, 3, 3), (16, 3, 3, 3), (32, 3, 3, 3), (64, 3, 3, 3)]
+
+        for i, ish in enumerate(ishape):
+            wsh = wshape[i]
+            images_internal = U2IConv(imshp=ish, kshp=wsh)(images)
+            convOutBias_internal = Conv2D(imshp=ish, kshp=wsh, filter_flip=False)(images_internal, weights, bias)
+            convOutBias_user = I2U()(convOutBias_internal)
+
+            ival = numpy.random.rand(*ish).astype(numpy.float64)
+            wval = numpy.random.rand(*wsh).astype(numpy.float64)
+            bval = numpy.random.rand(wsh[0]).astype(numpy.float64)
+
+            fopt = theano.function(inputs=[images, weights, bias], outputs=convOutBias_user, mode=mode_with_mkl)
+            new_old = fopt(ival, wval, bval)
+
+            convOut = conv2d(images, weights, input_shape=ish, filter_shape=wsh, filter_flip=False)
+            convOutBias = convOut + bias.dimshuffle('x', 0, 'x', 'x')
+            fori = theano.function(inputs=[images, weights, bias], outputs=convOutBias, mode=mode_without_mkl)
+            old_out = fori(ival, wval, bval)
+
+            assert str(fopt.maker.fgraph.toposort()) != str(fori.maker.fgraph.toposort())
+            assert numpy.allclose(old_out, new_old)
+
+    def test_no_shape(self):
+        images = T.dtensor4('inputs')
+        weights = T.dtensor4('weights')
+
+        convOut = conv2d(images, weights, filter_shape=(12, 3, 3, 3), filter_flip=False)
+
+        fopt = theano.function(inputs=[images, weights], outputs=convOut, mode=mode_with_mkl)
+
+        fori = theano.function(inputs=[images, weights], outputs=convOut, mode=mode_without_mkl)
+
+        # No optimization for the case image shape is None
+        assert all([not isinstance(n, (Conv2D, U2IConv, I2U)) for n in fopt.maker.fgraph.toposort()])
+        assert str(fopt.maker.fgraph.toposort()) == str(fori.maker.fgraph.toposort())
+
+
+class test_mkl_conv_backward(unittest.TestCase):
+    def test_conv_no_bias(self):
+        images = T.dtensor4('input_conv')
+        weights = T.dtensor4('weights')
+
+        images_internal = U2IConv(imshp=(12, 3, 256, 256), kshp=(12, 3, 3, 3))(images)
+
+        convOut = Conv2D(imshp=(12, 3, 256, 256), kshp=(12, 3, 3, 3), filter_flip=False)(images_internal, weights)
+        convOut_user = I2U()(convOut)
+        convOutLoss = T.mean(convOut_user)
+        conv_op_di = T.grad(convOutLoss, images)
+        conv_op_dk = T.grad(convOutLoss, weights)
+        convOutBack = [conv_op_di, conv_op_dk]
+
+        ival = numpy.random.rand(12, 3, 256, 256).astype(numpy.float64)
+        wval = numpy.random.rand(12, 3, 3, 3).astype(numpy.float64)
+
+        fopt = theano.function(inputs=[images, weights], outputs=convOutBack, mode=mode_with_mkl)
+        new_out = fopt(ival, wval)
+
+        convOut = conv2d(images, weights, input_shape=(12, 3, 256, 256), filter_shape=(12, 3, 3, 3), filter_flip=False)
+        convOutLoss = T.mean(convOut)
+        conv_op_di = T.grad(convOutLoss, images)
+        conv_op_dk = T.grad(convOutLoss, weights)
+        convOutBack = [conv_op_di, conv_op_dk]
+
+        fori = theano.function(inputs=[images, weights], outputs=convOutBack, mode=mode_without_mkl)
+        old_out = fori(ival, wval)
+
+        assert len(fopt.maker.fgraph.toposort()) != len(fori.maker.fgraph.toposort())
+        assert numpy.allclose(old_out[0], new_out[0])
+        assert new_out[0].dtype == 'float64'
+        # weightsGrad Layout is different.
+        # assert numpy.allclose(old_out[1], new_out[1])
+
+    def test_conv_with_bias(self):
+        images = T.dtensor4('input_conv')
+        weights = T.dtensor4('weights')
+        bias = T.dvector('bias')
+
+        ishape = [(8, 3, 256, 256), (16, 3, 256, 256), (32, 3, 256, 256), (64, 3, 256, 256)]
+        wshape = [(8, 3, 3, 3), (16, 3, 3, 3), (32, 3, 3, 3), (64, 3, 3, 3)]
+
+        for i, ish in enumerate(ishape):
+            wsh = wshape[i]
+
+            images_internal = U2IConv(imshp=ish, kshp=wsh)(images)
+            convOut = Conv2D(imshp=ish, kshp=wsh, filter_flip=False)(images_internal, weights, bias)
+            convOut_user = I2U()(convOut)
+            convOutLoss = T.mean(convOut_user)
+            conv_op_di = theano.grad(convOutLoss, images)
+            conv_op_dk = theano.grad(convOutLoss, weights)
+            conv_op_db = theano.grad(convOutLoss, bias)
+
+            convOutBack = [conv_op_di, conv_op_dk, conv_op_db]
+
+            ival = numpy.random.rand(*ish).astype(numpy.float64)
+            wval = numpy.random.rand(*wsh).astype(numpy.float64)
+            bval = numpy.random.rand(wsh[0]).astype(numpy.float64) - numpy.random.rand(wsh[0]).astype(numpy.float64)
+
+            fopt = theano.function(inputs=[images, weights, bias], outputs=convOutBack, mode=mode_with_mkl)
+            new_out = fopt(ival, wval, bval)
+
+            convOut = conv2d(images, weights, input_shape=ish, filter_shape=wsh, filter_flip=False)
+            convOutLoss = T.mean(convOut + bias.dimshuffle('x', 0, 'x', 'x'))
+            conv_op_di = theano.grad(convOutLoss, images)
+            conv_op_dk = theano.grad(convOutLoss, weights)
+            conv_op_db = theano.grad(convOutLoss, bias)
+
+            convOutBack = [conv_op_di, conv_op_dk, conv_op_db]
+
+            fori = theano.function(inputs=[images, weights, bias], outputs=convOutBack, mode=mode_without_mkl)
+            old_out = fori(ival, wval, bval)
+            assert len(fopt.maker.fgraph.toposort()) != len(fori.maker.fgraph.toposort())
+            assert numpy.allclose(old_out[0], new_out[0])
+            # assert numpy.allclose(old_out[1], new_out[1])
+            assert numpy.allclose(old_out[2], new_out[2])
+            assert new_out[0].dtype == 'float64'
+            assert new_out[2].dtype == 'float64'
+
+if __name__ == '__main__':
+    unittest.main()

--- a/theano/contrib/mkl/tests/test_mkl.py
+++ b/theano/contrib/mkl/tests/test_mkl.py
@@ -1,0 +1,17 @@
+import theano.contrib.mkl as mkl
+
+from nose.plugins.skip import SkipTest
+import unittest
+
+if not mkl.mkl_available:
+    raise SkipTest('Optional package MKL disabled')
+
+
+class TestMKLStatus(unittest.TestCase):
+
+    def test_mkl(self):
+        print('mkl_available: ' + str(mkl.mkl_available()))
+        print('mkl_version: ' + str(mkl.mkl_version()))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/theano/tests/test_flake8.py
+++ b/theano/tests/test_flake8.py
@@ -105,6 +105,7 @@ whitelist_flake8 = [
     "d3viz/__init__.py",
     "d3viz/tests/__init__.py",
     "gof/tests/__init__.py",
+    "contrib/__init__.py",
 ]
 
 


### PR DESCRIPTION
This PR is for the implementations of Intel MKL-based Convolution OP, regarding our previous discussion in [#5580](https://github.com/Theano/Theano/issues/5580) and [PR5770](https://github.com/Theano/Theano/pull/5770) and [PR6016](https://github.com/Theano/Theano/pull/6016).

In this PR, both data layout conversion and convolution computation OPs are included.
BTW, the MKLNdarray code is duplicated so we can continuously track it in 5770 separately.

**Data layout conversion OPs (in file basic_ops.py):**
- BaseConvertOp(MKLOp): base layer for all data conversion OP
- U2IConv(BaseConvertOp): change the user layout (numpy array) to MKLNdarray for convolution layers
- I2U(BaseConvertOp): change the MKLNdarray to user layout (numpy array) and this OP can work for any MKL outputs (such as convolution, relu, pool)  
- U2IGrad(BaseConvertOp): it's for backward computation of U2I and actually it's equal with I2U in functionality
- I2UGrad(BaseConvertOp): MKLNdarry to numpy layout translation for backward computation

**Convolution OPs (in file mkl_conv.py):**
- MKLConvBase(gof.Op):  base layer for convolution including common variables definitions
- Conv2D(MKLConvBase): forward path of convolution with MKL API
- ConvGradInputs(MKLConvBase): gradient input path of convolution with MKL API
- ConvGradWeights(MKLConvBase): gradient weight path of convolution with MKL API
- AbstractConvGroup(gof.Op): grouped convolution and there may be conflict with [PR5991](https://github.com/Theano/Theano/pull/5991) and we will take look for details
- AbstractConvGroupGrad(gof.Op): gradient computation for grouped convolution

**Tests (in file tests/test_conv.py)**
- test_conv_U2I(self):
- test_conv_no_bias(self):
- test_conv_with_bias(self):
- test_no_shape(self):
- test_conv_no_bias(self):
- test_conv_with_bias(self):

This is only a high-level description about our new Ops and feels free to raise any questions and suggestions for us.

The related link:
https://software.intel.com/en-us/mkl-developer-reference-c-dnn-operations
