### PR TITLE
Added the tri-gamma function.

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -2254,6 +2254,11 @@ def psi(a):
 
 
 @_scal_elemwise
+def tri_gamma(a):
+    """second derivative of the log gamma function"""
+
+
+@_scal_elemwise
 def chi2sf(x, k):
     """chi squared survival function"""
 

--- a/theano/tensor/inplace.py
+++ b/theano/tensor/inplace.py
@@ -276,6 +276,11 @@ def psi_inplace(a):
 
 
 @_scal_inplace
+def tri_gamma_inplace(a):
+    """second derivative of the log gamma function"""
+
+
+@_scal_inplace
 def chi2sf_inplace(x, k):
     """chi squared survival function"""
 

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -1706,6 +1706,7 @@ if imported_scipy_special:
     expected_gamma = scipy.special.gamma
     expected_gammaln = scipy.special.gammaln
     expected_psi = scipy.special.psi
+    expected_tri_gamma = partial(scipy.special.polygamma, 1)
     expected_chi2sf = scipy.stats.chi2.sf
     expected_j0 = scipy.special.j0
     expected_j1 = scipy.special.j1
@@ -1870,6 +1871,23 @@ PsiInplaceTester = makeBroadcastTester(
     inplace=True,
     skip=skip_scipy)
 
+_good_broadcast_unary_tri_gamma = _good_broadcast_unary_psi
+
+TriGammaTester = makeBroadcastTester(
+    op=tensor.tri_gamma,
+    expected=expected_tri_gamma,
+    good=_good_broadcast_unary_psi,
+    eps=2e-8,
+    mode=mode_no_scipy,
+    skip=skip_scipy)
+TriGammaInplaceTester = makeBroadcastTester(
+    op=inplace.tri_gamma_inplace,
+    expected=expected_tri_gamma,
+    good=_good_broadcast_unary_tri_gamma,
+    eps=2e-8,
+    mode=mode_no_scipy,
+    inplace=True,
+    skip=skip_scipy)
 
 # chi2sf takes two inputs, a value (x) and a degrees of freedom (k).
 # not sure how to deal with that here...


### PR DESCRIPTION
I've added the Tri-gamma function, which can be run on the GPU as well in comparison to #5963.

Note that I'm not too sure how you guys want to keep the name as the digamma function in Theano is named psi. 
As a note I'm aware of some efforts of doing the more general poly-gamma function, however, this requires a lot more effort and debugging of CUDA kernels as in #4198 which I can not do.
The implementation C code was taken from http://people.sc.fsu.edu/~jburkardt/cpp_src/asa121/asa121.html

As a side note if the `polygamma` makes it into to Theano you might want for `k=0` and `k=1` the Theano interface to return the `Psi` and `TriGamma` Ops, this might simplify the interface significantly. 