### PR TITLE
Params for other ops

### DIFF
--- a/theano/compile/ops.py
+++ b/theano/compile/ops.py
@@ -346,6 +346,18 @@ class Shape_i(gof.Op):
         i = int(i)
         self.i = i
 
+    # NB:
+    # 1) params_type is defined as a property to avoid
+    #    loop in Python import caused by importing theano.scalar below
+    #    when params_type is defined directly in class code.
+    # 2) We wrap scalar into ParamsType (instead of directly using scalar as op param)
+    #    to avoid Theano converting scalar param to constant that would be later
+    #    hardcoded as litteral in C code, making us loose all the advantages of
+    #    using params.
+    @property
+    def params_type(self):
+        return gof.ParamsType(i=theano.scalar.basic.int64)
+
     def __str__(self):
         return '%s{%i}' % (self.__class__.__name__, self.i)
 
@@ -360,7 +372,7 @@ class Shape_i(gof.Op):
                             (x, self.i))
         return theano.Apply(self, [x], [theano.tensor.lscalar()])
 
-    def perform(self, node, inp, out_):
+    def perform(self, node, inp, out_, params):
         x, = inp
         out, = out_
         if out[0] is None:
@@ -383,7 +395,7 @@ class Shape_i(gof.Op):
             version.append((str(t), v))
 
         if version:
-            version.append(1)
+            version.append(2)
 
         return tuple(version)
 
@@ -391,7 +403,8 @@ class Shape_i(gof.Op):
         iname, = inames
         oname, = onames
         fail = sub['fail']
-        i = self.i
+        # i is then 'params->i', not just 'params'.
+        i = sub['params'] + '->i'
 
         itype = node.inputs[0].type.__class__
         if itype in self.c_code_and_version:

--- a/theano/gpuarray/extra_ops.py
+++ b/theano/gpuarray/extra_ops.py
@@ -10,6 +10,9 @@ except ImportError:
 
 from .basic_ops import (as_gpuarray_variable, GpuKernelBase, Kernel, GpuReshape, infer_context_name)
 from .opt import register_opt, op_lifter, register_opt2
+from .type import gpu_context_type
+from theano.gof import ParamsType
+import theano.scalar as scalar
 
 
 class GpuCumOp(GpuKernelBase, Op):
@@ -21,9 +24,11 @@ class GpuCumOp(GpuKernelBase, Op):
     """
     SUPPORTED_NDIMS = 3
     __props__ = ('axis', 'mode')
+    params_type = ParamsType(axis=scalar.int32,
+                             context=gpu_context_type)
 
     def __init__(self, axis, mode='add'):
-        self.axis = axis if axis else 0
+        self.axis = int(axis) if axis is not None else 0
         self.mode = mode
 
     def __eq__(self, other):
@@ -35,13 +40,16 @@ class GpuCumOp(GpuKernelBase, Op):
         return hash(self.axis) ^ hash(self.mode)
 
     def c_code_cache_version(self):
-        return (6,)
+        return (7,)
 
     def c_headers(self):
         return ['<numpy_compat.h>', '<gpuarray/types.h>', '<gpuarray_helper.h>']
 
     def c_header_dirs(self):
         return [os.path.dirname(__file__)]
+
+    def get_params(self, node):
+        return self.params_type.get_params(self, context=node.inputs[0].type.context)
 
     def make_node(self, x):
         assert x.type.dtype == 'float32', "Only float32 supported for GpuCumOp"
@@ -244,24 +252,18 @@ class GpuCumOp(GpuKernelBase, Op):
     def c_code(self, node, nodename, inp, out, sub):
         if node.inputs[0].type.context.kind != b'cuda':
             raise NotImplementedError("cuda only")
-        x, = inp
-        z, = out
-        axis = self.axis if self.axis is not None else 0
-        fail = sub['fail']
-        ctx = sub['params']
-
-        code = """
-
+        return """
             const size_t* shape = PyGpuArray_DIMS(%(x)s);
             bool needAllocation = !%(z)s || PyGpuArray_NDIM(%(x)s) != PyGpuArray_NDIM(%(z)s);
 
-            int axis = %(axis)s;
+            int axis = %(params)s->axis;
             if (axis < 0) {
                 // Convert negative axis to positive axis.
                 axis += PyGpuArray_NDIM(%(x)s);
             }
 
-            if (theano_prep_output(&%(z)s, PyGpuArray_NDIM(%(x)s), PyGpuArray_DIMS(%(x)s), %(x)s->ga.typecode, GA_C_ORDER, %(ctx)s) != 0){
+            if (theano_prep_output(&%(z)s, PyGpuArray_NDIM(%(x)s), PyGpuArray_DIMS(%(x)s),
+                                   %(x)s->ga.typecode, GA_C_ORDER, %(params)s->context) != 0) {
                 %(fail)s;
             }
 
@@ -270,17 +272,17 @@ class GpuCumOp(GpuKernelBase, Op):
                 size_t max_grid_size1;
                 size_t max_grid_size2;
                 int err;
-                err = gpucontext_property(%(ctx)s->ctx, GA_CTX_PROP_MAXLSIZE0, &max_threads_dim0);
+                err = gpucontext_property(%(params)s->context->ctx, GA_CTX_PROP_MAXLSIZE0, &max_threads_dim0);
                 if (err != GA_NO_ERROR){
                     PyErr_SetString(PyExc_RuntimeError, "Could not fetch max_threads_dims0");
                     %(fail)s;
                 }
-                err = gpucontext_property(%(ctx)s->ctx, GA_CTX_PROP_MAXGSIZE1, &max_grid_size1);
+                err = gpucontext_property(%(params)s->context->ctx, GA_CTX_PROP_MAXGSIZE1, &max_grid_size1);
                 if (err != GA_NO_ERROR){
                     PyErr_SetString(PyExc_RuntimeError, "Could not fetch max_grid_size1");
                     %(fail)s;
                 }
-                err = gpucontext_property(%(ctx)s->ctx, GA_CTX_PROP_MAXGSIZE2, &max_grid_size2);
+                err = gpucontext_property(%(params)s->context->ctx, GA_CTX_PROP_MAXGSIZE2, &max_grid_size2);
                 if (err != GA_NO_ERROR){
                     PyErr_SetString(PyExc_RuntimeError, "Could not fetch max_grid_size2");
                     %(fail)s;
@@ -289,9 +291,7 @@ class GpuCumOp(GpuKernelBase, Op):
                     %(fail)s;
                 }
             }
-        """ % locals()
-
-        return code
+        """ % dict(x=inp[0], z=out[0], nodename=nodename, fail=sub['fail'], params=sub['params'])
 
     def c_support_code_struct(self, node, nodename):
         code = """

--- a/theano/gpuarray/extra_ops.py
+++ b/theano/gpuarray/extra_ops.py
@@ -28,7 +28,8 @@ class GpuCumOp(GpuKernelBase, Op):
                              context=gpu_context_type)
 
     def __init__(self, axis, mode='add'):
-        self.axis = int(axis) if axis is not None else 0
+        assert axis is not None
+        self.axis = int(axis)
         self.mode = mode
 
     def __eq__(self, other):

--- a/theano/gpuarray/neighbours.py
+++ b/theano/gpuarray/neighbours.py
@@ -21,7 +21,7 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
     Images2Neibs for the GPU.
 
     """
-    params_type = ParamsType(mode=Images2Neibs.params_type, context=gpu_context_type)
+    params_type = ParamsType(mode=Images2Neibs.BORDER_MODE, context=gpu_context_type)
 
     def get_params(self, node):
         return self.params_type.get_params(self, context=node.inputs[0].type.context)
@@ -57,9 +57,8 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
         flags = Kernel.get_flags(dtype_ten4, dtype_z)
         type_ten4 = gpuarray.dtype_to_ctype(dtype_ten4)
         type_z = gpuarray.dtype_to_ctype(dtype_z)
-        # Params type 'mode' is an enum list which c_support_code()
-        # contains C constants definitions that are useful here.
-        mode_constants = self.params_type.get_type('mode').c_support_code()
+        # `BORDER_MODE`'s c_support_code() contains C constants definitions that are useful here.
+        mode_constants = self.BORDER_MODE.c_support_code()
         kernels = []
         kname = "k_multi_warp_less"
         k_var = "k_multi_warp_less_" + nodename
@@ -110,29 +109,29 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                             ga_int i = LID_1;     // loop over c
                             {
                                 ga_int ten4_2 = i + a * step_x;
-                                if(%(mode)s == MODE_WRAP_CENTERED) {
+                                if(mode == MODE_WRAP_CENTERED) {
                                     ten4_2 -= wrap_centered_half_idx_shift_x;
                                     if ( ten4_2 < 0 )
                                         ten4_2 += height;
                                     else if (ten4_2 >= height)
                                         ten4_2 -= height;
-                                } else if (%(mode)s == MODE_HALF) {
+                                } else if (mode == MODE_HALF) {
                                     ten4_2 -= wrap_centered_half_idx_shift_x;
-                                } else if (%(mode)s == MODE_FULL) {
+                                } else if (mode == MODE_FULL) {
                                     ten4_2 -= c - 1;
                                 }
                                 ga_int j = LID_0;  // loop over d
                                 {
                                     ga_int ten4_3 = j + b * step_y;
-                                    if(%(mode)s == MODE_WRAP_CENTERED){
+                                    if(mode == MODE_WRAP_CENTERED){
                                         ten4_3 -= wrap_centered_half_idx_shift_y;
                                         if ( ten4_3 < 0 )
                                             ten4_3 += width;
                                         else if (ten4_3 >= width)
                                             ten4_3 -= width;
-                                    } else if (%(mode)s == MODE_HALF) {
+                                    } else if (mode == MODE_HALF) {
                                         ten4_3 -= wrap_centered_half_idx_shift_y;
-                                    } else if (%(mode)s == MODE_FULL) {
+                                    } else if (mode == MODE_FULL) {
                                         ten4_3 -= d - 1;
                                     }
 
@@ -212,30 +211,30 @@ class GpuImages2Neibs(GpuKernelBase, Images2Neibs, Op):
                             for (ga_int i = LID_1; i < c; i+=LDIM_1)
                             {
                                 ga_int ten4_2 = i + a * step_x;
-                                if(%(mode)s == MODE_WRAP_CENTERED) {
+                                if(mode == MODE_WRAP_CENTERED) {
                                     ten4_2 -= wrap_centered_half_idx_shift_x;
                                     if ( ten4_2 < 0 )
                                         ten4_2 += height;
                                     else if (ten4_2 >= height)
                                         ten4_2 -= height;
-                                } else if (%(mode)s == MODE_HALF) {
+                                } else if (mode == MODE_HALF) {
                                     ten4_2 -= wrap_centered_half_idx_shift_x;
-                                } else if (%(mode)s == MODE_FULL) {
+                                } else if (mode == MODE_FULL) {
                                     ten4_2 -= c - 1;
                                 }
                                 // loop over d
                                 for (ga_int j = LID_0; j < d; j+=LDIM_0)
                                 {
                                     ga_int ten4_3 = j + b * step_y;
-                                    if(%(mode)s == MODE_WRAP_CENTERED) {
+                                    if(mode == MODE_WRAP_CENTERED) {
                                         ten4_3 -= wrap_centered_half_idx_shift_y;
                                         if ( ten4_3 < 0 )
                                             ten4_3 += width;
                                         else if (ten4_3 >= width)
                                             ten4_3 -= width;
-                                    } else if (%(mode)s == MODE_HALF) {
+                                    } else if (mode == MODE_HALF) {
                                         ten4_3 -= wrap_centered_half_idx_shift_y;
-                                    } else if (%(mode)s == MODE_FULL) {
+                                    } else if (mode == MODE_FULL) {
                                         ten4_3 -= d - 1;
                                     }
 

--- a/theano/gpuarray/subtensor.py
+++ b/theano/gpuarray/subtensor.py
@@ -7,9 +7,11 @@ from six import integer_types
 from six.moves import StringIO
 
 from theano import tensor, gof, Op
+from theano.gof import ParamsType
 from theano.gradient import grad_not_implemented
 import theano.tensor as T
 from theano.tensor.subtensor import IncSubtensor, Subtensor, get_idx_list
+from theano.scalar import bool as bool_t, int32 as int_t, uint32 as size_t
 
 try:
     import pygpu
@@ -594,7 +596,15 @@ class GpuAdvancedIncSubtensor1(Op):
     """
     _f16_ok = True
     __props__ = ('inplace', 'set_instead_of_inc')
-    params_type = gpu_context_type
+    params_type = ParamsType(inplace=bool_t,
+                             set_instead_of_inc=bool_t,
+                             context=gpu_context_type,
+                             # following params are used into c_init_code_struct(),
+                             # as inputs are not available in that function.
+                             ndim_input_0=size_t,
+                             ndim_input_1=size_t,
+                             typecode_input_0=int_t,
+                             typecode_input_1=int_t)
 
     def __init__(self, inplace=False, set_instead_of_inc=False):
         self.inplace = inplace
@@ -634,12 +644,17 @@ class GpuAdvancedIncSubtensor1(Op):
         return gof.Apply(self, [x_, y_, ilist_], [x_.type()])
 
     def get_params(self, node):
-        return node.outputs[0].type.context
+        return self.params_type.get_params(self, context=node.outputs[0].type.context,
+                                           # following params are used into c_init_code_struct().
+                                           ndim_input_0=node.inputs[0].ndim,
+                                           ndim_input_1=node.inputs[1].ndim,
+                                           typecode_input_0=node.inputs[0].type.typecode,
+                                           typecode_input_1=node.inputs[1].type.typecode)
 
     # We can't use the parent version that loops on each index
     # as we also need to loop when set_instead_of_inc is True and the
     # parent doesn't loop in that case.
-    def perform(self, node, inp, out_, ctx=None):
+    def perform(self, node, inp, out_, params=None):
         # TODO opt to make this inplace
         x, y, idx = inp
         out, = out_
@@ -700,21 +715,18 @@ class GpuAdvancedIncSubtensor1(Op):
         return """
         gpuelemwise_arg args[2] = {{0}};
         args[0].name = "a";
-        args[0].typecode = %(type1)s;
+        args[0].typecode = %(params)s->typecode_input_0;
         args[0].flags = GE_READ|GE_WRITE;
         args[1].name = "b";
-        args[1].typecode = %(type2)s;
+        args[1].typecode = %(params)s->typecode_input_1;
         args[1].flags = GE_READ;
-        iadd = GpuElemwise_new(%(ctx)s->ctx, "", "a += b",
-                               2, args, %(nd)s, GE_CONVERT_F16);
+        iadd = GpuElemwise_new(%(params)s->context->ctx, "", "a += b",
+                               2, args, %(params)s->ndim_input_1, GE_CONVERT_F16);
         if (iadd == NULL) {
           PyErr_SetString(PyExc_RuntimeError, "Could not intialize inplace add support");
           %(fail)s
         }
-        """ % dict(ctx=sub['params'], fail=sub['fail'],
-                   type1=node.inputs[0].type.typecode,
-                   type2=node.inputs[1].type.typecode,
-                   nd=node.inputs[1].ndim)
+        """ % dict(params=sub['params'], fail=sub['fail'])
 
     def c_code(self, node, name, inputs, outputs, sub):
         if (node.inputs[0].ndim != node.inputs[1].ndim):
@@ -722,18 +734,26 @@ class GpuAdvancedIncSubtensor1(Op):
 
         return """
         PyGpuArrayObject *row_x, *row_y;
-        ssize_t start[%(nd)s], step[%(nd)s];
+        size_t nd = %(params)s->ndim_input_0;
+        ssize_t *start = NULL, *step = NULL;
         size_t num_indices, j;
         int ret;
         int broadcast_y;
 
-        for (j = 0; j < %(nd)s; j++) {
+        start = (ssize_t*)malloc(nd * sizeof(ssize_t));
+        step = (ssize_t*)malloc(nd * sizeof(ssize_t));
+        if (start == NULL || step == NULL) {
+            PyErr_NoMemory();
+            %(fail)s
+        }
+
+        for (j = 0; j < nd; ++j) {
           start[j] = 0;
           step[j] = 1;
         }
         step[0] = 0;
         num_indices = PyArray_SIZE(%(ind)s);
-        if (!%(inplace)s) {
+        if (!%(params)s->inplace) {
           %(out)s = theano_try_copy(%(out)s, %(x)s);
           if (%(out)s == NULL) {
             // Exception already set
@@ -774,7 +794,7 @@ class GpuAdvancedIncSubtensor1(Op):
               %(fail)s;
             }
 
-            if (%(set_instead_of_inc)s) {
+            if (%(params)s->set_instead_of_inc) {
               ret = GpuArray_setarray(&row_x->ga, &row_y->ga);
             } else {
               void *args[2];
@@ -788,13 +808,21 @@ class GpuAdvancedIncSubtensor1(Op):
               PyErr_SetString(PyExc_RuntimeError, "Failed to set/inc elements");
           }
         }
+
+        free(start);
+        free(step);
         """ % dict(x=inputs[0], y=inputs[1], ind=inputs[2], out=outputs[0],
-                   fail=sub['fail'], inplace=int(self.inplace),
-                   nd=node.inputs[0].ndim,
-                   set_instead_of_inc=int(self.set_instead_of_inc))
+                   params=sub['params'],
+                   fail="""
+                   {
+                        free(start);
+                        free(step);
+                        %(fail)s
+                   }
+                   """ % dict(fail=sub['fail']))
 
     def c_code_cache_version(self):
-        return (3,)
+        return (4,)
 
 
 class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, HideC,
@@ -805,6 +833,8 @@ class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, HideC,
 
     """
     _f16_ok = True
+    params_type = GpuAdvancedIncSubtensor1.params_type
+    get_params = GpuAdvancedIncSubtensor1.get_params
 
     def make_node(self, x, y, ilist):
         """
@@ -837,14 +867,11 @@ class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, HideC,
 
         return gof.Apply(self, [x_, y_, ilist_], [x_.type()])
 
-    def get_params(self, node):
-        return node.outputs[0].type.context
-
-    def perform(self, node, inp, out, ctx):
+    def perform(self, node, inp, out, params):
         return super(GpuAdvancedIncSubtensor1_dev20, self).perform(node, inp, out)
 
     def c_code_cache_version(self):
-        return (12,)
+        return (13,)
 
     def c_headers(self):
         return ['<numpy_compat.h>', '<gpuarray_helper.h>',
@@ -854,7 +881,7 @@ class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, HideC,
         return [os.path.dirname(__file__)]
 
     def c_code(self, node, name, inputs, outputs, sub):
-        ctx = self.get_params(node)
+        ctx = self.get_params(node).context
         if ctx.kind != b'cuda':
             raise NotImplementedError("cuda only")
         if (node.inputs[0].ndim != node.inputs[1].ndim or
@@ -862,16 +889,9 @@ class GpuAdvancedIncSubtensor1_dev20(GpuKernelBase, HideC,
                 int(ctx.bin_id[-2]) < 2):
             raise NotImplementedError("This case does not have C code yet.")
 
-        x = inputs[0]
-        y = inputs[1]
-        ind = inputs[2]
-        out = outputs[0]
-        fail = sub['fail']
-        set_instead_of_inc = int(self.set_instead_of_inc)
-        inplace = int(self.inplace)
         return """
 int err;
-if (%(inplace)s) {
+if (%(params)s->inplace) {
   Py_XDECREF(%(out)s);
   %(out)s = %(x)s;
   Py_INCREF(%(out)s);
@@ -882,25 +902,19 @@ if (!%(out)s) {
   // Exception already set
   %(fail)s
 }
-if (GpuArray_vector_add_fast(%(out)s, %(y)s, %(ind)s, %(set_instead_of_inc)s)) {
+if (GpuArray_vector_add_fast(%(out)s, %(y)s, %(ind)s, %(params)s->set_instead_of_inc)) {
   %(fail)s
 }
-        """ % locals()
+        """ % dict(x=inputs[0], y=inputs[1], ind=inputs[2], out=outputs[0], fail=sub['fail'], params=sub['params'])
 
     def gpu_kernels(self, node, nodename):
         dtype_x = node.inputs[0].dtype
         dtype_y = node.inputs[1].dtype
         dtype_ind = node.inputs[2].dtype
-        dtype_out = node.outputs[0].dtype
-        itemsize_x = np.dtype(dtype_x).itemsize
-        itemsize_y = np.dtype(dtype_y).itemsize
-        itemsize_ind = np.dtype(dtype_ind).itemsize
-        itemsize_out = np.dtype(dtype_out).itemsize
-        flags = Kernel.get_flags(dtype_x, dtype_y, dtype_ind)
         type_x = gpuarray.dtype_to_ctype(dtype_x)
         type_y = gpuarray.dtype_to_ctype(dtype_y)
         type_ind = gpuarray.dtype_to_ctype(dtype_ind)
-        type_out = gpuarray.dtype_to_ctype(dtype_out)
+        flags = Kernel.get_flags(dtype_x, dtype_y, dtype_ind)
         kname = "k_vector_add_fast"
         k_var = "k_vector_add_fast_" + nodename
         code = """
@@ -1010,7 +1024,7 @@ __device__ ga_half atomicExch(ga_half *addr, ga_half val) {
              }
              return;
         }
-        """ % locals()
+        """ % dict(type_x=type_x, type_y=type_y, type_ind=type_ind)
         params = [
             'uintp', 'uintp', 'intp', 'intp', gpuarray.GpuArray, 'uintp',
             'uintp', 'uintp', 'intp', 'intp', gpuarray.GpuArray, 'uintp',
@@ -1020,26 +1034,19 @@ __device__ ga_half atomicExch(ga_half *addr, ga_half val) {
                        flags=flags, objvar=k_var)]
 
     def c_support_code_struct(self, node, nodename):
-        dtype_x = node.inputs[0].dtype
-        dtype_y = node.inputs[1].dtype
-        dtype_ind = node.inputs[2].dtype
-        dtype_out = node.outputs[0].dtype
-        itemsize_x = np.dtype(dtype_x).itemsize
-        itemsize_y = np.dtype(dtype_y).itemsize
-        itemsize_ind = np.dtype(dtype_ind).itemsize
-        itemsize_out = np.dtype(dtype_out).itemsize
-        k_var = "k_vector_add_fast_" + nodename
-
         return super(GpuAdvancedIncSubtensor1_dev20, self).c_support_code_struct(node, nodename) + """
         int GpuArray_vector_add_fast(PyGpuArrayObject* py_self,
                                      PyGpuArrayObject* py_other,
-                                     PyGpuArrayObject *indices_arr,
+                                     PyGpuArrayObject* indices_arr,
                                      const int set_instead_of_inc)
         {
             size_t threads_per_block[3] = {std::min(PyGpuArray_DIMS(py_self)[1], (size_t)256), 1, 1};
             size_t n_blocks[3] = {std::min(PyGpuArray_SIZE(indices_arr), (size_t)4096), 1, 1};
             gpudata *errbuf;
             int err, kerr = 0;
+            size_t itemsize_x = GpuArray_ITEMSIZE(&py_self->ga);
+            size_t itemsize_y = GpuArray_ITEMSIZE(&py_other->ga);
+            size_t itemsize_ind = GpuArray_ITEMSIZE(&indices_arr->ga);
 
             if (threads_per_block[0] > 0 && n_blocks[0] > 0) {
               err = gpudata_property(py_self->ga.data,
@@ -1049,11 +1056,11 @@ __device__ ga_half atomicExch(ga_half *addr, ga_half val) {
                 return 1;
               }
 
-              ssize_t stride_X0 = PyGpuArray_STRIDES(py_self)[0] / %(itemsize_x)s;
-              ssize_t stride_X1 = PyGpuArray_STRIDES(py_self)[1] / %(itemsize_x)s;
-              ssize_t stride_Y0 = PyGpuArray_DIMS(py_other)[0] == 1 ? 0 : PyGpuArray_STRIDES(py_other)[0] / %(itemsize_y)s;
-              ssize_t stride_Y1 = PyGpuArray_DIMS(py_other)[1] == 1 ? 0 : PyGpuArray_STRIDES(py_other)[1] / %(itemsize_y)s;
-              ssize_t stride_ind = PyGpuArray_STRIDES(indices_arr)[0] / %(itemsize_ind)s;
+              ssize_t stride_X0 = PyGpuArray_STRIDES(py_self)[0] / itemsize_x;
+              ssize_t stride_X1 = PyGpuArray_STRIDES(py_self)[1] / itemsize_x;
+              ssize_t stride_Y0 = PyGpuArray_DIMS(py_other)[0] == 1 ? 0 : PyGpuArray_STRIDES(py_other)[0] / itemsize_y;
+              ssize_t stride_Y1 = PyGpuArray_DIMS(py_other)[1] == 1 ? 0 : PyGpuArray_STRIDES(py_other)[1] / itemsize_y;
+              ssize_t stride_ind = PyGpuArray_STRIDES(indices_arr)[0] / itemsize_ind;
               void *kernel_params[] = {(void *)&PyGpuArray_DIMS(py_self)[0],
                                        (void *)&PyGpuArray_DIMS(py_self)[1],
                                        (void *)&stride_X0,
@@ -1093,7 +1100,7 @@ __device__ ga_half atomicExch(ga_half *addr, ga_half val) {
             }
           return 0;
         }
-        """ % locals()
+        """ % dict(k_var="k_vector_add_fast_" + nodename)
 
 
 class GpuExtractDiag(Op):

--- a/theano/tensor/nnet/neighbours.py
+++ b/theano/tensor/nnet/neighbours.py
@@ -52,8 +52,8 @@ class Images2Neibs(Op):
     def __init__(self, mode='valid'):
         implemented_modes = self.params_type.get_aliases()
         if mode not in implemented_modes:
-            raise NotImplementedError("Only modes %s have been implemented for Images2Neibs"
-                                      % ', '.join(implemented_modes))
+            raise NotImplementedError("Only modes %s have been implemented for %s"
+                                      % (', '.join(implemented_modes), type(self).__name__))
         self.mode = mode
 
     def __str__(self):

--- a/theano/tensor/nnet/neighbours.py
+++ b/theano/tensor/nnet/neighbours.py
@@ -167,7 +167,7 @@ class Images2Neibs(Op):
                 grad_undefined(self, 2, neib_step)]
 
     def c_code_cache_version(self):
-        return (9,)
+        return (10,)
 
     def perform(self, node, inp, out_, params):
         ten4, neib_shape, neib_step = inp
@@ -579,9 +579,9 @@ class Images2Neibs(Op):
                                 ten4_2 -= wrap_centered_half_idx_shift_x;
                                 if ( ten4_2 < 0 ) ten4_2 += height;
                                 else if (ten4_2 >= height) ten4_2 -= height;
-                            } else if ( "%(mode)s" == "half" ){
+                            } else if (%(mode)s == MODE_HALF) {
                                 ten4_2 -= wrap_centered_half_idx_shift_x;
-                            } else if ( "%(mode)s" == "full" ){
+                            } else if (%(mode)s == MODE_FULL) {
                                 ten4_2 -= c - 1;
                             }
                             if (ten4_2 < 0 | ten4_2 >= height) {

--- a/theano/tensor/nnet/neighbours.py
+++ b/theano/tensor/nnet/neighbours.py
@@ -40,17 +40,18 @@ class Images2Neibs(Op):
     """
 
     __props__ = ("mode",)
-    params_type = EnumList(('MODE_VALID', 'valid'),
+    BORDER_MODE = EnumList(('MODE_VALID', 'valid'),
                            ('MODE_HALF', 'half'),
                            ('MODE_FULL', 'full'),
                            ('MODE_WRAP_CENTERED', 'wrap_centered'),
                            ('MODE_IGNORE_BORDERS', 'ignore_borders'))
+    params_type = BORDER_MODE
 
     def get_params(self, node):
         return self.mode
 
     def __init__(self, mode='valid'):
-        implemented_modes = self.params_type.get_aliases()
+        implemented_modes = self.BORDER_MODE.get_aliases()
         if mode not in implemented_modes:
             raise NotImplementedError("Only modes %s have been implemented for %s"
                                       % (', '.join(implemented_modes), type(self).__name__))

--- a/theano/tensor/subtensor.py
+++ b/theano/tensor/subtensor.py
@@ -1875,11 +1875,11 @@ class AdvancedIncSubtensor1(Op):
     __props__ = ('inplace', 'set_instead_of_inc')
     check_input = False
     params_type = ParamsType(inplace=scal.bool,
-                             set_instead_of_inc=scal.int8)
+                             set_instead_of_inc=scal.bool)
 
     def __init__(self, inplace=False, set_instead_of_inc=False):
         self.inplace = bool(inplace)
-        self.set_instead_of_inc = int(bool(set_instead_of_inc))
+        self.set_instead_of_inc = bool(set_instead_of_inc)
         if inplace:
             self.destroy_map = {0: [0]}
 

--- a/theano/tensor/subtensor.py
+++ b/theano/tensor/subtensor.py
@@ -1989,7 +1989,7 @@ class AdvancedIncSubtensor1(Op):
                    params=sub['params'], fail=sub['fail'])
 
     def c_code_cache_version(self):
-        return (7,)
+        return (8,)
 
     def perform(self, node, inp, out_, params):
         # TODO opt to make this inplace


### PR DESCRIPTION
Continues #5866 (cannot reopen that PR). Rebased and re-read. Adding op params for:
- GpuCumOp
- GPUA_mrg_uniform
- AdvancedIncSubtensor1 (+ set `check_input=False` for AdvancedSubtensor1)
- GpuAdvancedIncSubtensor1
- GpuAdvancedIncSubtensor1_dev20
- Images2Neibs
- GpuImages2Neibs
- compile.ops.Shape_i

I think it will not speed up TRAVIS so much, as changes are mainly in gpuarray module, but now we can end with this big old PR!

@nouiz @lamblin @abergeron 