### PR TITLE
Compile less C code

### DIFF
--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -856,14 +856,15 @@ class Op(utils.object2, PureOp, CLinkerOp):
         _logger.debug('Trying CLinker.make_thunk')
         outputs = cl.make_thunk(input_storage=node_input_storage,
                                 output_storage=node_output_storage)
-        fill_storage, node_input_filters, node_output_filters = outputs
+        thunk, node_input_filters, node_output_filters = outputs
 
         def rval():
-            fill_storage()
+            thunk()
             for o in node.outputs:
                 compute_map[o][0] = True
 
-        rval.cthunk = fill_storage.cthunk
+        rval.thunk = thunk
+        rval.cthunk = thunk.cthunk
         rval.inputs = node_input_storage
         rval.outputs = node_output_storage
         rval.lazy = False

--- a/theano/gof/tests/test_vm.py
+++ b/theano/gof/tests/test_vm.py
@@ -443,6 +443,6 @@ def test_reallocation():
 def test_no_recycling():
     x = theano.tensor.vector()
     mode = theano.Mode(optimizer='fast_compile')
-    f=theano.function([x], x+1, mode=mode)
-    f2=theano.function([x], (x+1)*2, mode=mode)
+    f = theano.function([x], x + 1, mode=mode)
+    f2 = theano.function([x], (x + 1) * 2, mode=mode)
     theano.printing.debugprint([f, f2])

--- a/theano/gof/tests/test_vm.py
+++ b/theano/gof/tests/test_vm.py
@@ -438,3 +438,11 @@ def test_reallocation():
         assert check_storage(storage_map)[0]
         assert len(set(id(v) for v in
                        itervalues(storage_map))) < len(storage_map)
+
+
+def test_no_recycling():
+    x = theano.tensor.vector()
+    mode = theano.Mode(optimizer='fast_compile')
+    f=theano.function([x], x+1, mode=mode)
+    f2=theano.function([x], (x+1)*2, mode=mode)
+    theano.printing.debugprint([f, f2])

--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -413,6 +413,9 @@ class Stack(VM):
         self.node_executed_order = []
         self.node_cleared_order = []
 
+        for cont in self.pre_call_clear:
+            cont[0] = None
+
         for k in self.storage_map:
             compute_map[k][0] = (k.owner is None)
             if self.callback_input and compute_map[k][0]:
@@ -1051,7 +1054,11 @@ class VM_Linker(link.LocalLinker):
                 thunks.append(node.op.make_thunk(node,
                                                  storage_map,
                                                  compute_map,
-                                                 no_recycling,
+                # The no recycling is done at the VM.__call__
+                # implementation at the next call with the
+                # pre_call_clear. So there is no need to cause
+                # duplicate c code by passing no_recycling here.
+                                                 no_recycling=[],
                                                  impl=impl))
                 linker_make_thunk_time[node] = time.time() - thunk_start
                 if not hasattr(thunks[-1], 'lazy'):

--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -1080,7 +1080,7 @@ class VM_Linker(link.LocalLinker):
                 thunks.append(node.op.make_thunk(node,
                                                  storage_map,
                                                  compute_map,
-                                                 no_recycling=[],
+                                                 [],
                                                  impl=impl))
                 linker_make_thunk_time[node] = time.time() - thunk_start
                 if not hasattr(thunks[-1], 'lazy'):

--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -748,8 +748,7 @@ class VM_Linker(link.LocalLinker):
             self.schedule = schedule
 
     def accept(self, fgraph, no_recycling=None, profile=None):
-        """
-        Check if fgraph is the first FunctionGraph that has ever been
+        """Check if fgraph is the first FunctionGraph that has ever been
         associated to self, else, create a new VM_Linker
         associated to fgraph
 
@@ -758,8 +757,33 @@ class VM_Linker(link.LocalLinker):
         fgraph
             A PerformLinker can have accepted one FunctionGraph instance
             at a time.
+
         no_recycling
-            WRITEME
+
+            no_recycling is a list of storage (list of 1 element, the
+            value corresponding to one variable). Those variable
+            storage should not be reused after the call that created
+            them.
+
+            This happen for example for output of the graph that we
+            give to the user. We don't want to reuse those object in
+            case the user have kept it.
+
+            VM_Linker make sure this happen by setting the list
+            element to None at the start of each call.
+
+            Older Linker use not exactly the same mechanism. They will
+            also modify the c code to don't look up the value in the
+            storage. This cause duplicate c code compilation for the
+            same op if they are in the middle of the graph or in the
+            no_recycling. We don't want that, so compile all c code
+            the same (middle of the graph vs output).
+
+            TODO: change the logic to remove the reference at the end
+            of the call instead of the start. This will request all VM
+            implementation (Loop, LoopGC, Stack, CVM).__call__ to
+            return the user outputs as Function.__call__ won't be able
+            to find them anymore.
 
         Returns
         -------
@@ -1021,7 +1045,6 @@ class VM_Linker(link.LocalLinker):
                  ):
         fgraph = self.fgraph
         order = self.schedule(fgraph)
-        no_recycling = self.no_recycling
 
         input_storage, output_storage, storage_map = link.map_storage(
             fgraph, order, input_storage, output_storage, storage_map)
@@ -1051,13 +1074,12 @@ class VM_Linker(link.LocalLinker):
         for node in order:
             try:
                 thunk_start = time.time()
+                # no-recycling is done at each VM.__call__ So there is
+                # no need to cause duplicate c code by passing
+                # no_recycling here.
                 thunks.append(node.op.make_thunk(node,
                                                  storage_map,
                                                  compute_map,
-                # The no recycling is done at the VM.__call__
-                # implementation at the next call with the
-                # pre_call_clear. So there is no need to cause
-                # duplicate c code by passing no_recycling here.
                                                  no_recycling=[],
                                                  impl=impl))
                 linker_make_thunk_time[node] = time.time() - thunk_start


### PR DESCRIPTION
This fix the long standing issue (for the VM only) about multiple compilation due to re_recycling.

Mostly, Theano was compiling different c code if one node was the output of a graph or not. I suspect that for the tests, this cause much extra c code compiled then needed.

on my travis, I deleted Theano cache to see the travis time in that case: https://travis-ci.org/nouiz/Theano/builds/250125948

On Theano travis, we will see how it behave with an empty cache.

When running the tests included in this PR on the master with an empty cache, we have this in the cache after the test
```
===============================================================================================================
Theano cache: /home/nouiz/.theano/compiledir_Linux-4.4--generic-x86_64-with-debian-stretch-sid-x86_64-2.7.13-64
===============================================================================================================

List of 4 compiled individual ops
+++++++++++++++++++++++++++++++++
sub dir/compiletime/Op/set of different associated Theano types
---------------------------------------------------------------
tmpJ3sZDB 0.512s Elemwise{add,no_inplace} [TensorType(float64, vector), TensorType(int8, (True,))]
tmpCV3isf 0.484s Elemwise{add,no_inplace} [TensorType(float64, vector), TensorType(int8, (True,))]
tmpdFCNse 0.400s Elemwise{mul,no_inplace} [TensorType(float64, vector), TensorType(int8, (True,))]
tmpAGDzD5 0.388s InplaceDimShuffle{x} [TensorType(int8, scalar)]

List of 0 compiled sets of ops
++++++++++++++++++++++++++++++
sub dir/compiletime/Set of ops/set of different associated Theano types
-----------------------------------------------------------------------

List of 2 compiled Op classes and the number of times they got compiled
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
<class 'theano.tensor.elemwise.DimShuffle'> 1
<class 'theano.tensor.elemwise.Elemwise'> 3

Number of keys for a compiled module
++++++++++++++++++++++++++++++++++++
number of keys/number of modules with that number of keys
---------------------------------------------------------
1 3
2 1

Skipped 0 files that contained 0 op (are they always theano.scalar ops?)
```

With this PR, an empty cache have after the test:
```
===============================================================================================================
Theano cache: /home/nouiz/.theano/compiledir_Linux-4.4--generic-x86_64-with-debian-stretch-sid-x86_64-2.7.13-64
===============================================================================================================

List of 3 compiled individual ops
+++++++++++++++++++++++++++++++++
sub dir/compiletime/Op/set of different associated Theano types
---------------------------------------------------------------
tmpp7QSN6 0.356s Elemwise{add,no_inplace} [TensorType(float64, vector), TensorType(int8, (True,))]
tmpWci61W 0.352s Elemwise{mul,no_inplace} [TensorType(float64, vector), TensorType(int8, (True,))]
tmpnjIxm_ 0.256s InplaceDimShuffle{x} [TensorType(int8, scalar)]

List of 0 compiled sets of ops
++++++++++++++++++++++++++++++
sub dir/compiletime/Set of ops/set of different associated Theano types
-----------------------------------------------------------------------

List of 2 compiled Op classes and the number of times they got compiled
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
<class 'theano.tensor.elemwise.DimShuffle'> 1
<class 'theano.tensor.elemwise.Elemwise'> 2

Number of keys for a compiled module
++++++++++++++++++++++++++++++++++++
number of keys/number of modules with that number of keys
---------------------------------------------------------
1 2
2 1

Skipped 0 files that contained 0 op (are they always theano.scalar ops?)
```

We see that for this test, there was 2 elemwise add before the PR and only 1 elemwise add after the PR.