### PR TITLE
Make the CAReduce tests faster

### DIFF
--- a/theano/gof/params_type.py
+++ b/theano/gof/params_type.py
@@ -655,7 +655,7 @@ class ParamsType(Type):
         return list(sorted(list(c_support_code_set))) + [final_struct_code]
 
     def c_code_cache_version(self):
-        return ((2,), tuple(t.c_code_cache_version() for t in self.types))
+        return ((3,), tuple(t.c_code_cache_version() for t in self.types))
 
     # As this struct has constructor and destructor, it could be instanciated on stack,
     # but current implementations of C ops will then pass the instance by value at functions,
@@ -684,6 +684,7 @@ class ParamsType(Type):
         /* Seems c_init() is not called for a op param. So I call `new` here. */
         %(name)s = new %(struct_name)s;
 
+        { // This need a separate namespace for Clinker
         const char* fields[] = {%(fields_list)s};
         if (py_%(name)s == Py_None) {
             PyErr_SetString(PyExc_ValueError, "ParamsType: expected an object, not None.");
@@ -702,6 +703,7 @@ class ParamsType(Type):
                 fprintf(stderr, "\\nParamsType: error when extracting value for attribute \\"%%s\\".\\n", fields[i]);
                 %(fail)s
             }
+        }
         }
         """ % dict(name=name, struct_name=self.name, length=self.length, fail=sub['fail'],
                    fields_list='"%s"' % '", "'.join(self.fields))

--- a/theano/gpuarray/tests/test_elemwise.py
+++ b/theano/gpuarray/tests/test_elemwise.py
@@ -212,32 +212,40 @@ class test_GpuCAReduceCPY(test_elemwise.test_CAReduce):
     def test_perform(self):
         for dtype in self.dtypes + self.bin_dtypes:
             for op in self.reds:
-                self.with_linker(gof.PerformLinker(), op, dtype=dtype,
-                                 pre_scalar_op=self.pre_scalar_op)
+                self.with_mode(Mode(linker='py',
+                                    optimizer=mode_with_gpu.optimizer),
+                               op, dtype=dtype,
+                               pre_scalar_op=self.pre_scalar_op)
 
     def test_perform_nan(self):
         for dtype in self.dtypes:
             if not dtype.startswith('float'):
                 continue
             for op in self.reds:
-                self.with_linker(gof.PerformLinker(), op, dtype=dtype,
-                                 test_nan=True,
-                                 pre_scalar_op=self.pre_scalar_op)
+                self.with_mode(Mode(linker='py',
+                                    optimizer=mode_with_gpu.optimizer)
+                               op, dtype=dtype,
+                               test_nan=True,
+                               pre_scalar_op=self.pre_scalar_op)
 
     def test_c(self):
         for dtype in self.dtypes + self.bin_dtypes:
             for op in self.reds:
-                self.with_linker(gof.CLinker(), op, dtype=dtype,
-                                 pre_scalar_op=self.pre_scalar_op)
+                self.with_mode(Mode(linker='c',
+                                    optimizer=mode_with_gpu.optimizer)
+                               op, dtype=dtype,
+                               pre_scalar_op=self.pre_scalar_op)
 
     def test_c_nan(self):
         for dtype in self.dtypes:
             if not dtype.startswith('float'):
                 continue
             for op in self.reds:
-                self.with_linker(gof.CLinker(), op, dtype=dtype,
-                                 test_nan=True,
-                                 pre_scalar_op=self.pre_scalar_op)
+                self.with_mode(Mode(linker='c',
+                                    optimizer=mode_with_gpu.optimizer)
+                               op, dtype=dtype,
+                               test_nan=True,
+                               pre_scalar_op=self.pre_scalar_op)
 
     def test_infer_shape(self):
         for dtype in self.dtypes:
@@ -333,6 +341,9 @@ class test_GpuCAReduceCuda(test_GpuCAReduceCPY):
     reds = [scalar.add, scalar.mul,
             scalar.maximum, scalar.minimum]
     pre_scalar_op = None
+
+    def test_perform_noopt(self):
+        return
 
     def test_perform(self):
         return

--- a/theano/gpuarray/tests/test_elemwise.py
+++ b/theano/gpuarray/tests/test_elemwise.py
@@ -7,7 +7,7 @@ import scipy.special
 
 import theano
 from theano import scalar, gof, tensor
-from theano.compile import DebugMode
+from theano.compile import DebugMode, Mode
 from theano.tests.unittest_tools import SkipTest, assert_allclose
 
 from theano.tensor.tests import test_elemwise
@@ -223,7 +223,7 @@ class test_GpuCAReduceCPY(test_elemwise.test_CAReduce):
                 continue
             for op in self.reds:
                 self.with_mode(Mode(linker='py',
-                                    optimizer=mode_with_gpu.optimizer)
+                                    optimizer=mode_with_gpu.optimizer),
                                op, dtype=dtype,
                                test_nan=True,
                                pre_scalar_op=self.pre_scalar_op)
@@ -232,7 +232,7 @@ class test_GpuCAReduceCPY(test_elemwise.test_CAReduce):
         for dtype in self.dtypes + self.bin_dtypes:
             for op in self.reds:
                 self.with_mode(Mode(linker='c',
-                                    optimizer=mode_with_gpu.optimizer)
+                                    optimizer=mode_with_gpu.optimizer),
                                op, dtype=dtype,
                                pre_scalar_op=self.pre_scalar_op)
 
@@ -242,7 +242,7 @@ class test_GpuCAReduceCPY(test_elemwise.test_CAReduce):
                 continue
             for op in self.reds:
                 self.with_mode(Mode(linker='c',
-                                    optimizer=mode_with_gpu.optimizer)
+                                    optimizer=mode_with_gpu.optimizer),
                                op, dtype=dtype,
                                test_nan=True,
                                pre_scalar_op=self.pre_scalar_op)

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -1202,7 +1202,7 @@ second dimension
         return support_code
 
     def c_code_cache_version_apply(self, node):
-        version = [12]  # the version corresponding to the c code in this Op
+        version = [13]  # the version corresponding to the c code in this Op
 
         # now we insert versions for the ops on which we depend...
         scalar_node = Apply(
@@ -1622,7 +1622,7 @@ class CAReduce(Op):
 
     def c_code_cache_version_apply(self, node):
         # the version corresponding to the c code in this Op
-        version = [7]
+        version = [8]
 
         # now we insert versions for the ops on which we depend...
         scalar_node = Apply(

--- a/theano/tensor/elemwise_cgen.py
+++ b/theano/tensor/elemwise_cgen.py
@@ -165,6 +165,8 @@ def make_alloc(loop_orders, dtype, sub, fortran='0'):
                 PyErr_Clear();
                 Py_XDECREF(%(olv)s);
                 %(olv)s = (PyArrayObject*)PyArray_EMPTY(%(nd)s, dims, %(type)s, 0);
+            } else {
+                Py_DECREF(success);
             }
         }
         if (!%(olv)s) {

--- a/theano/tensor/elemwise_cgen.py
+++ b/theano/tensor/elemwise_cgen.py
@@ -72,16 +72,12 @@ def make_checks(loop_orders, dtypes, sub):
                 %(var)s_n%(index)s = PyArray_DIMS(%(var)s)[%(index)s];
                 %(var)s_stride%(index)s = PyArray_STRIDES(%(var)s)[%(index)s] / sizeof(%(dtype)s);
                 %(var)s_jump%(index)s_%(j)s = %(jump)s;
-                //printf("%(var)s_jump%(index)s_%(j)s is:");
-                //std::cout << %(var)s_jump%(index)s_%(j)s << std::endl;
                 """ % locals()
                 adjust = "%(var)s_n%(index)s*%(var)s_stride%(index)s" % locals()
             else:
                 jump = "-(%s)" % adjust
                 init += """
                 %(var)s_jump%(index)s_%(j)s = %(jump)s;
-                //printf("%(var)s_jump%(index)s_%(j)s is:");
-                //std::cout << %(var)s_jump%(index)s_%(j)s << std::endl;
                 """ % locals()
                 adjust = "0"
     check = ""

--- a/theano/tensor/tests/test_elemwise.py
+++ b/theano/tensor/tests/test_elemwise.py
@@ -546,7 +546,8 @@ class test_CAReduce(unittest_tools.InferShapeTester):
 
     @attr('slow')
     def test_c(self):
-
+        if not theano.config.cxx:
+            raise SkipTest("G++ not available, so we need to skip this test.")
         for dtype in ["bool", "floatX", "complex64", "complex128", "int8", "uint8"]:
             self.with_mode(Mode(linker='c'), scalar.add, dtype=dtype)
             self.with_mode(Mode(linker='c'), scalar.mul, dtype=dtype)


### PR DESCRIPTION
This also fixes:
 - minor memory leak in the elemwise alloc code
 -  compile of ParamsType with CLinker of more than one op.