### PR TITLE
Wrap Op params for theano.gpuarray.dnn.GpuDnnBatchNorm

### DIFF
--- a/doc/extending/extending_theano_c.txt
+++ b/doc/extending/extending_theano_c.txt
@@ -894,7 +894,7 @@ If you pass a function name to the ``__init__()`` method of the
         theano Types) of your inputs and outputs.
 
 *       You can sepcify the number of inputs and outputs for your op
-        by setting the `_cop_num_inputs` and `_cop_num_outputs`
+        by setting the ``_cop_num_inputs`` and ``_cop_num_outputs``
         attributes on your op.  The main function will always be
         called with that number of arguments, using NULL to fill in
         for missing values at the end.  This can be used if your op

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -1666,13 +1666,20 @@ class GpuDnnBatchNorm(DnnBase):
     __props__ = ('mode', 'running_averages', 'inplace_running_mean',
                  'inplace_running_var', 'inplace_output')
 
+    check_input = False
+    params_type = ParamsType(mode=cudnn.cudnnBatchNormMode_t,
+                             inplace_output=bool_t,
+                             inplace_running_mean=bool_t,
+                             inplace_running_var=bool_t,
+                             handle=handle_type)
+
     def __init__(self, mode='per-activation', running_averages=False,
                  inplace_running_mean=False, inplace_running_var=False,
                  inplace_output=False):
         DnnBase.__init__(self, ['dnn_batchnorm_base.c', 'dnn_batchnorm.c'],
                          'dnn_batchnorm_op')
 
-        assert (mode in ('per-activation', 'spatial'))
+        assert cudnn.cudnnBatchNormMode_t.has_alias(mode)
         self.mode = mode
         self.running_averages = running_averages
         self.inplace_output = inplace_output
@@ -1700,23 +1707,11 @@ class GpuDnnBatchNorm(DnnBase):
             self.inplace_output = False
             self.destroy_map = {}
 
-    def get_op_params(self):
-        params = []
-        if self.inplace_output:
-            params.append(('INPLACE_OUTPUT', '1'))
-        if self.running_averages:
-            params.append(('RUNNING_AVERAGES', '1'))
-            if self.inplace_running_mean:
-                params.append(('INPLACE_RUNNING_MEAN', '1'))
-            if self.inplace_running_var:
-                params.append(('INPLACE_RUNNING_VAR', '1'))
-        params.append(('MODE', ("CUDNN_BATCHNORM_SPATIAL"
-                                if self.mode == "spatial"
-                                else "CUDNN_BATCHNORM_PER_ACTIVATION")))
-        return params
-
     def infer_shape(self, node, shape):
         return [shape[0]] + [shape[1]] * (len(node.outputs) - 1)
+
+    _cop_num_inputs = 7
+    _cop_num_outputs = 5
 
     def make_node(self, x, scale, bias, epsilon=1e-4,
                   running_average_factor=0.1,

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -1665,7 +1665,8 @@ class GpuDnnBatchNorm(DnnBase):
 
     __props__ = ('mode', 'running_averages', 'inplace_running_mean',
                  'inplace_running_var', 'inplace_output')
-
+    _cop_num_inputs = 7
+    _cop_num_outputs = 5
     check_input = False
     params_type = ParamsType(mode=cudnn.cudnnBatchNormMode_t,
                              inplace_output=bool_t,
@@ -1709,9 +1710,6 @@ class GpuDnnBatchNorm(DnnBase):
 
     def infer_shape(self, node, shape):
         return [shape[0]] + [shape[1]] * (len(node.outputs) - 1)
-
-    _cop_num_inputs = 7
-    _cop_num_outputs = 5
 
     def make_node(self, x, scale, bias, epsilon=1e-4,
                   running_average_factor=0.1,


### PR DESCRIPTION
When working on DNN module I had not parameterized GpuDnnBatchNorm because its inputs and outputs lengths depended on a macro param. But this op has a maximum inputs length and outputs length, and then `_cop_num_inputs` and `_cop_num_outputs` allow to handle this case for COps.

This PR adds params type to GpuDnnBatchNorm. Now DNN module does not contain `get_op_params()` implementations anymore.

@abergeron @nouiz @lamblin 

**NB**: I think the last op that may be rewritten into this module is `theano.gpuarray.dnn._RNNSplitParams`. This op does not have parameters, but it also has a variable outputs length, C code here is a little more complicated, and it is not currently a real COp (`c_code()` is redefined).