### PR TITLE
Add debug code to print algo chosen at runtime for cuDNN convolutions.

### DIFF
--- a/theano/gpuarray/dnn_fwd.c
+++ b/theano/gpuarray/dnn_fwd.c
@@ -161,6 +161,15 @@ APPLY_SPECIFIC(conv_fwd)(PyGpuArrayObject *input, PyGpuArrayObject *kerns,
         prev_kern_dims[i] = PyGpuArray_DIM(kerns, i);
       }
     }
+
+    #ifdef DEBUG
+    char algorithm_name[128];
+    if (0 != theano_enum_to_string_cudnnConvolutionFwdAlgo_t(algo, algorithm_name)) {
+        return 1;
+    };
+    // NB: This is printed only when algorithm is chosen at runtime.
+    fprintf(stderr, "(using %s) ", algorithm_name);
+    #endif
   }
 
   /* Only these algos are supported for 3d conv with cuDNN >= V5.1. */


### PR DESCRIPTION
I need it for tests script, but it's better to add it separately so that other people can start debugging too.

This PR adds a code to print algorithm chosen at runtime for fwd and gradinput cuDNN convolutions (already done for gradweight) when theano flag `cmodule.debug` is set to `True`.

This may be useful for @olimastro to help debug cuDNN convolutions with `time_once` !

NB: About `cmodule.debug`, should we modify how this flag is used ? Or is it currently right enough ? I had done an old comment about that here: https://github.com/Theano/Theano/pull/6102#issuecomment-312936201 . @abergeron @lamblin .