### PR TITLE
make variable class new style

### DIFF
--- a/theano/gof/unify.py
+++ b/theano/gof/unify.py
@@ -18,7 +18,7 @@ from theano.gof.utils import ANY_TYPE, comm_guard, FALL_THROUGH, iteritems
 ################################
 
 
-class Variable:
+class Variable(object):
     """
     Serves as a base class of variables for the purpose of unification.
     "Unification" here basically means matching two patterns, see the


### PR DESCRIPTION
In #6111 I introduced the user of `super()` for class initialisation without realising that the parent class `Variable` was old-style.

This PR makes it new-style (alternatively the changes in #6111 could be reverted to use `Variable.__init__` in child classes but I believe using `super()` is more proper - and in Python 3 all classes are new-style).