### PR TITLE
Wrap op params for [Gpu]DimShuffle.

### DIFF
--- a/theano/gpuarray/c_code/dimshuffle.c
+++ b/theano/gpuarray/c_code/dimshuffle.c
@@ -1,0 +1,1 @@
+#section support_code

--- a/theano/gpuarray/c_code/dimshuffle.c
+++ b/theano/gpuarray/c_code/dimshuffle.c
@@ -1,1 +1,81 @@
-#section support_code
+#section support_code_apply
+
+int gpu_dimshuffle(PyGpuArrayObject* input, PyGpuArrayObject** out, PARAMS_TYPE* params) {
+    PyGpuArrayObject *tmp = NULL;
+    npy_intp nd_in = PyArray_SIZE(params->input_broadcastable);
+    npy_intp nd_out = PyArray_SIZE(params->_new_order);
+    npy_int64* new_order = NULL;
+    unsigned int* transposition = NULL;
+    size_t* sh = NULL;
+    int e;
+
+    if (input->ga.nd != nd_in) {
+        PyErr_SetString(PyExc_TypeError, "input nd");
+        return 1;
+    }
+    if (!PyArray_IS_C_CONTIGUOUS(params->_new_order)) {
+        PyErr_SetString(PyExc_RuntimeError, "DimShuffle: param _new_order must be C-contiguous.");
+        return 1;
+    }
+    if (!PyArray_IS_C_CONTIGUOUS(params->transposition)) {
+        PyErr_SetString(PyExc_RuntimeError, "GpuDimShuffle: param transposition must be C-contiguous.");
+        return 1;
+    }
+
+    Py_XDECREF(*out);
+
+    /** Do shuffle. **/
+
+    new_order = (npy_int64*) PyArray_DATA(params->_new_order);
+    transposition = (unsigned int*) malloc(nd_in * sizeof(unsigned int));
+    sh = (size_t*) malloc(nd_out * sizeof(size_t));
+    if (transposition == NULL || sh == NULL) {
+        PyErr_NoMemory();
+        free(transposition);
+        free(sh);
+        return 1;
+    }
+    for (npy_intp i = 0; i < nd_in; ++i) {
+        transposition[i] = ((npy_int64*) PyArray_DATA(params->transposition))[i];
+    }
+    tmp = pygpu_transpose(input, transposition);
+    if (!tmp) {
+        PyErr_SetString(PyExc_RuntimeError, "GpuDimShuffle: unable to transpose input.");
+        free(transposition);
+        free(sh);
+        return 1;
+    }
+    e = 0;
+    for (npy_intp i = 0; i < nd_out; ++i) {
+        if (new_order[i] == -1) {
+            sh[i] = 1;
+        } else {
+            sh[i] = tmp->ga.dimensions[e];
+            ++e;
+        }
+    }
+    *out = pygpu_reshape(tmp, nd_out, sh, GA_ANY_ORDER, 1, -1);
+    Py_DECREF(tmp);
+    free(transposition);
+    free(sh);
+
+    /** End shuffle. **/
+
+    if (*out == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "GpuDimShuffle: unable to reshape output.");
+        return 1;
+    }
+
+    if (!params->inplace) {
+        tmp = pygpu_copy(*out, GA_ANY_ORDER);
+        Py_DECREF(*out);
+        if (!tmp) {
+            PyErr_SetString(PyExc_RuntimeError, "GpuDimShuffle: unable to copy output.");
+            *out = NULL;
+            return 1;
+        }
+        *out = tmp;
+    }
+
+    return 0;
+}

--- a/theano/gpuarray/elemwise.py
+++ b/theano/gpuarray/elemwise.py
@@ -430,7 +430,7 @@ class GpuDimShuffle(HideC, DimShuffle):
             s = "GpuDimShuffle{%s}"
         return s % (','.join(str(x) for x in self.new_order))
 
-    def perform(self, node, inp, out):
+    def perform(self, node, inp, out, params):
         input, = inp
         storage, = out
 

--- a/theano/gpuarray/elemwise.py
+++ b/theano/gpuarray/elemwise.py
@@ -407,12 +407,13 @@ class SupportCodeError(Exception):
     """
 
 
-class GpuDimShuffle(HideC, DimShuffle):
+class GpuDimShuffle(DimShuffle):
     """
     DimShuffle on the GPU.
 
     """
     _f16_ok = True
+    c_func_name = 'gpu_dimshuffle'
 
     def make_node(self, input):
         ctx_name = infer_context_name(input)
@@ -447,66 +448,6 @@ class GpuDimShuffle(HideC, DimShuffle):
             res = res.copy()
 
         storage[0] = res
-
-    def c_support_code_apply(self, node, name):
-        def copy_shape(nd_out):
-            stmts = []
-            e = 0
-            for d in range(nd_out):
-                if d in self.augment:
-                    stmts.append("sh[%s] = 1;" % (d,))
-                else:
-                    stmts.append("sh[%s] = tmp->ga.dimensions[%s];" % (d, e))
-                    e += 1
-            return '\n            '.join(stmts)
-
-        return """
-        static const unsigned int %(name)s_ax[] = {%(shuffle)s};
-
-        static PyGpuArrayObject *%(name)s_f(PyGpuArrayObject *a) {
-            PyGpuArrayObject *res, *tmp;
-            size_t sh[%(nd_out)s];
-
-            tmp = pygpu_transpose(a, %(name)s_ax);
-            if (!tmp) return NULL;
-            %(copy_shape)s
-            res = pygpu_reshape(tmp, %(nd_out)s, sh, GA_ANY_ORDER, 1, -1);
-            Py_DECREF(tmp);
-            return res;
-        }
-        """ % dict(shuffle=', '.join(str(a) for a in (self.shuffle + self.drop)),
-                   name=name, nd_out=len(self.new_order),
-                   copy_shape=copy_shape(len(self.new_order)))
-
-    def c_code(self, node, name, inputs, outputs, sub):
-        d = dict(name=name, fail=sub['fail'], inp=inputs[0], out=outputs[0],
-                 nd=len(self.input_broadcastable))
-        process = """
-        PyGpuArrayObject *tmp = NULL;
-        if (%(inp)s->ga.nd != %(nd)s) {
-            PyErr_SetString(PyExc_TypeError, "input nd");
-            %(fail)s
-        }
-
-        Py_XDECREF(%(out)s);
-        %(out)s = %(name)s_f(%(inp)s);
-        if (%(out)s == NULL) {%(fail)s}
-        """ % d
-
-        if not self.inplace:
-            process += """
-            tmp = pygpu_copy(%(out)s, GA_ANY_ORDER);
-            Py_DECREF(%(out)s);
-            if (!tmp) {
-                %(out)s = NULL;
-                %(fail)s
-            }
-            %(out)s = tmp;
-            """ % d
-        return process
-
-    def c_code_cache_version(self):
-        return (5,)
 
 
 class GpuCAReduceCuda(GpuKernelBase, HideC, CAReduceDtype):
@@ -563,7 +504,7 @@ class GpuCAReduceCuda(GpuKernelBase, HideC, CAReduceDtype):
             reduce_mask = tuple(reduce_mask)
         self.reduce_mask = reduce_mask
 
-        # used to make sure that calls to scalar op
+        # used to make sure that callfs to scalar op
         # have unique name arguments
         self._n_scalar_op_calls = 0
         CAReduceDtype.__init__(self, scalar_op, axis=axis,

--- a/theano/gpuarray/elemwise.py
+++ b/theano/gpuarray/elemwise.py
@@ -504,7 +504,7 @@ class GpuCAReduceCuda(GpuKernelBase, HideC, CAReduceDtype):
             reduce_mask = tuple(reduce_mask)
         self.reduce_mask = reduce_mask
 
-        # used to make sure that callfs to scalar op
+        # used to make sure that calls to scalar op
         # have unique name arguments
         self._n_scalar_op_calls = 0
         CAReduceDtype.__init__(self, scalar_op, axis=axis,

--- a/theano/tensor/c_code/dimshuffle.c
+++ b/theano/tensor/c_code/dimshuffle.c
@@ -1,0 +1,103 @@
+#section support_code_apply
+
+int cpu_dimshuffle(PyArrayObject* input, PyArrayObject** res, PARAMS_TYPE* params) {
+    npy_bool* input_broadcastable;
+    npy_int64* new_order;
+    npy_intp nd_in;
+    npy_intp nd_out;
+    PyArrayObject* basename;
+    npy_intp* dimensions;
+    npy_intp* strides;
+
+    if (!PyArray_IS_C_CONTIGUOUS(params->input_broadcastable)) {
+        PyErr_SetString(PyExc_RuntimeError, "DimShuffle: param input_broadcastable must be C-contiguous.");
+        return 1;
+    }
+    if (!PyArray_IS_C_CONTIGUOUS(params->_new_order)) {
+        PyErr_SetString(PyExc_RuntimeError, "DimShuffle: param _new_order must be C-contiguous.");
+        return 1;
+    }
+    input_broadcastable = (npy_bool*) PyArray_DATA(params->input_broadcastable);
+    new_order = (npy_int64*) PyArray_DATA(params->_new_order);
+    nd_in = PyArray_SIZE(params->input_broadcastable);
+    nd_out = PyArray_SIZE(params->_new_order);
+
+    /* check_input_nd */
+    if (PyArray_NDIM(input) != nd_in) {
+        PyErr_SetString(PyExc_NotImplementedError, "input nd");
+        return 1;
+    }
+
+    /* clear_output */
+    if (*res)
+        Py_XDECREF(*res);
+
+    /* get_base */
+    if (params->inplace) {
+        basename = input;
+        Py_INCREF((PyObject*)basename);
+    } else {
+        basename =
+            (PyArrayObject*)PyArray_FromAny((PyObject*)input,
+                                            NULL, 0, 0, NPY_ARRAY_ALIGNED|NPY_ARRAY_ENSURECOPY, NULL);
+    }
+
+    /* shape_statements and strides_statements */
+    dimensions = (npy_intp*) malloc(nd_out * sizeof(npy_intp));
+    strides = (npy_intp*) malloc(nd_out * sizeof(npy_intp));
+    if (dimensions == NULL || strides == NULL) {
+        PyErr_NoMemory();
+        free(dimensions);
+        free(strides);
+        return 1;
+    };
+
+    for (npy_intp i = 0; i < nd_out; ++i) {
+        if (new_order[i] != -1) {
+            dimensions[i] = PyArray_DIMS(basename)[new_order[i]];
+            strides[i] = PyArray_DIMS(basename)[new_order[i]] == 1 ?
+                            0 : PyArray_STRIDES(basename)[new_order[i]];
+        } else {
+            dimensions[i] = 1;
+            strides[i] = 0;
+        }
+    }
+
+    /* set the strides of the broadcasted dimensions.
+     * This algorithm is from numpy: PyArray_Newshape() in
+     * cvs/numpy/numpy/core/src/multiarraymodule.c */
+    if (nd_out > 0) {
+        if (strides[nd_out - 1] == 0)
+            strides[nd_out - 1] = PyArray_DESCR(basename)->elsize;
+        for (npy_intp i = nd_out - 2; i > -1; --i) {
+            if (strides[i] == 0)
+                strides[i] = strides[i + 1] * dimensions[i + 1];
+        }
+    }
+
+    /* close_bracket */
+    // create a new array.
+    *res = (PyArrayObject*)PyArray_New(&PyArray_Type, nd_out, dimensions,
+                                       PyArray_TYPE(basename), strides,
+                                       PyArray_DATA(basename), PyArray_ITEMSIZE(basename),
+                                       // borrow only the writable flag from the base
+                                       // the NPY_OWNDATA flag will default to 0.
+                                       (NPY_ARRAY_WRITEABLE * PyArray_ISWRITEABLE(basename)),
+                                       NULL);
+
+    if (*res == NULL) {
+        free(dimensions);
+        free(strides);
+        return 1;
+    }
+
+    // recalculate flags: CONTIGUOUS, FORTRAN, ALIGNED
+    PyArray_UpdateFlags(*res, NPY_ARRAY_UPDATE_ALL);
+
+    // we are making a view in both inplace and non-inplace cases
+    PyArray_SetBaseObject(*res, (PyObject*)basename);
+
+    free(strides);
+    free(dimensions);
+    return 0;
+}

--- a/theano/tensor/c_code/dimshuffle.c
+++ b/theano/tensor/c_code/dimshuffle.c
@@ -99,5 +99,6 @@ int cpu_dimshuffle(PyArrayObject* input, PyArrayObject** res, PARAMS_TYPE* param
 
     free(strides);
     free(dimensions);
+
     return 0;
 }

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -139,6 +139,7 @@ class DimShuffle(COp):
         # because of importation issues related to TensorType.
         return ParamsType(input_broadcastable=TensorType(dtype='bool', broadcastable=(False,)),
                           _new_order=theano.tensor.lvector,
+                          transposition=theano.tensor.lvector,
                           inplace=theano.scalar.bool)
 
     @property
@@ -147,6 +148,10 @@ class DimShuffle(COp):
         # self.new_order may contain 'x', which is not a valid integer value.
         # We replace it with -1.
         return [(-1 if x == 'x' else x) for x in self.new_order]
+
+    @property
+    def transposition(self):
+        return self.shuffle + self.drop
 
     def __init__(self, input_broadcastable, new_order, inplace=True):
         COp.__init__(self, [self.c_func_file], self.c_func_name)
@@ -206,8 +211,6 @@ class DimShuffle(COp):
         if not hasattr(self, 'func_files'):
             # Perhaps we are loading an old `Op` version of DimShuffle.
             # Let's just build the COp.
-            self.c_func_file = 'c_code/dimshuffle.c'
-            self.c_func_name = 'cpu_dimshuffle'
             COp.__init__(self, [self.c_func_file], self.c_func_name)
 
     def make_node(self, _input):

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -139,7 +139,7 @@ class DimShuffle(COp):
         # because of importation issues related to TensorType.
         return ParamsType(input_broadcastable=TensorType(dtype='bool', broadcastable=(False,)),
                           _new_order=theano.tensor.lvector,
-                          transposition=theano.tensor.lvector,
+                          transposition=TensorType(dtype='uint32', broadcastable=(False,)),
                           inplace=theano.scalar.bool)
 
     @property

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -9,7 +9,7 @@ import theano
 from theano import gof
 from theano.compat import izip
 from theano.configparser import change_flags
-from theano.gof import Apply, Op, OpenMPOp, ParamsType
+from theano.gof import Apply, Op, COp, OpenMPOp, ParamsType
 from theano import scalar
 from theano.scalar import get_scalar_type
 from theano.printing import pprint
@@ -50,7 +50,7 @@ def TensorConstant(*inputs, **kwargs):
 #   DimShuffle   #
 ##################
 
-class DimShuffle(Op):
+class DimShuffle(COp):
     """
     Allows to reorder the dimensions of a tensor or insert or remove
     broadcastable dimensions.
@@ -130,6 +130,8 @@ class DimShuffle(Op):
     _f16_ok = True
     check_input = False
     __props__ = ("input_broadcastable", "new_order", "inplace")
+    c_func_file = 'c_code/dimshuffle.c'
+    c_func_name = 'cpu_dimshuffle'
 
     @property
     def params_type(self):
@@ -147,6 +149,7 @@ class DimShuffle(Op):
         return [(-1 if x == 'x' else x) for x in self.new_order]
 
     def __init__(self, input_broadcastable, new_order, inplace=True):
+        COp.__init__(self, [self.c_func_file], self.c_func_name)
         self.input_broadcastable = tuple(input_broadcastable)
         self.new_order = tuple(new_order)
         if inplace is True:
@@ -197,6 +200,15 @@ class DimShuffle(Op):
 
         if self.inplace:
             self.view_map = {0: [0]}
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if not hasattr(self, 'func_files'):
+            # Perhaps we are loading an old `Op` version of DimShuffle.
+            # Let's just build the COp.
+            self.c_func_file = 'c_code/dimshuffle.c'
+            self.c_func_name = 'cpu_dimshuffle'
+            COp.__init__(self, [self.c_func_file], self.c_func_name)
 
     def make_node(self, _input):
         input = as_tensor_variable(_input)
@@ -272,119 +284,6 @@ class DimShuffle(Op):
         if None in eval_points:
             return [None]
         return self(*eval_points, **dict(return_list=True))
-
-    def c_code(self, node, name, inp, out, sub):
-        input, = inp
-        res, = out
-        basename = input + '__view_or_copy'
-
-        return """{
-        npy_bool* input_broadcastable;
-        npy_int64* new_order;
-        npy_intp nd_in;
-        npy_intp nd_out;
-        PyArrayObject* %(basename)s;
-        npy_intp* dimensions;
-        npy_intp* strides;
-
-        if (!PyArray_IS_C_CONTIGUOUS(%(params)s->input_broadcastable)) {
-            PyErr_SetString(PyExc_RuntimeError, "DimShuffle: param input_broadcastable must be C-contiguous.");
-            %(just_fail)s
-        }
-        if (!PyArray_IS_F_CONTIGUOUS(%(params)s->_new_order)) {
-            PyErr_SetString(PyExc_RuntimeError, "DimShuffle: param _new_order must be C-contiguous.");
-            %(just_fail)s
-        }
-        input_broadcastable = (npy_bool*) PyArray_DATA(%(params)s->input_broadcastable);
-        new_order = (npy_int64*) PyArray_DATA(%(params)s->_new_order);
-        nd_in = PyArray_SIZE(%(params)s->input_broadcastable);
-        nd_out = PyArray_SIZE(%(params)s->_new_order);
-
-        /* check_input_nd */
-        if (PyArray_NDIM(%(input)s) != nd_in) {
-            PyErr_SetString(PyExc_NotImplementedError, "input nd");
-            %(just_fail)s
-        }
-
-        /* clear_output */
-        if (%(res)s)
-            Py_XDECREF(%(res)s);
-
-        /* get_base */
-        if (%(params)s->inplace) {
-            %(basename)s = %(input)s;
-            Py_INCREF((PyObject*)%(basename)s);
-        } else {
-            %(basename)s =
-                (PyArrayObject*)PyArray_FromAny((PyObject*)%(input)s,
-                                                NULL, 0, 0, NPY_ARRAY_ALIGNED|NPY_ARRAY_ENSURECOPY, NULL);
-        }
-
-        /* shape_statements and strides_statements */
-        dimensions = (npy_intp*) malloc(nd_out * sizeof(npy_intp));
-        strides = (npy_intp*) malloc(nd_out * sizeof(npy_intp));
-        if (dimensions == NULL || strides == NULL) {
-            PyErr_NoMemory();
-            %(fail)s
-        };
-
-        for (npy_intp i = 0; i < nd_out; ++i) {
-            if (new_order[i] != -1) {
-                dimensions[i] = PyArray_DIMS(%(basename)s)[new_order[i]];
-                strides[i] = PyArray_DIMS(%(basename)s)[new_order[i]] == 1 ?
-                                0 : PyArray_STRIDES(%(basename)s)[new_order[i]];
-            } else {
-                dimensions[i] = 1;
-                strides[i] = 0;
-            }
-        }
-
-        /* set the strides of the broadcasted dimensions.
-         * This algorithm is from numpy: PyArray_Newshape() in
-         * cvs/numpy/numpy/core/src/multiarraymodule.c */
-        if (nd_out > 0) {
-            if (strides[nd_out - 1] == 0)
-                strides[nd_out - 1] = PyArray_DESCR(%(basename)s)->elsize;
-            for (npy_intp i = nd_out - 2; i > -1; --i) {
-                if (strides[i] == 0)
-                    strides[i] = strides[i + 1] * dimensions[i + 1];
-            }
-        }
-
-        /* close_bracket */
-        // create a new array.
-        %(res)s = (PyArrayObject*)PyArray_New(&PyArray_Type, nd_out, dimensions,
-                                              PyArray_TYPE(%(basename)s), strides,
-                                              PyArray_DATA(%(basename)s), PyArray_ITEMSIZE(%(basename)s),
-                                              // borrow only the writable flag from the base
-                                              // the NPY_OWNDATA flag will default to 0.
-                                              (NPY_ARRAY_WRITEABLE * PyArray_ISWRITEABLE(%(basename)s)),
-                                              NULL);
-
-        if (%(res)s == NULL) {
-            %(fail)s
-        }
-
-        // recalculate flags: CONTIGUOUS, FORTRAN, ALIGNED
-        PyArray_UpdateFlags(%(res)s, NPY_ARRAY_UPDATE_ALL);
-
-        // we are making a view in both inplace and non-inplace cases
-        PyArray_SetBaseObject(%(res)s, (PyObject*)%(basename)s);
-
-        free(strides);
-        free(dimensions);
-        }""" % dict(input=input, res=res,
-                    basename=basename,
-                    params=sub['params'],
-                    just_fail=sub['fail'],
-                    fail="""
-                    free(strides);
-                    free(dimensions);
-                    %(fail)s
-                    """ % dict(fail=sub['fail']))
-
-    def c_code_cache_version(self):
-        return (4,)
 
     def grad(self, inp, grads):
         x, = inp


### PR DESCRIPTION
As a quick benchmark, running:
```
nosetests -xvs
 theano\tensor\tests\test_basic.py:test_batched_dot
 theano\tensor\tests\test_basic.py:test_batched_dot_not_contiguous
 theano\tensor\tests\test_basic.py:BatchedDotTester
```
With `master` branch (after `theano-cache purge`), 70.428s and 11 compilations for CPU DimShuffle.

With this branch (after `theano-cache purge`), 62.231s and 1 compilation for CPU DimShuffle.

@abergeron @lamblin 