### PR TITLE
Added GpuCublasTriangularSolve and the associated lifter optimizations

### DIFF
--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -74,11 +74,13 @@ def attach_cusolver_handle_to_context(ctx):
         with ctx:
             ctx.cusolver_handle = cusolver.cusolverDnCreate()
 
+
 def attach_cublas_handle_to_context(ctx):
     handle = getattr(ctx, 'cublas_handle', None)
     if handle is None:
         with ctx:
             ctx.cublas_handle = cublas.cublasCreate()
+
 
 # it is a subset of all cases available in slinalg's MATRIX_STRUCTURE
 MATRIX_STRUCTURES_SOLVE = (
@@ -243,6 +245,7 @@ class GpuCusolverSolve(Op):
 
         z[0] = b
 
+
 class GpuCublasTriangularSolve(Op):
     """
     CUBLAS GPU Triangular Solve Op.
@@ -356,6 +359,7 @@ class GpuCublasTriangularSolve(Op):
                                    n, m, alpha, A_ptr, lda, b_ptr, ldb)
 
         x[0] = b
+
 
 def gpu_solve(A, b, A_structure='general', trans='N'):
     if A_structure == 'lower':

--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -249,7 +249,7 @@ class GpuCusolverSolve(Op):
 class GpuCublasTriangularSolve(Op):
     """
     CUBLAS GPU Triangular Solve Op.
-    
+
     Parameters
     ----------
     lower
@@ -282,11 +282,10 @@ class GpuCublasTriangularSolve(Op):
         assert inp1.dtype == 'float32'
         assert inp2.dtype == 'float32'
 
-        return theano.Apply(
-        self, [inp1, inp2],
-        [GpuArrayType('float32',
-                        broadcastable=inp2.broadcastable,
-                        context_name=context_name)()])
+        return theano.Apply(self, [inp1, inp2],
+                            [GpuArrayType('float32',
+                                          broadcastable=inp2.broadcastable,
+                                          context_name=context_name)()])
 
     def prepare_node(self, node, storage_map, compute_map, impl):
         ctx = node.inputs[0].type.context
@@ -295,7 +294,7 @@ class GpuCublasTriangularSolve(Op):
     def perform(self, node, inputs, outputs):
         ctx = node.inputs[0].type.context
 
-        # Solution set 
+        # Solution set
         x = outputs[0]
 
         # Matrix.
@@ -305,8 +304,8 @@ class GpuCublasTriangularSolve(Op):
         b = inputs[1]
 
         assert(len(A.shape) == 2)
-        assert(len(b.shape) in [1,2])
-        
+        assert(len(b.shape) in [1, 2])
+
         # implicitly deal with the difference between C order
         # and fortran order by flipping the trans and lower flags
         lower = not self.lower
@@ -336,7 +335,7 @@ class GpuCublasTriangularSolve(Op):
 
         # solution overwrites right hand side on exit
         b = pygpu.array(b, copy=True, order='F')
-    
+
         A_ptr = A.gpudata
         b_ptr = b.gpudata
 


### PR DESCRIPTION
This is an update of #4007 to use the gpuarray backend. This is an alternative to #6176 that separates the triangular solve into a new op, and deals with the case when the right hand side is a vector (as in #4007).