### PR TITLE
[WIP] Compute the determinant of a matrix on the GPU

### DIFF
--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -15,6 +15,7 @@ from theano.gpuarray import GpuArrayType
 
 from .basic_ops import (CGpuKernelBase, as_gpuarray_variable, gpu_contiguous,
                         infer_context_name)
+from .subtensor import GpuExtractDiag
 from .type import gpu_context_type
 
 try:
@@ -66,6 +67,7 @@ def attach_cusolver_handle_to_context(ctx):
     if handle is None:
         with ctx:
             ctx.cusolver_handle = cusolver.cusolverDnCreate()
+
 
 # it is a subset of all cases available in slinalg's MATRIX_STRUCTURE
 MATRIX_STRUCTURES_SOLVE = (
@@ -353,7 +355,125 @@ def gpu_cholesky(A, lower=True):
     return GpuCholesky(lower)(A)
 
 
-# TODO: add support for float64
+class GpuLU(Op):
+    """
+    CUSOLVER GPU LU factorization Op.
+
+    Given a non-singular square matrix, computes its LU
+    factorization. Useful for computing the matrix determinant
+
+    Parameters
+    ----------
+
+    """
+    __props__ = ('inplace', 'check_output')
+
+    def __init__(self, inplace=False, check_output=True):
+        self.inplace = inplace
+        self.check_output = check_output
+        if self.inplace:
+            self.destroy_map = {0: [0]}
+        super(GpuLU, self).__init__()
+
+    def clone_inplace(self):
+        return self.__class__(lower=self.lower, inplace=True)
+
+    def make_node(self, inp):
+        if not cusolver_available:
+            raise RuntimeError('CUSOLVER is not available and '
+                               'GpuLU Op can not be constructed.')
+        if skcuda.__version__ <= '0.5.1':
+            warnings.warn('The GpuLU op requires scikit-cuda > 0.5.1 to work with CUDA 8')
+        if not pygpu_available:
+            raise RuntimeError('Missing pygpu or triu/tril functions.'
+                               'Install or update libgpuarray.')
+        context_name = infer_context_name(inp)
+
+        inp = as_gpuarray_variable(inp, context_name)
+
+        inp = gpu_contiguous(inp)
+
+        # this op can only operate on float32 matrices
+        # because of current implementation of triu/tril.
+        # TODO: support float64
+        assert inp.ndim == 2
+        assert inp.dtype == 'float32'
+
+        # outputs a scalar
+        return theano.Apply(self, [inp], [inp.type()])
+
+    def prepare_node(self, node, storage_map, compute_map, impl):
+        ctx = node.inputs[0].type.context
+        attach_cusolver_handle_to_context(ctx)
+
+    def perform(self, node, inputs, outputs):
+        context = inputs[0][0].context
+
+        # Input matrix.
+        A = inputs[0]
+
+        l, n = A.shape
+        if l != n:
+            raise ValueError('A must be a square matrix')
+
+        lda = max(1, n)
+
+        # cusolver operates on F ordered matrices
+        if not self.inplace:
+            LU = pygpu.array(A, copy=True, order='F')
+        else:
+            LU = A.T if A.flags['C_CONTIGUOUS'] else A
+
+        LU_ptr = LU.gpudata
+
+        with context:
+            workspace_size = cusolver.cusolverDnSgetrf_bufferSize(
+                context.cusolver_handle, n, n, LU_ptr, lda)
+
+            workspace = pygpu.zeros(workspace_size, dtype='float32',
+                                    context=context)
+
+            pivots = pygpu.zeros(n, dtype='int32', context=context)
+
+            dev_info = pygpu.zeros((1,), dtype='int32', context=context)
+
+            workspace_ptr = workspace.gpudata
+            pivots_ptr = pivots.gpudata
+            dev_info_ptr = dev_info.gpudata
+
+            cusolver.cusolverDnSgetrf(
+                context.cusolver_handle, n, n, LU_ptr, lda, workspace_ptr,
+                pivots_ptr, dev_info_ptr)
+
+            if self.check_output:
+                val_dev_info = np.asarray(dev_info)[0]
+                if val_dev_info > 0:
+                    raise LinAlgError('LU decomposition failed')
+
+        outputs[0][0] = LU
+
+
+def gpu_det(A, inplace=False):
+    """
+        Computes the matrix determinant on the GPU using its LU
+        factorization; i.e. if A = PLU then det(A) = (-1)**p*prod(L)*prod(U),
+        where p is the number of permuted rows defined by P
+    """
+    return GpuExtractDiag(view=True)(GpuLU(inplace=inplace)(A)).prod()
+
+
+def gpu_logdet(A, inplace=False):
+    """
+        Computes the logartihm of the matrix determinant on the GPU using 
+        its LU factorization; i.e. if A = PLU then 
+        det(A) = (-1)**p*prod(L)*prod(U),
+        where p is the number of permuted rows defined by P
+    """
+    return theano.tensor.log(GpuExtractDiag(view=True)(GpuLU(inplace=inplace)(A))).sum()
+
+
+# TODO: add support
+#  for float64
 class GpuMagmaBase(COp):
     """Base class for magma related operations. Add the necessary headers,
     libraries and optionally the location of headers and library.

--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -9,12 +9,15 @@ from numpy.linalg.linalg import LinAlgError
 
 import theano
 from theano import Op, config, tensor
-from theano.scalar import bool as bool_t
+from theano.scalar import (bool as bool_t,
+                           neq as scalar_neq_op,
+                           log as scalar_log_op)
 from theano.gof import COp, ParamsType
 from theano.gpuarray import GpuArrayType
 
 from .basic_ops import (CGpuKernelBase, as_gpuarray_variable, gpu_contiguous,
                         infer_context_name)
+from .elemwise import GpuElemwise
 from .subtensor import GpuExtractDiag
 from .type import gpu_context_type
 
@@ -399,8 +402,11 @@ class GpuLU(Op):
         assert inp.ndim == 2
         assert inp.dtype == 'float32'
 
-        # outputs a scalar
-        return theano.Apply(self, [inp], [inp.type()])
+        # outputs LU in a single matrix, and a pivots array
+        pivots_type = GpuArrayType('int32',
+                                   broadcastable=inp[0].broadcastable,
+                                   context_name=context_name)()
+        return theano.Apply(self, [inp], [inp.type(), pivots_type])
 
     def prepare_node(self, node, storage_map, compute_map, impl):
         ctx = node.inputs[0].type.context
@@ -450,6 +456,8 @@ class GpuLU(Op):
                 if val_dev_info > 0:
                     raise LinAlgError('LU decomposition failed')
 
+            outputs[1][0] = pivots
+
         outputs[0][0] = LU
 
 
@@ -458,18 +466,43 @@ def gpu_det(A, inplace=False):
         Computes the matrix determinant on the GPU using its LU
         factorization; i.e. if A = PLU then det(A) = (-1)**p*prod(L)*prod(U),
         where p is the number of permuted rows defined by P
+
+        Parameters
+        ----------
+        A : square matrix
+
+        Returns
+        -------
+        det : determinant of A
     """
-    return GpuExtractDiag(view=True)(GpuLU(inplace=inplace)(A)).prod()
+    LU, pivots = GpuLU(inplace=inplace)(A)
+    idx = theano.tensor.arange(1, A.shape[0] + 1, dtype=pivots.dtype)
+    p = GpuElemwise(scalar_neq_op)(pivots, idx).sum().astype(A.dtype)
+    diag = GpuExtractDiag(view=True)(LU)
+    det = diag.prod() * ((-1)**(p))
+    return det
 
 
-def gpu_logdet(A, inplace=False):
+def gpu_slogdet(A, inplace=False):
     """
-        Computes the logartihm of the matrix determinant on the GPU using 
-        its LU factorization; i.e. if A = PLU then 
+        Computes the logartihm of the matrix determinant on the GPU using
+        its LU factorization; i.e. if A = PLU then
         det(A) = (-1)**p*prod(L)*prod(U),
         where p is the number of permuted rows defined by P
+
+        Parameters
+        ----------
+        A : square matrix
+
+        Returns
+        -------
+        s, logabsdet : sign of the determinant and log(|det(A)|)
     """
-    return theano.tensor.log(GpuExtractDiag(view=True)(GpuLU(inplace=inplace)(A))).sum()
+    LU, pivots = GpuLU(inplace=inplace)(A)
+    idx = theano.tensor.arange(1, A.shape[0] + 1, dtype=pivots.dtype)
+    p = GpuElemwise(scalar_neq_op)(pivots, idx).sum().astype(A.dtype)
+    logabsdet = GpuElemwise(scalar_log_op)(GpuExtractDiag(view=True)(LU)).sum()
+    return ((-1)**(p)), logabsdet
 
 
 # TODO: add support

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -76,7 +76,8 @@ from .opt_util import alpha_merge, output_merge, pad_dims, unpad_dims
 from .reduction import GpuMaxAndArgmax
 from .linalg import (GpuCusolverSolve, MATRIX_STRUCTURES_SOLVE, GpuCholesky,
                      cusolver_available, GpuMagmaMatrixInverse, gpu_svd,
-                     GpuMagmaCholesky, gpu_qr, GpuMagmaEigh)
+                     GpuMagmaCholesky, gpu_qr, GpuMagmaEigh,
+                     GpuLU, gpu_det)
 from .neighbours import GpuImages2Neibs
 
 _logger = logging.getLogger("theano.gpuarray.opt")
@@ -2122,6 +2123,21 @@ def local_inplace_gpu_solve(node):
                                  inplace=True)(*node.inputs)]
 
 
+#  determinant
+@register_opt('fast_compile')
+@op_lifter([theano.tensor.nlinalg.Det])
+@register_opt2([theano.tensor.nlinalg.Det], 'fast_compile')
+def local_gpu_det(op, context_name, inputs, outputs):
+    if not cusolver_available:
+        return
+    if inputs[0].dtype not in ['float16', 'float32']:
+        return
+    if inputs[0].dtype == 'float16':
+        return gpu_det(inputs[0].astype('float32')).astype('float16')
+    else:
+        return gpu_det(inputs[0])
+
+
 # Cholesky decomposition
 def local_gpu_cholesky(op, context_name, inputs, outputs):
     if not cusolver_available:
@@ -2133,6 +2149,8 @@ def local_gpu_cholesky(op, context_name, inputs, outputs):
         return op(inputs[0].astype('float32')).astype('float16')
 
     return op
+
+
 matrix_ops_db = LocalGroupDB()
 matrix_ops_db2 = LocalGroupDB(local_opt=theano.gof.opt.GraphToGPULocalOptGroup)
 matrix_ops_db2.__name__ = "matrix_ops_db2"

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -77,7 +77,7 @@ from .reduction import GpuMaxAndArgmax
 from .linalg import (GpuCusolverSolve, MATRIX_STRUCTURES_SOLVE, GpuCholesky,
                      cusolver_available, GpuMagmaMatrixInverse, gpu_svd,
                      GpuMagmaCholesky, gpu_qr, GpuMagmaEigh,
-                     GpuLU, gpu_det)
+                     gpu_det)
 from .neighbours import GpuImages2Neibs
 
 _logger = logging.getLogger("theano.gpuarray.opt")


### PR DESCRIPTION
This PR adds a GpuLU op for computing the LU factorization of a square matrix on the GPU. The GpuLU op is used to define the gpu_det and gpu_slogdet helper functions. These functions are used to define lifter optimizations that replace the theano.tensor.nlinalg.Det op with a graph that computes the determinant from the LU factorization as explained here: https://en.wikipedia.org/wiki/LU_decomposition#Computing_the_determinant

For small matrices on a Titan Xp, moving the determinant operation to the GPU is slightly slower than on the CPU. However, moving the determinant operation to the GPU removes a memory transfer, which can result in a significant sppedup when calling the Det op inside a scan loop. For matrices bigger than 1000x1000, the GPU version is faster.

I've marked this as WIP since I believe a better job can be done by writing a GpuDet Op that implements the same algorithm in the Op c_code. I'm looking at how the Magma Ops do this, but I'm not sure how to call cusolver directly from C code.