### PR TITLE
Support more debuggers for PdbBreakpoint

### DIFF
--- a/doc/tutorial/debug_faq.txt
+++ b/doc/tutorial/debug_faq.txt
@@ -608,3 +608,6 @@ Breakpoint during Theano function execution
 
 You can set a breakpoint during the execution of a Theano function with
 :class:`PdbBreakpoint <theano.tests.breakpoint.PdbBreakpoint>`.
+:class:`PdbBreakpoint <theano.tests.breakpoint.PdbBreakpoint>` automatically
+detects available debuggers and uses the first available in the following order:
+`pudb`, `ipdb`, or `pdb`.

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function, division
 import numpy as np
-import pdb
+import imp
 
 import theano
 from theano.gof import Op, Apply
@@ -116,7 +116,16 @@ class PdbBreakpoint(Op):
             print("Their contents can be altered and, when execution")
             print("resumes, the updated values will be used.")
             print("-------------------------------------------------")
-            pdb.set_trace()
+
+            if imp.find_module('pudb'):
+                import pudb
+                pudb.set_trace()
+            elif imp.find_module('ipdb'):
+                import ipdb
+                ipdb.set_trace()
+            else:
+                import pdb
+                pdb.set_trace()
 
             # Take the new values in monitored, cast them back to their
             # original type and store them in the output_storage

--- a/theano/tests/breakpoint.py
+++ b/theano/tests/breakpoint.py
@@ -11,7 +11,8 @@ class PdbBreakpoint(Op):
     """
     This is an identity-like op with the side effect of enforcing a
     conditional breakpoint, inside a theano function, based on a symbolic
-    scalar condition.
+    scalar condition. It automatically detects available debuggers and uses
+    the first available in the following order: `pudb`, `ipdb`, or `pdb`.
 
     :type name: String
     :param name: name of the conditional breakpoint. To be printed when the


### PR DESCRIPTION
`PdbBreakpoint` by default supports only `pdb` debugger which has limited functionality. This pull request adds support for `pudb` or `ipdb` if available.