### PR TITLE
Bump c_code_cache_version for GpuGemv to ensure that new builds use the right C code.

### DIFF
--- a/theano/gpuarray/blas.py
+++ b/theano/gpuarray/blas.py
@@ -140,7 +140,7 @@ class GpuGemv(BlasOp):
         return code
 
     def c_code_cache_version(self):
-        return (8,)
+        return (9,)
 
 gpugemv_no_inplace = GpuGemv(inplace=False)
 gpugemv_inplace = GpuGemv(inplace=True)


### PR DESCRIPTION
#6161 and #6169 both raised the c_code_cache_version for GpuGemv to (8,) and thus the new params code may end up using old cached compiled module which doesn't work.

Fix this by raising the c_code_cache version.