### PR TITLE
Install c_code/* files for every submodule

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ def do_setup():
           },
           package_data={
               '': ['*.txt', '*.rst', '*.cu', '*.cuh', '*.c', '*.sh', '*.pkl',
-                   '*.h', '*.cpp', 'ChangeLog'],
+                   '*.h', '*.cpp', 'ChangeLog', 'c_code/*'],
               'theano.misc': ['*.sh'],
               'theano.d3viz' : ['html/*','css/*','js/*']
           },


### PR DESCRIPTION
Fixes #6222. Closes #6223.

Reading the source code of distutils (https://github.com/python/cpython/blob/master/Lib/distutils/command/build_py.py#L97-L132), I found that a much simpler option is to make use of the `''` entry in `package_data` -- it specifies globbing patterns that are applied to every package specified in `packages`. We can just add `c_code/*` there.