### PR TITLE
Update doc for package parameterized.

### DIFF
--- a/doc/install_windows.txt
+++ b/doc/install_windows.txt
@@ -24,12 +24,18 @@ Install requirements and optional packages
 
 .. code-block:: bash
 
-    conda install numpy scipy mkl-service libpython <m2w64-toolchain> <nose> <parameterized> <sphinx> <pydot-ng>
+    conda install numpy scipy mkl-service libpython <m2w64-toolchain> <nose> <sphinx> <pydot-ng>
 
 .. note::
 
     * Arguments between <...> are optional.
     * ``m2w64-toolchain`` package provides a fully-compatible version of GCC and is then highly recommended.
+
+Package ``parameterized`` is also optional but may be required for unit testing. It is available via ``pip``.
+
+.. code-block:: bash
+
+    pip install parameterized
 
 .. _gpu_windows:
 

--- a/doc/requirements.inc
+++ b/doc/requirements.inc
@@ -80,6 +80,11 @@ Install requirements and optional packages
 
 * Arguments between <...> are optional.
 
+Package ``parameterized`` is also optional but may be required for unit testing. It is available via ``pip``.
+
+.. code-block:: bash
+
+    pip install parameterized
 
 Install and configure the GPU drivers (recommended)
 ---------------------------------------------------


### PR DESCRIPTION
About #6209 , it seems that package `parameterized` is not available in conda.

On Windows:
```batch
(python2) C:\Users\notoraptor\mila\dev\git\theano>conda install parameterized
Fetching package metadata ...........

PackageNotFoundError: Package missing in current win-64 channels:
  - parameterized

Close matches found; did you mean one of these?

    parameterized: nose-parameterized


(python2) C:\Users\notoraptor\mila\dev\git\theano>conda search parameterized
Fetching package metadata ...........
nose-parameterized           0.5.0                    py27_0  defaults
                             0.5.0                    py34_0  defaults
                             0.5.0                    py35_0  defaults
                             0.5.0                    py36_0  defaults
                             0.6.0                    py27_0  defaults
                             0.6.0                    py35_0  defaults
                             0.6.0                    py36_0  defaults
```

On Linux:
```
[SLURM] boccoset@leto52:~$ conda install parameterized
Fetching package metadata .........


PackageNotFoundError: Package missing in current linux-64 channels:
  - parameterized

Close matches found; did you mean one of these?

    parameterized: nose-parameterized


[SLURM] boccoset@leto52:~$ conda search parameterized
Fetching package metadata .........
nose-parameterized           0.5.0                    py27_0  defaults
                             0.5.0                    py36_0  defaults
                             0.5.0                    py35_0  defaults
                             0.5.0                    py34_0  defaults
                             0.6.0                    py36_0  defaults
                             0.6.0                    py35_0  defaults
                             0.6.0                    py27_0  defaults
```

This PR update doc to tell users that package `parameterized` is available via `pip` if they want to install it.

@nouiz @lamblin 