### PR TITLE
Add deprecation warning for the softmax and logsoftmax vector case

### DIFF
--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -429,6 +429,10 @@ class Softmax(gof.Op):
             raise ValueError('x must be 1-d or 2-d tensor of floats. Got %s' %
                              x.type)
         if x.ndim == 1:
+            warnings.warn("DEPRECATION: If x is a vector, Softmax will not automatically pad x "
+                          "anymore in next releases. If you need it, please do it manually. The "
+                          "vector case is gonna be supported soon and the output will be a vector.",
+                          stacklevel=4)
             x = tensor.shape_padleft(x, n_ones=1)
 
         return Apply(self, [x], [x.type()])
@@ -613,6 +617,10 @@ class LogSoftmax(gof.Op):
             raise ValueError('x must be 1-d or 2-d tensor of floats. Got %s' %
                              x.type)
         if x.ndim == 1:
+            warnings.warn("DEPRECATION: If x is a vector, LogSoftmax will not automatically pad x "
+                          "anymore in next releases. If you need it, please do it manually. The "
+                          "vector case is gonna be supported soon and the output will be a vector.",
+                          stacklevel=4)
             x = tensor.shape_padleft(x, n_ones=1)
 
         return Apply(self, [x], [x.type()])


### PR DESCRIPTION
Since, for the next versions of Theano PR #6132 , we'll handle the vector case inside the softmax and logsoftmax op, we'll notify the user that the padding will be removed and that the output will be a vector instead of a matrix. @ReyhaneAskari @lamblin @nouiz 