### PR TITLE
Use sha256 for config hash to be FIPS compliant and make Theano cache more forward compatible

### DIFF
--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -1208,9 +1208,7 @@ AddConfigVar('cmodule.age_thresh_use',
 AddConfigVar('cmodule.debug',
              "If True, define a DEBUG macro (if not exists) for any compiled C code.",
              BoolParam(False),
-             # Do not add it in the c key when we keep use the old default.
-             # To do not recompile for no good reason.
-             in_c_key=lambda: theano.config.cmodule.debug)
+             in_c_key=True)
 
 
 def default_blas_ldflags():

--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -185,9 +185,12 @@ def _config_print(thing, buf, print_doc=True):
 
 def get_config_md5():
     """
-    Return a string md5 of the current config options. It should be such that
-    we can safely assume that two different config setups will lead to two
-    different strings.
+    Return a string sha256 of the current config options. hash_from_code uses
+	sha256, and not md5. Updated in PR#5916. Function names will be properly
+	updated in future release. 
+	
+	The string should be such that we can safely assume that two different 
+	config setups will lead to two different strings.
 
     We only take into account config options for which `in_c_key` is True.
     """

--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -186,11 +186,11 @@ def _config_print(thing, buf, print_doc=True):
 def get_config_md5():
     """
     Return a string sha256 of the current config options. hash_from_code uses
-	sha256, and not md5. Updated in PR#5916. Function names will be properly
-	updated in future release. 
-	
-	The string should be such that we can safely assume that two different 
-	config setups will lead to two different strings.
+    sha256, and not md5. Updated in PR#5916. Function names will be properly
+    updated in future release.
+
+    The string should be such that we can safely assume that two different
+    config setups will lead to two different strings.
 
     We only take into account config options for which `in_c_key` is True.
     """

--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -183,11 +183,10 @@ def _config_print(thing, buf, print_doc=True):
         print("", file=buf)
 
 
-def get_config_md5():
+def get_config_hash():
     """
-    Return a string sha256 of the current config options. hash_from_code uses
-    sha256, and not md5. Updated in PR#5916. Function names will be properly
-    updated in future release.
+    Return a string sha256 of the current config options. In the past,
+    it was md5.
 
     The string should be such that we can safely assume that two different
     config setups will lead to two different strings.

--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -193,16 +193,7 @@ def get_config_hash():
 
     We only take into account config options for which `in_c_key` is True.
     """
-    all_opts = []
-    for c in _config_var_list:
-        if callable(c.in_c_key):
-            i = c.in_c_key()
-        else:
-            i = c.in_c_key
-        if i:
-            all_opts.append(c)
-
-    all_opts = sorted(all_opts,
+    all_opts = sorted([c for c in _config_var_list if c.in_c_key],
                       key=lambda cv: cv.fullname)
     return theano.gof.utils.hash_from_code('\n'.join(
         ['%s = %s' % (cv.fullname, cv.__get__(True, None)) for cv in all_opts]))

--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -1236,8 +1236,7 @@ class CLinker(link.Linker):
             (opK, input_signatureK, output_signatureK),
         }}}
 
-        Note that config hash now uses sha256, and not md5. Function names will
-        updated in a future release to reflect the use of hashlib.sha256.
+        Note that config hash now uses sha256, and not md5.
 
         The signature is a tuple, some elements of which are sub-tuples.
 
@@ -1385,8 +1384,7 @@ class CLinker(link.Linker):
         # can lead to a different compiled file with the same source code.
 
         # NOTE: config md5 is not using md5 hash, but sha256 instead. Function
-        # names and string instances of md5 will be updated at a later release.
-        # See PR#5916 for details.
+        # string instances of md5 will be updated at a later release.
         if insert_config_hash:
             sig.append('md5:' + theano.configparser.get_config_hash())
         else:

--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -1444,6 +1444,8 @@ class CLinker(link.Linker):
         for node_pos, node in enumerate(order):
             if hasattr(node.op, 'c_code_cache_version_apply'):
                 version.append(node.op.c_code_cache_version_apply(node))
+            if hasattr(node.op, '__props__'):
+                version.append(node.op.__props__)
             for i in node.inputs:
                 version.append(i.type.c_code_cache_version())
             for o in node.outputs:

--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -1388,7 +1388,7 @@ class CLinker(link.Linker):
         # names and string instances of md5 will be updated at a later release.
         # See PR#5916 for details.
         if insert_config_hash:
-            sig.append('md5:' + theano.configparser.get_config_md5())
+            sig.append('md5:' + theano.configparser.get_config_hash())
         else:
             sig.append('md5: <omitted>')
 

--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -1301,7 +1301,7 @@ class CLinker(link.Linker):
 
     def cmodule_key_variables(self, inputs, outputs, no_recycling,
                               compile_args=None, libraries=None,
-                              header_dirs=None, insert_config_md5=True,
+                              header_dirs=None, insert_config_hash=True,
                               c_compiler=None):
 
         # Assemble a dummy fgraph using the provided inputs and outputs. It is
@@ -1324,11 +1324,11 @@ class CLinker(link.Linker):
 
         fgraph = FakeFunctionGraph(inputs, outputs)
         return self.cmodule_key_(fgraph, no_recycling, compile_args,
-                                 libraries, header_dirs, insert_config_md5,
+                                 libraries, header_dirs, insert_config_hash,
                                  c_compiler)
 
     def cmodule_key_(self, fgraph, no_recycling, compile_args=None,
-                     libraries=None, header_dirs=None, insert_config_md5=True,
+                     libraries=None, header_dirs=None, insert_config_hash=True,
                      c_compiler=None):
         """
         Do the actual computation of cmodule_key in a static method
@@ -1383,11 +1383,11 @@ class CLinker(link.Linker):
         # parameters from the rest of the key. If you want to add more key
         # elements, they should be before this md5 hash if and only if they
         # can lead to a different compiled file with the same source code.
-		
-	# NOTE: config md5 is not using md5 hash, but sha256 instead. Function
-	# names and string instances of md5 will be updated at a later release. 
-	# See PR#5916 for details.
-        if insert_config_md5:
+
+        # NOTE: config md5 is not using md5 hash, but sha256 instead. Function
+        # names and string instances of md5 will be updated at a later release.
+        # See PR#5916 for details.
+        if insert_config_hash:
             sig.append('md5:' + theano.configparser.get_config_md5())
         else:
             sig.append('md5: <omitted>')

--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -1229,16 +1229,16 @@ class CLinker(link.Linker):
         The signature has the following form:
         {{{
             'CLinker.cmodule_key', compilation args, libraries,
-            header_dirs, numpy ABI version, config md5,
+            header_dirs, numpy ABI version, config hash,
             (op0, input_signature0, output_signature0),
             (op1, input_signature1, output_signature1),
             ...
             (opK, input_signatureK, output_signatureK),
         }}}
 
-	Note that config md5 uses sha256, and not md5. Function names will
-	updated in a future release to reflect the use of hashlib.sha256. 
-		
+        Note that config hash now uses sha256, and not md5. Function names will
+        updated in a future release to reflect the use of hashlib.sha256.
+
         The signature is a tuple, some elements of which are sub-tuples.
 
         The outer tuple has a brief header, containing the compilation options
@@ -1350,7 +1350,7 @@ class CLinker(link.Linker):
         constant_ids = dict()
         op_pos = {}  # Apply -> topological position
 
-        # First we put the header, compile_args, library names and config md5
+        # First we put the header, compile_args, library names and config hash
         # into the signature.
         sig = ['CLinker.cmodule_key']  # will be cast to tuple on return
         if compile_args is not None:

--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -1236,10 +1236,13 @@ class CLinker(link.Linker):
             (opK, input_signatureK, output_signatureK),
         }}}
 
+		Note that config md5 uses sha256, and not md5. Function names will
+		updated in a future release to reflect the use of hashlib.sha256. 
+		
         The signature is a tuple, some elements of which are sub-tuples.
 
         The outer tuple has a brief header, containing the compilation options
-        passed to the compiler, the libraries to link against, an md5 hash
+        passed to the compiler, the libraries to link against, a sha256 hash
         of theano.config (for all config options where "in_c_key" is True).
         It is followed by elements for every node in the topological ordering
         of `self.fgraph`.
@@ -1376,6 +1379,10 @@ class CLinker(link.Linker):
         if c_compiler:
             sig.append('c_compiler_str=' + c_compiler.version_str())
 
+		# NOTE: config md5 is not using md5 hash, but sha256 instead. Function
+		# names and string instances of md5 will be updated at a later release. 
+		# See PR#5916 for details.
+		
         # IMPORTANT: The 'md5' prefix is used to isolate the compilation
         # parameters from the rest of the key. If you want to add more key
         # elements, they should be before this md5 hash if and only if they

--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -1387,6 +1387,10 @@ class CLinker(link.Linker):
         # parameters from the rest of the key. If you want to add more key
         # elements, they should be before this md5 hash if and only if they
         # can lead to a different compiled file with the same source code.
+		
+		# NOTE: config md5 is not using md5 hash, but sha256 instead. Function
+		# names and string instances of md5 will be updated at a later release. 
+		# See PR#5916 for details.
         if insert_config_md5:
             sig.append('md5:' + theano.configparser.get_config_md5())
         else:

--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -1236,8 +1236,8 @@ class CLinker(link.Linker):
             (opK, input_signatureK, output_signatureK),
         }}}
 
-		Note that config md5 uses sha256, and not md5. Function names will
-		updated in a future release to reflect the use of hashlib.sha256. 
+	Note that config md5 uses sha256, and not md5. Function names will
+	updated in a future release to reflect the use of hashlib.sha256. 
 		
         The signature is a tuple, some elements of which are sub-tuples.
 
@@ -1379,18 +1379,14 @@ class CLinker(link.Linker):
         if c_compiler:
             sig.append('c_compiler_str=' + c_compiler.version_str())
 
-		# NOTE: config md5 is not using md5 hash, but sha256 instead. Function
-		# names and string instances of md5 will be updated at a later release. 
-		# See PR#5916 for details.
-		
         # IMPORTANT: The 'md5' prefix is used to isolate the compilation
         # parameters from the rest of the key. If you want to add more key
         # elements, they should be before this md5 hash if and only if they
         # can lead to a different compiled file with the same source code.
 		
-		# NOTE: config md5 is not using md5 hash, but sha256 instead. Function
-		# names and string instances of md5 will be updated at a later release. 
-		# See PR#5916 for details.
+	# NOTE: config md5 is not using md5 hash, but sha256 instead. Function
+	# names and string instances of md5 will be updated at a later release. 
+	# See PR#5916 for details.
         if insert_config_md5:
             sig.append('md5:' + theano.configparser.get_config_md5())
         else:

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -377,7 +377,7 @@ def is_same_entry(entry_1, entry_2):
 
 def get_module_hash(src_code, key):
     """
-    Return a SHA256 hash that uniquely identifies a module.
+    Return a SHA256 (for FIPS compatibility) hash that uniquely identifies a module.
 
     This hash takes into account:
         1. The C source code of the module (`src_code`).

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -416,10 +416,10 @@ def get_module_hash(src_code, key):
             to_hash += list(key_element)
         elif isinstance(key_element, string_types):
             if key_element.startswith('md5:'):
-                # This is actually a sha256 hash of the config options. 
-				# Ref PR#5916. String and function names will be updated in 
-				# future release.
-				# We can stop here.
+                # This is actually a sha256 hash of the config options.
+                # Ref PR#5916. String and function names will be updated in
+                # future release.
+                # We can stop here.
                 break
             elif (key_element.startswith('NPY_ABI_VERSION=0x') or
                   key_element.startswith('c_compiler_str=')):
@@ -449,7 +449,7 @@ def get_safe_part(key):
     assert version
 
     # Find the hash part, which is using sha256, not md5.
-	# Instances of md5 will be replaced in future release.
+    # Instances of md5 will be replaced in future release.
     c_link_key = key[1]
     # In case in the future, we don't have an md5 part and we have
     # such stuff in the cache.  In that case, we can set None, and the

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -377,7 +377,7 @@ def is_same_entry(entry_1, entry_2):
 
 def get_module_hash(src_code, key):
     """
-    Return an MD5 hash that uniquely identifies a module.
+    Return a SHA256 hash that uniquely identifies a module.
 
     This hash takes into account:
         1. The C source code of the module (`src_code`).
@@ -416,8 +416,10 @@ def get_module_hash(src_code, key):
             to_hash += list(key_element)
         elif isinstance(key_element, string_types):
             if key_element.startswith('md5:'):
-                # This is the md5 hash of the config options. We can stop
-                # here.
+                # This is actually a sha256 hash of the config options. 
+				# Ref PR#5916. String and function names will be updated in 
+				# future release.
+				# We can stop here.
                 break
             elif (key_element.startswith('NPY_ABI_VERSION=0x') or
                   key_element.startswith('c_compiler_str=')):
@@ -435,17 +437,19 @@ def get_safe_part(key):
 
     This tuple should only contain objects whose __eq__ and __hash__ methods
     can be trusted (currently: the version part of the key, as well as the
-    md5 hash of the config options).
+    SHA256 hash of the config options).
     It is used to reduce the amount of key comparisons one has to go through
     in order to find broken keys (i.e. keys with bad implementations of __eq__
     or __hash__).
+
 
     """
     version = key[0]
     # This function should only be called on versioned keys.
     assert version
 
-    # Find the md5 hash part.
+    # Find the hash part, which is using sha256, not md5.
+	# Instances of md5 will be replaced in future release.
     c_link_key = key[1]
     # In case in the future, we don't have an md5 part and we have
     # such stuff in the cache.  In that case, we can set None, and the

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -377,7 +377,7 @@ def is_same_entry(entry_1, entry_2):
 
 def get_module_hash(src_code, key):
     """
-    Return a SHA256 (for FIPS compatibility) hash that uniquely identifies a module.
+    Return a SHA256 hash that uniquely identifies a module.
 
     This hash takes into account:
         1. The C source code of the module (`src_code`).
@@ -416,11 +416,10 @@ def get_module_hash(src_code, key):
             to_hash += list(key_element)
         elif isinstance(key_element, string_types):
             if (key_element.startswith('md5:') or
-                    key_element.startswith('sha256:') or
                     key_element.startswith('hash:')):
                 # This is actually a sha256 hash of the config options.
                 # Currently, we still keep md5 to don't break old Theano.
-                # We add 'sha256:' and 'hash:' so that when we change it in
+                # We add 'hash:' so that when we change it in
                 # the futur, it won't break this version of Theano.
                 break
             elif (key_element.startswith('NPY_ABI_VERSION=0x') or
@@ -452,7 +451,7 @@ def get_safe_part(key):
 
     # Find the hash part. This is actually a sha256 hash of the config
     # options.  Currently, we still keep md5 to don't break old
-    # Theano.  We add 'sha256:' and 'hash:' so that when we change it
+    # Theano.  We add 'hash:' so that when we change it
     # in the futur, it won't break this version of Theano.
     c_link_key = key[1]
     # In case in the future, we don't have an md5 part and we have
@@ -463,9 +462,6 @@ def get_safe_part(key):
         if isinstance(key_element, string_types):
             if key_element.startswith('md5:'):
                 hash = key_element[4:]
-                break
-            elif key_element.startswith('sha256:'):
-                hash = key_element[7:]
                 break
             elif key_element.startswith('hash:'):
                 hash = key_element[5:]

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1252,7 +1252,7 @@ class ModuleCache(object):
                 "Ops. The file is: %s. The key is: %s" % (msg, key_pkl, key))
         # Also verify that there exists no other loaded key that would be equal
         # to this key. In order to speed things up, we only compare to keys
-        # with the same version part and config md5, since we can assume this
+        # with the same version part and config hash, since we can assume this
         # part of the key is not broken.
         for other in self.similar_keys.get(get_safe_part(key), []):
             if other is not key and other == key and hash(other) != hash(key):

--- a/theano/gof/params_type.py
+++ b/theano/gof/params_type.py
@@ -295,8 +295,8 @@ class ParamsType(Type):
         # (see c_support_code() below).
         fields_string = ','.join(self.fields).encode('utf-8')
         types_string = ','.join(str(t) for t in self.types).encode('utf-8')
-        fields_hex = hashlib.md5(fields_string).hexdigest()
-        types_hex = hashlib.md5(types_string).hexdigest()
+        fields_hex = hashlib.md5(fields_string, usedforsecurity=False).hexdigest()
+        types_hex = hashlib.md5(types_string, usedforsecurity=False).hexdigest()
         return '_Params_%s_%s' % (fields_hex, types_hex)
 
     def has_type(self, theano_type):

--- a/theano/gof/params_type.py
+++ b/theano/gof/params_type.py
@@ -295,8 +295,8 @@ class ParamsType(Type):
         # (see c_support_code() below).
         fields_string = ','.join(self.fields).encode('utf-8')
         types_string = ','.join(str(t) for t in self.types).encode('utf-8')
-        fields_hex = hashlib.md5(fields_string, usedforsecurity=False).hexdigest()
-        types_hex = hashlib.md5(types_string, usedforsecurity=False).hexdigest()
+        fields_hex = hashlib.sha256(fields_string).hexdigest()
+        types_hex = hashlib.sha256(types_string).hexdigest()
         return '_Params_%s_%s' % (fields_hex, types_hex)
 
     def has_type(self, theano_type):

--- a/theano/gof/utils.py
+++ b/theano/gof/utils.py
@@ -552,17 +552,17 @@ if PY3:
             msg = msg.encode()
         # Python 3 does not like module names that start with
         # a digit.
-        return 'm' + hashlib.md5(msg).hexdigest()
+        return 'm' + hashlib.md5(msg, usedforsecurity=False).hexdigest()
 
 else:
     import hashlib
 
     def hash_from_code(msg):
         try:
-            return hashlib.md5(msg).hexdigest()
+            return hashlib.md5(msg, usedforsecurity=False).hexdigest()
         except TypeError:
             assert isinstance(msg, np.ndarray)
-            return hashlib.md5(np.getbuffer(msg)).hexdigest()
+            return hashlib.md5(np.getbuffer(msg), usedforsecurity=False).hexdigest()
 
 
 def hash_from_file(file_path):

--- a/theano/gof/utils.py
+++ b/theano/gof/utils.py
@@ -546,23 +546,23 @@ if PY3:
     import hashlib
 
     def hash_from_code(msg):
-        # hashlib.md5() requires an object that supports buffer interface,
+        # hashlib.sha256() requires an object that supports buffer interface,
         # but Python 3 (unicode) strings don't.
         if isinstance(msg, str):
             msg = msg.encode()
         # Python 3 does not like module names that start with
         # a digit.
-        return 'm' + hashlib.md5(msg, usedforsecurity=False).hexdigest()
+        return 'm' + hashlib.sha256(msg).hexdigest()
 
 else:
     import hashlib
 
     def hash_from_code(msg):
         try:
-            return hashlib.md5(msg, usedforsecurity=False).hexdigest()
+            return hashlib.sha256(msg).hexdigest()
         except TypeError:
             assert isinstance(msg, np.ndarray)
-            return hashlib.md5(np.getbuffer(msg), usedforsecurity=False).hexdigest()
+            return hashlib.sha256(np.getbuffer(msg)).hexdigest()
 
 
 def hash_from_file(file_path):

--- a/theano/gof/utils.py
+++ b/theano/gof/utils.py
@@ -567,7 +567,7 @@ else:
 
 def hash_from_file(file_path):
     """
-    Return the MD5 hash of a file.
+    Return the SHA256 hash of a file.
 
     """
     with open(file_path, 'rb') as f:

--- a/theano/printing.py
+++ b/theano/printing.py
@@ -1221,7 +1221,7 @@ def var_descriptor(obj, _prev_obs=None, _tag_generator=None):
         name = '<ndarray:'
         name += 'strides=[' + ','.join(str(stride)
                                        for stride in obj.strides) + ']'
-        name += ',digest=' + hashlib.md5(obj, usedforsecurity=False).hexdigest() + '>'
+        name += ',digest=' + hashlib.sha256(obj).hexdigest() + '>'
     elif hasattr(obj, 'owner') and obj.owner is not None:
         name = str(obj.owner.op) + '('
         name += ','.join(var_descriptor(ipt,
@@ -1265,7 +1265,7 @@ def hex_digest(x):
     Returns a short, mostly hexadecimal hash of a numpy ndarray
     """
     assert isinstance(x, np.ndarray)
-    rval = hashlib.md5(x.tostring(), usedforsecurity=False).hexdigest()
+    rval = hashlib.sha256(x.tostring()).hexdigest()
     # hex digest must be annotated with strides to avoid collisions
     # because the buffer interface only exposes the raw data, not
     # any info about the semantics of how that data should be arranged

--- a/theano/printing.py
+++ b/theano/printing.py
@@ -1221,7 +1221,7 @@ def var_descriptor(obj, _prev_obs=None, _tag_generator=None):
         name = '<ndarray:'
         name += 'strides=[' + ','.join(str(stride)
                                        for stride in obj.strides) + ']'
-        name += ',digest=' + hashlib.md5(obj).hexdigest() + '>'
+        name += ',digest=' + hashlib.md5(obj, usedforsecurity=False).hexdigest() + '>'
     elif hasattr(obj, 'owner') and obj.owner is not None:
         name = str(obj.owner.op) + '('
         name += ','.join(var_descriptor(ipt,
@@ -1265,7 +1265,7 @@ def hex_digest(x):
     Returns a short, mostly hexadecimal hash of a numpy ndarray
     """
     assert isinstance(x, np.ndarray)
-    rval = hashlib.md5(x.tostring()).hexdigest()
+    rval = hashlib.md5(x.tostring(), usedforsecurity=False).hexdigest()
     # hex digest must be annotated with strides to avoid collisions
     # because the buffer interface only exposes the raw data, not
     # any info about the semantics of how that data should be arranged

--- a/theano/sparse/utils.py
+++ b/theano/sparse/utils.py
@@ -9,7 +9,7 @@ def hash_from_sparse(data):
     # We also need to add the dtype to make the distinction between
     # uint32 and int32 of zeros with the same shape.
 
-    # Python hash is not strong, so I always use md5. To avoid having a too
+    # Python hash is not strong, so use sha256 instead. To avoid having a too
     # long hash, I call it again on the contatenation of all parts.
     return hash_from_code(hash_from_code(data.data) +
                           hash_from_code(data.indices) +

--- a/theano/tensor/utils.py
+++ b/theano/tensor/utils.py
@@ -19,8 +19,9 @@ def hash_from_ndarray(data):
     # We also need to add the dtype to make the distinction between
     # uint32 and int32 of zeros with the same shape and strides.
 
-    # python hash are not strong, so I always use md5 in order not to have a
-    # too long hash, I call it again on the concatenation of all parts.
+    # python hash are not strong, so use sha256 (md5 is not
+    # FIPS compatible). To not have too long of hash, I call it again on 
+	# the concatenation of all parts.
     if not data.flags["C_CONTIGUOUS"]:
         # hash_from_code needs a C-contiguous array.
         data = np.ascontiguousarray(data)

--- a/theano/tensor/utils.py
+++ b/theano/tensor/utils.py
@@ -20,8 +20,8 @@ def hash_from_ndarray(data):
     # uint32 and int32 of zeros with the same shape and strides.
 
     # python hash are not strong, so use sha256 (md5 is not
-    # FIPS compatible). To not have too long of hash, I call it again on 
-	# the concatenation of all parts.
+    # FIPS compatible). To not have too long of hash, I call it again on
+    # the concatenation of all parts.
     if not data.flags["C_CONTIGUOUS"]:
         # hash_from_code needs a C-contiguous array.
         data = np.ascontiguousarray(data)

--- a/theano/tests/record.py
+++ b/theano/tests/record.py
@@ -112,7 +112,7 @@ class Record(object):
 class RecordMode(Mode):
     """
     Records all computations done with a function in a file at output_path.
-    Writes into the file the index of each apply node and md5 digests of the
+    Writes into the file the index of each apply node and sha256 digests of the
     numpy ndarrays it receives as inputs and produces as output.
 
     Example:


### PR DESCRIPTION
The first part (sha256) if the rebase/finish up from: https://github.com/Theano/Theano/pull/5916

As this force the recompilation of all c code, I also include in this PR gh-6068 to have only 1 PR that force the recompilation. This commit help the cache don't collide if we add props to an op but forget to bump the version number.