### PR TITLE
(small fix) use `os.remove` instead of system `rm` command

### DIFF
--- a/theano/gof/tests/test_graph_opt_caching.py
+++ b/theano/gof/tests/test_graph_opt_caching.py
@@ -8,8 +8,8 @@ floatX = 'float32'
 
 
 def test_graph_opt_caching():
-    opt_db_file = theano.config.compiledir + '/optimized_graphs.pkl'
-    os.system('rm %s' % opt_db_file)
+    opt_db_file = os.path.join(theano.config.compiledir, 'optimized_graphs.pkl')
+    os.remove(opt_db_file)
 
     mode = theano.config.mode
     if mode in ["DEBUG_MODE", "DebugMode"]:


### PR DESCRIPTION
Reported in #6284 .

@nouiz @abergeron 