### PR TITLE
Support NumPy 1.13

### DIFF
--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -520,10 +520,14 @@ class _tensor_py_operators(object):
             args[ellipsis_at: ellipsis_at + 1] = (
                 [slice(None)] * (self.ndim - index_dim_count))
 
+        def is_empty_array(val):
+            return ((isinstance(val, (tuple, list)) and len(val) == 0) or
+                    (isinstance(val, np.ndarray) and val.size == 0))
+
         # Force input to be int64 datatype if input is an empty list or tuple
         # Else leave it as is if it is a real number
         args = tuple([np.array(inp, dtype=np.int64)
-                      if(inp == [] or inp == ()) else inp for inp in args])
+                      if(is_empty_array(inp)) else inp for inp in args])
         # Convert python literals to theano constants
         args = theano.tensor.subtensor.make_constant(args)
         # Determine if advanced indexing is needed or not


### PR DESCRIPTION
fix #6217 .

NumPy versions prior to 1.13 should print a `FutureWarning` when a comparaison `array == None` is done:
```
(test) C:\Users\notoraptor\mila\dev\git\theano>python -c "import numpy; print(numpy.__version__); a = numpy.arange(10); print(a == None)"
1.12.1
-c:1: FutureWarning: comparison to `None` will result in an elementwise object comparison in the future.
False
```

So, as a first check, I looked for `FutureWarning` into a previous successful CI testing, in both Jenkins and Travis:
- http://earlgrey.iro.umontreal.ca:8080/job/Theano_PR/616/console
- https://travis-ci.org/Theano/Theano/builds/263080988

As results:
- There are no `FutureWarning` messages in Jenkins console output.
- There are 4 `FutureWarning` messages in Travis tests, but all come frome SciPy (not Theano), via the same test `theano.sparse.tests.test_basic:Test_getitem.test_GetItem2D`. These are related Travis log files:
  - https://travis-ci.org/Theano/Theano/jobs/263080993
  - https://travis-ci.org/Theano/Theano/jobs/263080994
  - https://travis-ci.org/Theano/Theano/jobs/263081005
  - https://travis-ci.org/Theano/Theano/jobs/263081006

And I don't find any `== None`, `!= None`, `None ==` or `None !=` in Theano code. So, it seems that comparison `array == None` is not currently used in Theano.

What I suggest is to run Travis with NumPy 1.13, and then check if some errors occur. This PR contains a temporar commit that should install NumPy 1.13 for Travis tests. Let's see if all tests pass.

What do you think, @nouiz ?