### PR TITLE
Flag to disable pickling test values

### DIFF
--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -55,6 +55,13 @@ AddConfigVar('warn_float64',
              in_c_key=False,
              )
 
+AddConfigVar('pickle_test_value',
+             "Dump test values while pickling model. "
+             "If True, test values will be dumped with model.",
+             BoolParam(False),
+             in_c_key=False,
+             )
+
 AddConfigVar('cast_policy',
              'Rules for implicit type casting',
              EnumStr('custom', 'numpy+floatX',

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -58,7 +58,7 @@ AddConfigVar('warn_float64',
 AddConfigVar('pickle_test_value',
              "Dump test values while pickling model. "
              "If True, test values will be dumped with model.",
-             BoolParam(False),
+             BoolParam(True),
              in_c_key=False,
              )
 

--- a/theano/gof/graph.py
+++ b/theano/gof/graph.py
@@ -7,6 +7,8 @@ from collections import deque
 from copy import copy
 from itertools import count
 
+import warnings
+
 import theano
 from theano import config
 from theano.gof import utils
@@ -524,6 +526,11 @@ class Variable(Node):
     def __getstate__(self):
         d = self.__dict__.copy()
         d.pop("_fn_cache", None)
+        if (not config.pickle_test_value) and (hasattr(self.tag, 'test_value')):
+            warnings.warn("Test value of variable %s(%s) will not be dumped." % (d['auto_name'], d['name']))
+            t = d["tag"]
+            del t.test_value
+            d["tag"] = t
         return d
 
 

--- a/theano/gof/graph.py
+++ b/theano/gof/graph.py
@@ -526,9 +526,12 @@ class Variable(Node):
     def __getstate__(self):
         d = self.__dict__.copy()
         d.pop("_fn_cache", None)
-        if (not config.pickle_test_value) and (hasattr(self.tag, 'test_value')):
-            warnings.warn("Test value of variable %s(%s) will not be dumped." % (d['auto_name'], d['name']))
-            t = d["tag"]
+        if (not config.pickle_test_value) \
+           and (hasattr(self.tag, 'test_value')) \
+           and (not type(config).pickle_test_value.is_default):
+            warnings.warn("pickle_test_value is not defaut value (True).\n"
+                          "Test value of variable %s(%s) will not be dumped." % (d['auto_name'], d['name']))
+            t = copy(d["tag"])
             del t.test_value
             d["tag"] = t
         return d


### PR DESCRIPTION
A Flag is added to disable pickling test values. By default, it's False. A warning will raised by default if there are test values at pickling time.

fix gh-2655