### PR TITLE
Dilated causal convolution

### DIFF
--- a/theano/gpuarray/blas.py
+++ b/theano/gpuarray/blas.py
@@ -480,11 +480,11 @@ class BaseGpuCorrMM(CGpuKernelBase):
                     'tuple of length 2'.format(border_mode))
             border = ()
             for mode in border_mode:
-                if isinstance(mode, integer_types) and mode >= 0:
-                    border += ((mode, mode),)
-                elif isinstance(mode, tuple) and len(mode) == 2 and \
+                if isinstance(mode, tuple) and len(mode) == 2 and \
                         min(mode) >= 0:
                     border += ((int(mode[0]), int(mode[1])),)
+                elif mode >= 0:
+                    border += ((int(mode), int(mode)),)
                 else:
                     raise ValueError(
                         'invalid border mode {}. The tuple can only contain '
@@ -630,13 +630,13 @@ class BaseGpuCorrMM(CGpuKernelBase):
         if height:
             height = '(*(npy_int*)(PyArray_DATA(%s)))' % height
         else:
-            if ((direction != 0) and (dH != 1)) or ((direction == 1) and (padH_l == -1)):
+            if ((direction != 0) and (dH != 1)) or ((direction == 1) and (padH_l == -1 or padH_r == -1)):
                 raise ValueError("height must be given for backprop with vertical sampling or pad='half'")
             height = '-1'
         if width:
             width = '(*(npy_int*)(PyArray_DATA(%s)))' % width
         else:
-            if ((direction != 0) and (dW != 1)) or ((direction == 1) and (padW_l == -1)):
+            if ((direction != 0) and (dW != 1)) or ((direction == 1) and (padW_l == -1 or padW_r == -1)):
                 raise ValueError("width must be given for backprop with horizontal sampling or pad='half'")
             width = '-1'
 

--- a/theano/gpuarray/blas.py
+++ b/theano/gpuarray/blas.py
@@ -449,8 +449,8 @@ class BaseGpuCorrMM(CGpuKernelBase):
     Parameters
     ----------
     border_mode : {'valid', 'full', 'half'}
-        Additionally, the padding size could be directly specified by an integer
-        or a pair of integers
+        Additionally, the padding size could be directly specified by an integer,
+        a pair of integers, or two pairs of integers.
     subsample
         Perform subsampling of the output (default: (1, 1)).
     filter_dilation

--- a/theano/gpuarray/blas.py
+++ b/theano/gpuarray/blas.py
@@ -927,8 +927,11 @@ class GpuCorrMM(BaseGpuCorrMM):
         ``'valid'`` for ``(0, 0)`` (valid convolution, no padding), ``'full'``
         for ``(kernel_rows - 1, kernel_columns - 1)`` (full convolution),
         ``'half'`` for ``(kernel_rows // 2, kernel_columns // 2)`` (same
-        convolution for odd-sized kernels). Note that the two widths are each
-        applied twice, once per side (left and right, top and bottom).
+        convolution for odd-sized kernels).
+        If it is a tuple containing 2 pairs of integers, then these specify
+        the padding to be applied on each side ((left, right), (top, bottom)).
+        Otherwise, each width is applied twice, once per side (left and right,
+        top and bottom).
     subsample
         The subsample operation applied to each output image.
         Should be a tuple with 2 elements.

--- a/theano/gpuarray/c_code/corr_gemm.c
+++ b/theano/gpuarray/c_code/corr_gemm.c
@@ -42,7 +42,7 @@ KERNEL void dilated_im2col_kernel(const ga_size n,
     const ga_size height, const ga_size width,
     const ga_size kernel_h, const ga_size kernel_w,
     const ga_size dilation_h, const ga_size dilation_w,
-    const ga_size pad_h, const ga_size pad_w,
+    const ga_size pad_hl, const ga_size pad_wl,
     const ga_size stride_h, const ga_size stride_w,
     const ga_size height_col, const ga_size width_col,
     GLOBAL_MEM DTYPE_INPUT_0 * data_col,
@@ -57,8 +57,8 @@ KERNEL void dilated_im2col_kernel(const ga_size n,
     const ga_size w_col = index % width_col;
     const ga_size c_im = h_index / height_col;
     const ga_size c_col = c_im * kernel_h * kernel_w;
-    const ga_size h_offset = h_col * stride_h - pad_h;
-    const ga_size w_offset = w_col * stride_w - pad_w;
+    const ga_size h_offset = h_col * stride_h - pad_hl;
+    const ga_size w_offset = w_col * stride_w - pad_wl;
     GLOBAL_MEM DTYPE_INPUT_0 * data_col_ptr = data_col;
     data_col_ptr += (c_col * height_col + h_col) * width_col + w_col;
     GLOBAL_MEM const DTYPE_INPUT_0 * data_im_ptr = data_im + data_im_offset;
@@ -86,7 +86,7 @@ KERNEL void im2col_kernel(const ga_size n,
     // data_im_offset is an offset of elements in the array
     const ga_size height, const ga_size width,
     const ga_size kernel_h, const ga_size kernel_w,
-    const ga_size pad_h, const ga_size pad_w,
+    const ga_size pad_hl, const ga_size pad_wl,
     const ga_size stride_h, const ga_size stride_w,
     const ga_size height_col, const ga_size width_col,
     GLOBAL_MEM DTYPE_INPUT_0 * data_col,
@@ -101,8 +101,8 @@ KERNEL void im2col_kernel(const ga_size n,
     const ga_size w_col = index % width_col;
     const ga_size c_im = h_index / height_col;
     const ga_size c_col = c_im * kernel_h * kernel_w;
-    const ga_size h_offset = h_col * stride_h - pad_h;
-    const ga_size w_offset = w_col * stride_w - pad_w;
+    const ga_size h_offset = h_col * stride_h - pad_hl;
+    const ga_size w_offset = w_col * stride_w - pad_wl;
     GLOBAL_MEM DTYPE_INPUT_0 * data_col_ptr = data_col;
     data_col_ptr += (c_col * height_col + h_col) * width_col + w_col;
     GLOBAL_MEM const DTYPE_INPUT_0 * data_im_ptr = data_im + data_im_offset;
@@ -127,7 +127,7 @@ KERNEL void dilated_col2im_kernel(const ga_size n,
     const ga_size height, const ga_size width, const ga_size channels,
     const ga_size kernel_h, const ga_size kernel_w,
     const ga_size dilation_h, const ga_size dilation_w,
-    const ga_size pad_h, const ga_size pad_w,
+    const ga_size pad_hl, const ga_size pad_wl,
     const ga_size stride_h, const ga_size stride_w,
     const ga_size height_col, const ga_size width_col,
     GLOBAL_MEM DTYPE_INPUT_0 * data_im,
@@ -141,8 +141,8 @@ KERNEL void dilated_col2im_kernel(const ga_size n,
   for (ga_size index = GID_0 * LDIM_0 + LID_0;
        index < (n); index += LDIM_0 * GDIM_0) {
     DTYPE_INPUT_0 val = 0;
-    const ga_size w_im = index % width + pad_w;
-    const ga_size h_im = (index / width) % height + pad_h;
+    const ga_size w_im = index % width + pad_wl;
+    const ga_size h_im = (index / width) % height + pad_hl;
     const ga_size c_im = index / (width * height);
     ga_size kernel_extent_w = (kernel_w - 1) * dilation_w + 1;
     ga_size kernel_extent_h = (kernel_h - 1) * dilation_h + 1;
@@ -177,7 +177,7 @@ KERNEL void col2im_kernel(const ga_size n,
     GLOBAL_MEM const DTYPE_INPUT_0 * data_col, const ga_size offset_col,
     const ga_size height, const ga_size width, const ga_size channels,
     const ga_size kernel_h, const ga_size kernel_w,
-    const ga_size pad_h, const ga_size pad_w,
+    const ga_size pad_hl, const ga_size pad_wl,
     const ga_size stride_h, const ga_size stride_w,
     const ga_size height_col, const ga_size width_col,
     GLOBAL_MEM DTYPE_INPUT_0 * data_im,
@@ -191,8 +191,8 @@ KERNEL void col2im_kernel(const ga_size n,
   for (ga_size index = GID_0 * LDIM_0 + LID_0;
        index < (n); index += LDIM_0 * GDIM_0) {
     DTYPE_INPUT_0 val = 0;
-    const ga_size w_im = index % width + pad_w;
-    const ga_size h_im = (index / width) % height + pad_h;
+    const ga_size w_im = index % width + pad_wl;
+    const ga_size h_im = (index / width) % height + pad_hl;
     const ga_size c_im = index / (width * height);
     // compute the start and end of the output
     const ga_size w_col_start =
@@ -254,15 +254,16 @@ int rgemm(cb_order o, cb_transpose tA, cb_transpose tB,
 int im2col(GpuArray *data_im, const size_t data_im_offset, const size_t channels,
     const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w,
     const size_t dilation_h, const size_t dilation_w,
-    const size_t pad_h, const size_t pad_w,
+    const size_t pad_hl, const size_t pad_hr,
+    const size_t pad_wl, const size_t pad_wr,
     const size_t stride_h, const size_t stride_w,
     GpuArray *data_col) {
   // We are going to launch channels * height_col * width_col kernels, each
   // kernel responsible for copying a single-channel grid.
   size_t dil_kernel_h = (kernel_h - 1) * dilation_h + 1;
   size_t dil_kernel_w = (kernel_w - 1) * dilation_w + 1;
-  size_t height_col = (height + 2 * pad_h - dil_kernel_h) / stride_h + 1;
-  size_t width_col = (width + 2 * pad_w - dil_kernel_w) / stride_w + 1;
+  size_t height_col = (height + pad_hl + pad_hr - dil_kernel_h) / stride_h + 1;
+  size_t width_col = (width + pad_wl + pad_wr - dil_kernel_w) / stride_w + 1;
   size_t num_kernels = channels * height_col * width_col;
   int err;
   if (dilation_h != 1 || dilation_w != 1) {
@@ -270,7 +271,7 @@ int im2col(GpuArray *data_im, const size_t data_im_offset, const size_t channels
       1, &num_kernels, 0,
       num_kernels, data_im->data, data_im->offset, data_im_offset,
       height, width, kernel_h, kernel_w,
-      dilation_h, dilation_w, pad_h, pad_w, stride_h, stride_w, height_col,
+      dilation_h, dilation_w, pad_hl, pad_wl, stride_h, stride_w, height_col,
       width_col, data_col->data, data_col->offset);
     if (err != GA_NO_ERROR) {
         PyErr_Format(PyExc_RuntimeError,
@@ -282,7 +283,7 @@ int im2col(GpuArray *data_im, const size_t data_im_offset, const size_t channels
       1, &num_kernels, 0,
       num_kernels, data_im->data, data_im->offset, data_im_offset,
       height, width, kernel_h, kernel_w,
-      pad_h, pad_w, stride_h, stride_w, height_col,
+      pad_hl, pad_wl, stride_h, stride_w, height_col,
       width_col, data_col->data, data_col->offset);
     if (err != GA_NO_ERROR) {
         PyErr_Format(PyExc_RuntimeError,
@@ -296,12 +297,12 @@ int im2col(GpuArray *data_im, const size_t data_im_offset, const size_t channels
 int col2im(GpuArray *data_col, const size_t channels,
     const size_t height, const size_t width, const size_t patch_h, const size_t patch_w,
     const size_t dilation_h, const size_t dilation_w,
-    const size_t pad_h, const size_t pad_w, const size_t stride_h,
-    const size_t stride_w, GpuArray *data_im, const size_t data_im_offset) {
+    const size_t pad_hl, const size_t pad_hr, const size_t pad_wl, const size_t pad_wr,
+    const size_t stride_h, const size_t stride_w, GpuArray *data_im, const size_t data_im_offset) {
   size_t dil_patch_h = (patch_h - 1) * dilation_h + 1;
   size_t dil_patch_w = (patch_w - 1) * dilation_w + 1;
-  size_t height_col = (height + 2 * pad_h - dil_patch_h) / stride_h + 1;
-  size_t width_col = (width + 2 * pad_w - dil_patch_w) / stride_w + 1;
+  size_t height_col = (height + pad_hl + pad_hr - dil_patch_h) / stride_h + 1;
+  size_t width_col = (width + pad_wl + pad_wr - dil_patch_w) / stride_w + 1;
   size_t num_kernels = channels * height * width;
   // To avoid involving atomic operations, we will launch one kernel per
   // bottom dimension, and then in the kernel add up the top dimensions.
@@ -311,7 +312,7 @@ int col2im(GpuArray *data_col, const size_t channels,
       1, &num_kernels, 0,
       num_kernels, data_col->data, data_col->offset,
       height, width, channels, patch_h, patch_w,
-      dilation_h, dilation_w, pad_h, pad_w, stride_h, stride_w,
+      dilation_h, dilation_w, pad_hl, pad_wl, stride_h, stride_w,
       height_col, width_col, data_im->data, data_im->offset, data_im_offset);
     if (err != GA_NO_ERROR) {
         PyErr_Format(PyExc_RuntimeError,
@@ -323,7 +324,7 @@ int col2im(GpuArray *data_col, const size_t channels,
       1, &num_kernels, 0,
       num_kernels, data_col->data, data_col->offset,
       height, width, channels, patch_h, patch_w,
-      pad_h, pad_w, stride_h, stride_w,
+      pad_hl, pad_wl, stride_h, stride_w,
       height_col, width_col, data_im->data, data_im->offset, data_im_offset);
     if (err != GA_NO_ERROR) {
         PyErr_Format(PyExc_RuntimeError,
@@ -347,8 +348,10 @@ PyGpuArrayObject* corrMM(PyGpuArrayObject *const bottom,
                          const size_t dW = 1,
                          const size_t dilH = 1,
                          const size_t dilW = 1,
-                         const size_t padH = 0,
-                         const size_t padW = 0,
+                         const size_t padH_l = 0,
+                         const size_t padH_r = 0,
+                         const size_t padW_l = 0,
+                         const size_t padW_r = 0,
                          const size_t numgroups = 1,
                          const size_t unshared = 0)
 {
@@ -443,8 +446,8 @@ PyGpuArrayObject* corrMM(PyGpuArrayObject *const bottom,
     const size_t dil_kH = (kH - 1) * dilH + 1;
     const size_t dil_kW = (kW - 1) * dilW + 1;
     // top: (batchSize, nFilters, topHeight, topWidth)
-    const size_t topHeightNoDH = (bottomHeight + 2*padH - dil_kH);
-    const size_t topWidthNoDW  = (bottomWidth + 2*padW - dil_kW);
+    const size_t topHeightNoDH = (bottomHeight + padH_l + padH_r - dil_kH);
+    const size_t topWidthNoDW  = (bottomWidth + padW_l + padW_r - dil_kW);
     // the above values might be negative so we need to use Python-like
     // flooring integer division to be compatible with get_conv_output.
     // note: this macro implements Python's // for negative x only
@@ -558,7 +561,7 @@ PyGpuArrayObject* corrMM(PyGpuArrayObject *const bottom,
             err = im2col(&bottom->ga, n * batch_bottom_stride,
                          nChannels, bottomHeight,
                          bottomWidth, kH, kW, dilH, dilW,
-                         padH, padW, dH, dW, &col->ga);
+                         padH_l, padH_r, padW_l, padW_r, dH, dW, &col->ga);
             if (err != GA_NO_ERROR) {
                 Py_DECREF(col);
                 return NULL;
@@ -618,7 +621,7 @@ PyGpuArrayObject* corrMM(PyGpuArrayObject *const bottom,
             err = im2col(&bottom->ga, n * batch_bottom_stride,
                          nChannels, bottomHeight,
                          bottomWidth, kH, kW, dilH, dilW,
-                         padH, padW, dH, dW, &col->ga);
+                         padH_l, padH_r, padW_l, padW_r, dH, dW, &col->ga);
             if (err != GA_NO_ERROR) {
                 Py_DECREF(col);
                 return NULL;
@@ -712,7 +715,7 @@ PyGpuArrayObject* corrMM(PyGpuArrayObject *const bottom,
             }
             // col2im back to the data
             err = col2im(&col->ga, nChannels, bottomHeight, bottomWidth,
-                         kH, kW, dilH, dilW, padH, padW,
+                         kH, kW, dilH, dilW, padH_l, padH_r, padW_l, padW_r,
                          dH, dW, &bottom->ga, n * batch_bottom_stride);
             if (err != GA_NO_ERROR) {
                 Py_DECREF(col);

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -3038,6 +3038,9 @@ def local_abstractconv_cudnn_graph(op, context_name, inputs, outputs):
     if op.unshared:
         return None
 
+    if isinstance(op.border_mode, tuple) and any(isinstance(p, tuple) for p in op.border_mode):
+        return None
+
     inp1 = inputs[0]
     inp2 = inputs[1]
 
@@ -3134,6 +3137,8 @@ def local_abstractconv_cudnn(node):
         return
     if node.op.unshared:
         return None
+    if isinstance(node.op.border_mode, tuple) and any(isinstance(p, tuple) for p in node.op.border_mode):
+        return None
     if isinstance(node.op, AbstractConv2d):
         return local_abstractconv_cudnn_graph(node.op, ctx, node.inputs, node.outputs)
     elif isinstance(node.op, AbstractConv3d):
@@ -3149,6 +3154,8 @@ def local_abstractconv_cudnn_alt(node):
     if version(raises=False) < 6000 and node.op.filter_dilation != (1, 1):
         return None
     if node.op.unshared:
+        return None
+    if isinstance(node.op.border_mode, tuple) and any(isinstance(p, tuple) for p in node.op.border_mode):
         return None
     inp1 = node.inputs[0]
     inp2 = node.inputs[1]
@@ -3358,6 +3365,8 @@ def local_abstractconv_gw_cudnn(node):
         return
     if node.op.unshared:
         return None
+    if isinstance(node.op.border_mode, tuple) and any(isinstance(p, tuple) for p in node.op.border_mode):
+        return None
     if isinstance(node.op, AbstractConv2d_gradWeights):
         return local_abstractconv_cudnn_graph(node.op, ctx, node.inputs, node.outputs)
     elif isinstance(node.op, AbstractConv3d_gradWeights):
@@ -3370,6 +3379,8 @@ def local_abstractconv_gi_cudnn(node):
     if not isinstance(node.inputs[0].type, GpuArrayType):
         return
     if node.op.unshared:
+        return None
+    if isinstance(node.op.border_mode, tuple) and any(isinstance(p, tuple) for p in node.op.border_mode):
         return None
     if isinstance(node.op, AbstractConv2d_gradInputs):
         return local_abstractconv_cudnn_graph(node.op, ctx, node.inputs, node.outputs)

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -3039,6 +3039,7 @@ def local_abstractconv_cudnn_graph(op, context_name, inputs, outputs):
         return None
 
     if isinstance(op.border_mode, tuple) and any(isinstance(p, tuple) for p in op.border_mode):
+        # Asymmetric padding not yet supported
         return None
 
     inp1 = inputs[0]
@@ -3138,6 +3139,7 @@ def local_abstractconv_cudnn(node):
     if node.op.unshared:
         return None
     if isinstance(node.op.border_mode, tuple) and any(isinstance(p, tuple) for p in node.op.border_mode):
+        # Asymmetric padding not yet supported
         return None
     if isinstance(node.op, AbstractConv2d):
         return local_abstractconv_cudnn_graph(node.op, ctx, node.inputs, node.outputs)
@@ -3156,6 +3158,7 @@ def local_abstractconv_cudnn_alt(node):
     if node.op.unshared:
         return None
     if isinstance(node.op.border_mode, tuple) and any(isinstance(p, tuple) for p in node.op.border_mode):
+        # Asymmetric padding not yet supported
         return None
     inp1 = node.inputs[0]
     inp2 = node.inputs[1]
@@ -3366,6 +3369,7 @@ def local_abstractconv_gw_cudnn(node):
     if node.op.unshared:
         return None
     if isinstance(node.op.border_mode, tuple) and any(isinstance(p, tuple) for p in node.op.border_mode):
+        # Asymmetric padding not yet supported
         return None
     if isinstance(node.op, AbstractConv2d_gradWeights):
         return local_abstractconv_cudnn_graph(node.op, ctx, node.inputs, node.outputs)
@@ -3381,6 +3385,7 @@ def local_abstractconv_gi_cudnn(node):
     if node.op.unshared:
         return None
     if isinstance(node.op.border_mode, tuple) and any(isinstance(p, tuple) for p in node.op.border_mode):
+        # Asymmetric padding not yet supported
         return None
     if isinstance(node.op, AbstractConv2d_gradInputs):
         return local_abstractconv_cudnn_graph(node.op, ctx, node.inputs, node.outputs)

--- a/theano/gpuarray/tests/test_gemmcorr.py
+++ b/theano/gpuarray/tests/test_gemmcorr.py
@@ -12,6 +12,7 @@ from ..type import gpuarray_shared_constructor
 from ..blas import GpuCorrMM, GpuCorrMM_gradWeights, GpuCorrMM_gradInputs
 from .config import mode_with_gpu, mode_without_gpu, ref_cast
 from theano.tensor.nnet.tests.test_abstract_conv import Grouped_conv_noOptim, TestUnsharedConv
+from theano.tensor.nnet.tests.test_abstract_conv import TestAsymmetricPadding
 
 
 class TestCorrMM(unittest.TestCase):
@@ -269,6 +270,13 @@ class TestGroupGpuCorr2d(Grouped_conv_noOptim):
 
 class TestUnsharedGpuCorr2d(TestUnsharedConv):
     mode = mode_with_gpu
+    conv2d_op = GpuCorrMM
+    conv2d_gradw_op = GpuCorrMM_gradWeights
+    conv2d_gradi_op = GpuCorrMM_gradInputs
+
+
+class TestAsymmetricGpu(TestAsymmetricPadding):
+    mode = mode_with_gpu.excluding('cudnn')
     conv2d_op = GpuCorrMM
     conv2d_gradw_op = GpuCorrMM_gradWeights
     conv2d_gradi_op = GpuCorrMM_gradInputs

--- a/theano/gpuarray/tests/test_gemmcorr.py
+++ b/theano/gpuarray/tests/test_gemmcorr.py
@@ -276,11 +276,11 @@ class TestUnsharedGpuCorr2d(TestUnsharedConv):
 
 
 class TestAsymmetricGpu(TestAsymmetricPadding):
-    mode = mode_with_gpu.excluding('cudnn')
+    mode = mode_with_gpu
     conv2d_op = GpuCorrMM
     conv2d_gradw_op = GpuCorrMM_gradWeights
     conv2d_gradi_op = GpuCorrMM_gradInputs
 
 
 class TestCausalGpuCorr(TestCausalConv):
-    mode = mode_with_gpu.excluding('cudnn')
+    mode = mode_with_gpu

--- a/theano/gpuarray/tests/test_gemmcorr.py
+++ b/theano/gpuarray/tests/test_gemmcorr.py
@@ -12,7 +12,7 @@ from ..type import gpuarray_shared_constructor
 from ..blas import GpuCorrMM, GpuCorrMM_gradWeights, GpuCorrMM_gradInputs
 from .config import mode_with_gpu, mode_without_gpu, ref_cast
 from theano.tensor.nnet.tests.test_abstract_conv import Grouped_conv_noOptim, TestUnsharedConv
-from theano.tensor.nnet.tests.test_abstract_conv import TestAsymmetricPadding
+from theano.tensor.nnet.tests.test_abstract_conv import TestAsymmetricPadding, TestCausalConv
 
 
 class TestCorrMM(unittest.TestCase):
@@ -280,3 +280,7 @@ class TestAsymmetricGpu(TestAsymmetricPadding):
     conv2d_op = GpuCorrMM
     conv2d_gradw_op = GpuCorrMM_gradWeights
     conv2d_gradi_op = GpuCorrMM_gradInputs
+
+
+class TestCausalGpuCorr(TestCausalConv):
+    mode = mode_with_gpu.excluding('cudnn')

--- a/theano/tensor/nnet/__init__.py
+++ b/theano/tensor/nnet/__init__.py
@@ -72,21 +72,30 @@ def conv2d(input, filters, input_shape=None, filter_shape=None,
         You can give ``None`` for any element of the list to specify that this
         element is not known at compile time.
 
-    border_mode: str, int or tuple of two int
+     border_mode: str, int or tuple of ``convdim`` elements where each element
+        is an integer or a tuple of length 2.
         Either of the following:
 
         ``'valid'``: apply filter wherever it completely overlaps with the
             input. Generates output of shape: input shape - filter shape + 1
         ``'full'``: apply filter wherever it partly overlaps with the input.
             Generates output of shape: input shape + filter shape - 1
-        ``'half'``: pad input with a symmetric border of ``filter rows // 2``
-            rows and ``filter columns // 2`` columns, then perform a valid
-            convolution. For filters with an odd number of rows and columns, this
-            leads to the output shape being equal to the input shape.
+        ``'half'``: pad input with a symmetric border of ``filter size // 2``
+            in each convolution dimension, then perform a valid convolution.
+            For filters with an odd filter size, this leads to the output
+            shape being equal to the input shape.
         ``int``: pad input with a symmetric border of zeros of the given
             width, then perform a valid convolution.
-        ``(int1, int2)``: pad input with a symmetric border of ``int1`` rows
-            and ``int2`` columns, then perform a valid convolution.
+        ``(int1, int2)``: (for 2D) pad input with a symmetric border of ``int1``,
+            ``int2``, then perform a valid convolution.
+        ``(int1, (int2, int3))`` or ``((int1, int2), int3)``: (for 2D)
+            pad input with one symmetric border of `int1`` or ``int3``, and
+            one asymmetric border of ``(int2, int3)`` or ``(int1, int2)``.
+        ``((int1, int2), (int3, int4))``: (for 2D) pad input with an asymmetric
+            border of ``(int1, int2)`` along one dimension and ``(int3, int4)``
+            along the second dimension.
+        ``(int1, int2, int3)``: (for 3D) pad input with a symmetric border of
+            ``int1``, ``int2`` and ``int3``, then perform a valid convolution.
 
     subsample: tuple of len 2
         Factor by which to subsample the output.
@@ -199,7 +208,7 @@ def conv2d_transpose(input, filters, output_shape, filter_shape=None,
         You can give ``None`` for any element of the list to specify that this
         element is not known at compile time.
 
-    border_mode: str, int or tuple of two int
+    border_mode: str, int or tuple of two elements
         Refers to the ``border_mode`` argument of the corresponding forward
         (non-transposed) convolution. See the argument description in
         ``conv2d``.  What was ``padding`` for the forward convolution means

--- a/theano/tensor/nnet/__init__.py
+++ b/theano/tensor/nnet/__init__.py
@@ -72,18 +72,17 @@ def conv2d(input, filters, input_shape=None, filter_shape=None,
         You can give ``None`` for any element of the list to specify that this
         element is not known at compile time.
 
-     border_mode: str, int or tuple of ``convdim`` elements where each element
-        is an integer or a tuple of length 2.
+    border_mode: str, int or a tuple of two ints or pairs of ints
         Either of the following:
 
         ``'valid'``: apply filter wherever it completely overlaps with the
             input. Generates output of shape: input shape - filter shape + 1
         ``'full'``: apply filter wherever it partly overlaps with the input.
             Generates output of shape: input shape + filter shape - 1
-        ``'half'``: pad input with a symmetric border of ``filter size // 2``
-            in each convolution dimension, then perform a valid convolution.
-            For filters with an odd filter size, this leads to the output
-            shape being equal to the input shape.
+        ``'half'``: pad input with a symmetric border of ``filter rows // 2``
+            rows and ``filter columns // 2`` columns, then perform a valid
+            convolution. For filters with an odd number of rows and columns, this
+            leads to the output shape being equal to the input shape.
         ``int``: pad input with a symmetric border of zeros of the given
             width, then perform a valid convolution.
         ``(int1, int2)``: (for 2D) pad input with a symmetric border of ``int1``,
@@ -91,11 +90,6 @@ def conv2d(input, filters, input_shape=None, filter_shape=None,
         ``(int1, (int2, int3))`` or ``((int1, int2), int3)``: (for 2D)
             pad input with one symmetric border of `int1`` or ``int3``, and
             one asymmetric border of ``(int2, int3)`` or ``(int1, int2)``.
-        ``((int1, int2), (int3, int4))``: (for 2D) pad input with an asymmetric
-            border of ``(int1, int2)`` along one dimension and ``(int3, int4)``
-            along the second dimension.
-        ``(int1, int2, int3)``: (for 3D) pad input with a symmetric border of
-            ``int1``, ``int2`` and ``int3``, then perform a valid convolution.
 
     subsample: tuple of len 2
         Factor by which to subsample the output.
@@ -208,7 +202,7 @@ def conv2d_transpose(input, filters, output_shape, filter_shape=None,
         You can give ``None`` for any element of the list to specify that this
         element is not known at compile time.
 
-    border_mode: str, int or tuple of two elements
+    border_mode: str, int or tuple of two int
         Refers to the ``border_mode`` argument of the corresponding forward
         (non-transposed) convolution. See the argument description in
         ``conv2d``.  What was ``padding`` for the forward convolution means

--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -52,7 +52,7 @@ def get_conv_output_shape(image_shape, kernel_shape,
         number of output channels, height and width of the output, number of
         input channels, height and width of the kernel.
         None where undefined.
-     border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
+    border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
         or numeric) or pairs of ints. If it is a string, it must be 'valid',
         'half' or 'full'. If it is a tuple, its two (or three) elements respectively
         correspond to the padding on height and width (and possibly depth)
@@ -174,7 +174,7 @@ def get_conv_gradweights_shape(image_shape, top_shape,
         image shape. Its four (or five) element must correspond respectively
         to: batch size, number of output channels, height and width (and
         possibly depth) of the image. None where undefined.
-     border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
+    border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
         or numeric) or pairs of ints. If it is a string, it must be 'valid',
         'half' or 'full'. If it is a tuple, its two (or three) elements respectively
         correspond to the padding on height and width (and possibly depth)
@@ -298,7 +298,7 @@ def get_conv_gradinputs_shape(kernel_shape, top_shape,
         image shape. Its four (or five) element must correspond respectively
         to: batch size, number of output channels, height and width (and
         possibly depth) of the image. None where undefined.
-     border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
+    border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
         or numeric) or pairs of ints. If it is a string, it must be 'valid',
         'half' or 'full'. If it is a tuple, its two (or three) elements respectively
         correspond to the padding on height and width (and possibly depth)
@@ -426,7 +426,7 @@ def check_conv_gradinputs_shape(image_shape, kernel_shape, output_shape,
         output shape. Its four (or five) elements must correspond respectively
         to: batch size, number of output channels, height and width
         (and possibly depth) of the output. None where undefined.
-     border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
+    border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
         or numeric) or pairs of ints. If it is a string, it must be 'valid',
         'half' or 'full'. If it is a tuple, its two (or three) elements respectively
         correspond to the padding on height and width (and possibly depth)

--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -1971,16 +1971,22 @@ class BaseAbstractConv(Op):
                 raise ValueError(
                     'invalid border_mode {}, which must be a '
                     'tuple of length {}'.format(border_mode, convdim))
+            new_border_mode = ()
             for mode in border_mode:
-                if isinstance(mode, tuple) and convdim != 2:
-                    raise NotImplementedError(
-                        'Asymmetric padding not implemented for {}D'.format(convdim))
                 if not((isinstance(mode, integer_types) and mode >= 0) or
                         (isinstance(mode, tuple) and len(mode) == 2 and min(mode) >= 0 and
                          all(isinstance(m, integer_types) for m in mode))):
                     raise ValueError(
                         'invalid border mode {}. The tuple can only contain integers '
                         ' or pairs of integers'.format(border_mode))
+                if isinstance(mode, tuple):
+                    if convdim != 2:
+                        raise NotImplementedError(
+                            'Asymmetric padding not implemented for {}D'.format(convdim))
+                    if mode[0] == mode[1]:
+                        mode = mode[0]
+                new_border_mode += (mode,)
+            border_mode = new_border_mode
         elif border_mode not in ('valid', 'full', 'half'):
             raise ValueError(
                 'invalid border_mode {}, which must be either '

--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -52,11 +52,11 @@ def get_conv_output_shape(image_shape, kernel_shape,
         number of output channels, height and width of the output, number of
         input channels, height and width of the kernel.
         None where undefined.
-    border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
-        or numeric). If it is a string, it must be 'valid', 'half' or 'full'.
-        If it is a tuple, its two (or three) elements respectively correspond
-        to the padding (possibly left and right) on height and width
-        (and possibly depth) axis.
+     border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
+        or numeric) or pairs of ints. If it is a string, it must be 'valid',
+        'half' or 'full'. If it is a tuple, its two (or three) elements respectively
+        correspond to the padding on height and width (and possibly depth)
+        axis. For asymmetric padding, provide a pair of ints for each dimension.
     subsample: tuple of int (symbolic or numeric). Its two or three elements
         espectively correspond to the subsampling on height and width (and
         possibly depth) axis.
@@ -104,10 +104,11 @@ def get_conv_shape_1axis(image_shape, kernel_shape, border_mode,
         given axis. None if undefined.
     kernel_shape: int or None. Corresponds to the kernel shape on a given
         axis. None if undefined.
-    border_mode: string, int or tuple. If it is a string, it must be
+    border_mode: string, int or tuple of 2 ints. If it is a string, it must be
         'valid', 'half' or 'full'. If it is an integer, it must correspond to
         the padding on the considered axis. If it is a tuple, its two elements
-        must correspond to the padding (left and right) on the desired axis.
+        must correspond to the asymmetric padding (e.g., left and right) on
+        the considered axis.
     subsample: int. It must correspond to the subsampling on the
         considered axis.
     dilation: int. It must correspond to the dilation on the
@@ -173,11 +174,11 @@ def get_conv_gradweights_shape(image_shape, top_shape,
         image shape. Its four (or five) element must correspond respectively
         to: batch size, number of output channels, height and width (and
         possibly depth) of the image. None where undefined.
-    border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
-        or numeric). If it is a string, it must be 'valid', 'half' or 'full'.
-        If it is a tuple, its two (or three) elements respectively correspond
-        to the padding (possibly left and right) on height and width
-        (and possibly depth) axis.
+     border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
+        or numeric) or pairs of ints. If it is a string, it must be 'valid',
+        'half' or 'full'. If it is a tuple, its two (or three) elements respectively
+        correspond to the padding on height and width (and possibly depth)
+        axis. For asymmetric padding, provide a pair of ints for each dimension.
     subsample: tuple of int (symbolic or numeric). Its two or three elements
         respectively correspond to the subsampling on height and width (and
         possibly depth) axis.
@@ -234,10 +235,11 @@ def get_conv_gradweights_shape_1axis(image_shape, top_shape, border_mode,
         given axis. None if undefined.
     top_shape: int or None. Corresponds to the top shape on a given axis.
         None if undefined.
-    border_mode: string, int or tuple. If it is a string, it must be
+    border_mode: string, int or tuple of 2 ints. If it is a string, it must be
         'valid', 'half' or 'full'. If it is an integer, it must correspond to
         the padding on the considered axis. If it is a tuple, its two elements
-        must correspond to the padding (left and right) on the desired axis.
+        must correspond to the asymmetric padding (e.g., left and right) on
+        the considered axis.
     subsample: int. It must correspond to the subsampling on the
         considered axis.
     dilation: int. It must correspond to the dilation on the
@@ -296,11 +298,11 @@ def get_conv_gradinputs_shape(kernel_shape, top_shape,
         image shape. Its four (or five) element must correspond respectively
         to: batch size, number of output channels, height and width (and
         possibly depth) of the image. None where undefined.
-    border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
-        or numeric). If it is a string, it must be 'valid', 'half' or 'full'.
-        If it is a tuple, its two (or three) elements respectively correspond
-        to the padding (possibly left and right) on height and width
-        (and possibly depth) axis.
+     border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
+        or numeric) or pairs of ints. If it is a string, it must be 'valid',
+        'half' or 'full'. If it is a tuple, its two (or three) elements respectively
+        correspond to the padding on height and width (and possibly depth)
+        axis. For asymmetric padding, provide a pair of ints for each dimension.
     subsample: tuple of int (symbolic or numeric). Its two or three elements
         respectively correspond to the subsampling on height and width (and
         possibly depth) axis.
@@ -354,10 +356,11 @@ def get_conv_gradinputs_shape_1axis(kernel_shape, top_shape, border_mode,
         axis. None if undefined.
     top_shape: int or None. Corresponds to the top shape on a given axis.
         None if undefined.
-    border_mode: string, int or tuple. If it is a string, it must be
+    border_mode: string, int or tuple of 2 ints. If it is a string, it must be
         'valid', 'half' or 'full'. If it is an integer, it must correspond to
         the padding on the considered axis. If it is a tuple, its two elements
-        must correspond to the padding (left and right) on the desired axis.
+        must correspond to the asymmetric padding (e.g., left and right) on
+        the considered axis.
     subsample: int. It must correspond to the subsampling on the
         considered axis.
     dilation: int. It must correspond to the dilation on the
@@ -423,11 +426,11 @@ def check_conv_gradinputs_shape(image_shape, kernel_shape, output_shape,
         output shape. Its four (or five) elements must correspond respectively
         to: batch size, number of output channels, height and width
         (and possibly depth) of the output. None where undefined.
-    border_mode: string, int (symbolic or numeric) or tuple where each element
-        is either an int or a tuple of length 2 (symbolic or numeric).
-        If it is a string, it must be 'valid', 'half' or 'full'.
-        If it is a tuple, its two (or three) elements respectively correspond
-        to the padding on height and width (and possibly depth) axis.
+     border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
+        or numeric) or pairs of ints. If it is a string, it must be 'valid',
+        'half' or 'full'. If it is a tuple, its two (or three) elements respectively
+        correspond to the padding on height and width (and possibly depth)
+        axis. For asymmetric padding, provide a pair of ints for each dimension.
     subsample: tuple of int (symbolic or numeric). Its two or three elements
         respectively correspond to the subsampling on height and width (and
         possibly depth) axis.
@@ -553,8 +556,9 @@ def assert_shape(x, expected_shape, msg='Unexpected shape.'):
         return x
 
 
-def mode_to_pad(mode, convdim, kshp):
-    """ Computes a tuple for padding given the border_mode parameter
+def border_mode_to_pad(mode, convdim, kshp):
+    """
+    Computes a tuple for padding given the border_mode parameter
 
     Parameters
     ----------
@@ -708,10 +712,10 @@ def separable_conv2d(input,
             width, then perform a valid convolution.
         ``(int1, int2)``: pad input with a symmetric border of ``int1`` rows
             and ``int2`` columns, then perform a valid convolution.
-        ``(int1, (int2, int3))`` or ``((int1, int2), int3)``: (for 2D)
+        ``(int1, (int2, int3))`` or ``((int1, int2), int3)``:
             pad input with one symmetric border of `int1`` or ``int3``, and
             one asymmetric border of ``(int2, int3)`` or ``(int1, int2)``.
-        ``((int1, int2), (int3, int4))``: (for 2D) pad input with an asymmetric
+        ``((int1, int2), (int3, int4))``: pad input with an asymmetric
             border of ``(int1, int2)`` along one dimension and ``(int3, int4)``
             along the second dimension.
 
@@ -1041,8 +1045,7 @@ def conv2d_grad_wrt_inputs(output_grad,
         Optional, possibly used  to choose an optimal implementation.
         You can give ``None`` for any element of the list to specify that
         this element is not known at compile time.
-     border_mode: str, int or tuple of 2 elements where each element
-        is an integer or a tuple of length 2.
+    border_mode: str, int or a tuple of two ints or pairs of ints
         Either of the following:
 
           ``'valid'``
@@ -1073,8 +1076,8 @@ def conv2d_grad_wrt_inputs(output_grad,
             pad input with one symmetric border of `int1`` or ``int3``, and
             one asymmetric border of ``(int2, int3)`` or ``(int1, int2)``.
 
-          ``((int1, int2), (int3, int4))``: (for 2D) pad input with an asymmetric
-            border of ``(int1, int2)`` along one dimension and ``(int3, int4)``
+          ``((int1, int2), (int3, int4))``
+            pad input with an asymmetric border of ``(int1, int2)`` along one dimension and ``(int3, int4)``
             along the second dimension.
 
     subsample : tuple of len 2
@@ -1336,8 +1339,7 @@ def conv2d_grad_wrt_weights(input,
         Optional, possibly used to choose an optimal implementation.
         You can give ``None`` for any element of the list to specify
         that this element is not known at compile time.
-     border_mode: str, int or tuple of 2 elements where each element
-        is an integer or a tuple of length 2.
+    border_mode: str, int or a tuple of two ints or pairs of ints
         Either of the following:
 
           ``'valid'``
@@ -1368,9 +1370,9 @@ def conv2d_grad_wrt_weights(input,
             pad input with one symmetric border of `int1`` or ``int3``, and
             one asymmetric border of ``(int2, int3)`` or ``(int1, int2)``.
 
-          ``((int1, int2), (int3, int4))``: (for 2D) pad input with an asymmetric
-            border of ``(int1, int2)`` along one dimension and ``(int3, int4)``
-            along the second dimension.
+          ``((int1, int2), (int3, int4))``
+            pad input with an asymmetric border of ``(int1, int2)`` along
+            one dimension and ``(int3, int4)`` along the second dimension.
     subsample : tuple of len 2
         The subsampling used in the forward pass of the convolutional
         operation.  Also called strides elsewhere.
@@ -1584,16 +1586,17 @@ def conv3d_grad_wrt_weights(input,
     return gradWeight_op(input, output_grad, filter_shape[-3:])
 
 
-def causal_conv(input,
-                filters,
-                filter_shape,
-                input_shape=None,
-                subsample=1,
-                filter_flip=True,
-                filter_dilation=1,
-                num_groups=1,
-                unshared=False):
-    """Computes (dilated) causal convolution
+def causal_conv1d(input,
+                  filters,
+                  filter_shape,
+                  input_shape=None,
+                  subsample=1,
+                  filter_flip=True,
+                  filter_dilation=1,
+                  num_groups=1,
+                  unshared=False):
+    """
+    Computes (dilated) causal convolution
 
     The output at time t depends only on the inputs till t-1. Used for
     modelling temporal data.
@@ -1629,7 +1632,7 @@ def causal_conv(input,
     num_groups : int
         Divides the image, kernel and output tensors into num_groups
         separate groups. Each which carry out convolutions separately
-    unshared: bool
+    unshared : bool
         If true, then unshared or 'locally connected' convolution will be
         performed. A different filter will be used for each region of the
         input.
@@ -1639,6 +1642,11 @@ def causal_conv(input,
     Symbolic 3D tensor.
         Set of feature vectors generated by convolutional layer. Tensor is
         of shape (batch_size, output_channels, output_length)
+
+    Notes
+    -----
+
+    :note: Currently, this is implemented with the 2D convolution ops.
 
     """
 
@@ -1885,8 +1893,7 @@ class BaseAbstractConv(Op):
         element is not known at compile time.
         kshp is defined w.r.t the forward conv.
 
-     border_mode: str, int or tuple of ``convdim`` elements where each element
-        is an integer or a tuple of length 2.
+    border_mode: str, int or a tuple of two ints or pairs of ints
         Either of the following:
 
         ``'valid'``: apply filter wherever it completely overlaps with the
@@ -1965,12 +1972,15 @@ class BaseAbstractConv(Op):
                     'invalid border_mode {}, which must be a '
                     'tuple of length {}'.format(border_mode, convdim))
             for mode in border_mode:
+                if isinstance(mode, tuple) and convdim != 2:
+                    raise NotImplementedError(
+                        'Asymmetric padding not implemented for {}D'.format(convdim))
                 if not((isinstance(mode, integer_types) and mode >= 0) or
                         (isinstance(mode, tuple) and len(mode) == 2 and min(mode) >= 0 and
                          all(isinstance(m, integer_types) for m in mode))):
                     raise ValueError(
                         'invalid border mode {}. The tuple can only contain integers '
-                        ' or tuples of integers of length 2'.format(border_mode))
+                        ' or pairs of integers'.format(border_mode))
         elif border_mode not in ('valid', 'full', 'half'):
             raise ValueError(
                 'invalid border_mode {}, which must be either '
@@ -2238,7 +2248,7 @@ class AbstractConv(BaseAbstractConv):
                                       % self.convdim)
         o, = out_
         mode = self.border_mode
-        pad = mode_to_pad(mode, self.convdim, dil_kernshp)
+        pad = border_mode_to_pad(mode, self.convdim, dil_kernshp)
 
         if any(p != (0, 0) for p in pad):
             mode = "valid"
@@ -2503,7 +2513,7 @@ class AbstractConv_gradWeights(BaseAbstractConv):
         dil_shape = tuple((shape[i] - 1) * self.filter_dilation[i] + 1
                           for i in range(self.convdim))
 
-        pad = mode_to_pad(self.border_mode, self.convdim, dil_shape)
+        pad = border_mode_to_pad(self.border_mode, self.convdim, dil_shape)
 
         if any(p != (0, 0) for p in pad):
             new_img = np.zeros((img.shape[0], img.shape[1]) +
@@ -2805,8 +2815,7 @@ class AbstractConv_gradInputs(BaseAbstractConv):
         dil_kernshp = tuple((kern.shape[-self.convdim + i] - 1) * self.filter_dilation[i] + 1
                             for i in range(self.convdim))
 
-        mode = self.border_mode
-        pad = mode_to_pad(mode, self.convdim, dil_kernshp)
+        pad = border_mode_to_pad(self.border_mode, self.convdim, dil_kernshp)
 
         imshp = self.imshp[:] if self.imshp is not None else [None] * (2 + self.convdim)
         fallback_imshp = ([topgrad.shape[0], kern.shape[-self.convdim - 1]] +
@@ -2815,7 +2824,7 @@ class AbstractConv_gradInputs(BaseAbstractConv):
                  for i in range(2 + self.convdim)]
         expected_topgrad_shape = get_conv_output_shape(
             imshp, kern.shape,
-            mode, self.subsample, self.filter_dilation)
+            self.border_mode, self.subsample, self.filter_dilation)
         if not tuple(expected_topgrad_shape) == tuple(topgrad.shape):
             raise ValueError(
                 'invalid input_shape for gradInputs: the given input_shape '

--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -2784,7 +2784,7 @@ class AbstractConv_gradInputs(BaseAbstractConv):
 
         if any(p != (0, 0) or p != 0 for p in pad):
             img = img[(slice(None), slice(None)) +
-                      tuple(slice(pad[i][0], img.shape[i + 2] - pad[i][0])
+                      tuple(slice(pad[i][0], img.shape[i + 2] - pad[i][1])
                             for i in range(self.convdim))]
         o[0] = node.outputs[0].type.filter(img)
 

--- a/theano/tensor/nnet/corr.py
+++ b/theano/tensor/nnet/corr.py
@@ -89,7 +89,7 @@ class BaseCorrMM(gof.OpenMPOp):
             raise ValueError(
                 'invalid border_mode {}, which must be either '
                 '"valid", "full", "half", an integer or a tuple '
-                'of length 2'.format(border_mode))
+                'of two integers or a pair of integers'.format(border_mode))
         self.border_mode = border_mode
         if len(subsample) != 2:
             raise ValueError("subsample must have two elements")

--- a/theano/tensor/nnet/corr.py
+++ b/theano/tensor/nnet/corr.py
@@ -195,7 +195,7 @@ class BaseCorrMM(gof.OpenMPOp):
 
     def c_code_cache_version(self):
         # raise this whenever modifying any of the support_code_files
-        return (9, self.openmp, blas_header_version())
+        return (10, self.openmp, blas_header_version())
 
     def c_support_code_apply(self, node, nodename):
         # REMEMBER TO RAISE c_code_cache_version when changing any of
@@ -439,7 +439,7 @@ class BaseCorrMM(gof.OpenMPOp):
         break;
     case 1:  // backprop wrt. weights
         // output is weights: (num_filters, num_channels, height, width)
-        // height and width: weights = (bottom + 2*pad - (top - 1) * sample - 1) / dil + 1
+        // height and width: weights = (bottom + pad_l + pad_r - (top - 1) * sample - 1) / dil + 1
         out_dim[0] = (npy_intp)PyArray_DIMS(top)[1];
         if (unshared){
             odim = 6;

--- a/theano/tensor/nnet/corr.py
+++ b/theano/tensor/nnet/corr.py
@@ -603,8 +603,11 @@ class CorrMM(BaseCorrMM):
         ``'valid'`` for ``(0, 0)`` (valid convolution, no padding), ``'full'``
         for ``(kernel_rows - 1, kernel_columns - 1)`` (full convolution),
         ``'half'`` for ``(kernel_rows // 2, kernel_columns // 2)`` (same
-        convolution for odd-sized kernels). Note that the two widths are each
-        applied twice, once per side (left and right, top and bottom).
+        convolution for odd-sized kernels).
+        If it is a tuple containing 2 pairs of integers, then these specify
+        the padding to be applied on each side ((left, right), (top, bottom)).
+        Otherwise, each width is applied twice, once per side (left and right,
+        top and bottom).
     subsample
         The subsample operation applied to each output image.
         Should be a tuple with 2 elements.

--- a/theano/tensor/nnet/corr.py
+++ b/theano/tensor/nnet/corr.py
@@ -34,8 +34,8 @@ class BaseCorrMM(gof.OpenMPOp):
     Parameters
     ----------
     border_mode : {'valid', 'full', 'half'}
-        Additionally, the padding size could be directly specified by an integer
-        or a pair of integers
+        Additionally, the padding size could be directly specified by an integer,
+        a pair of integers, or two pairs of integers.
     subsample
         Perform subsampling of the output (default: (1, 1)).
     filter_dilation

--- a/theano/tensor/nnet/corr.py
+++ b/theano/tensor/nnet/corr.py
@@ -75,7 +75,7 @@ class BaseCorrMM(gof.OpenMPOp):
                     'tuple of length 2'.format(border_mode))
             border = ()
             for mode in border_mode:
-                if isinstance(mode, integer_types) and mode > 0:
+                if isinstance(mode, integer_types) and mode >= 0:
                     border += ((mode, mode),)
                 elif isinstance(mode, tuple) and len(mode) == 2 and \
                         min(mode) >= 0:
@@ -489,8 +489,8 @@ class BaseCorrMM(gof.OpenMPOp):
         // height and width: bottom = (top - 1) * sample + (weights-1)*dil + 1 - 2*pad
         out_dim[0] = (npy_intp)PyArray_DIMS(top)[0];
         out_dim[1] = (npy_intp)PyArray_DIMS(weights)[wdim-3] * numgroups;
-        out_dim[2] = (npy_intp)((%(height)s != -1) ? %(height)s : (PyArray_DIMS(top)[2] - 1) * dH + (PyArray_DIMS(weights)[wdim-2]-1)*dilH + 1 - 2*padH);
-        out_dim[3] = (npy_intp)((%(width)s != -1) ? %(width)s : (PyArray_DIMS(top)[3] - 1) * dW + (PyArray_DIMS(weights)[wdim-1]-1)*dilW + 1 - 2*padW);
+        out_dim[2] = (npy_intp)((%(height)s != -1) ? %(height)s : (PyArray_DIMS(top)[2] - 1) * dH + (PyArray_DIMS(weights)[wdim-2]-1)*dilH + 1 - padH_l - padH_r);
+        out_dim[3] = (npy_intp)((%(width)s != -1) ? %(width)s : (PyArray_DIMS(top)[3] - 1) * dW + (PyArray_DIMS(weights)[wdim-1]-1)*dilW + 1 - padW_l - padW_r);
         if (unshared) {
             if (out_dim[0] < 0 || out_dim[1] < 0 || out_dim[2] <= 0 || out_dim[3] <= 0)
             {

--- a/theano/tensor/nnet/tests/test_abstract_conv.py
+++ b/theano/tensor/nnet/tests/test_abstract_conv.py
@@ -24,7 +24,7 @@ from theano.tensor.nnet.abstract_conv import bilinear_kernel_1D
 from theano.tensor.nnet.abstract_conv import bilinear_kernel_2D
 from theano.tensor.nnet.abstract_conv import bilinear_upsampling
 from theano.tensor.nnet.abstract_conv import separable_conv2d, separable_conv3d
-from theano.tensor.nnet.abstract_conv import causal_conv
+from theano.tensor.nnet.abstract_conv import causal_conv1d
 from theano.tensor.nnet.corr import (CorrMM, CorrMM_gradWeights,
                                      CorrMM_gradInputs)
 from theano.tensor.nnet.corr3d import (Corr3dMM, Corr3dMM_gradWeights,
@@ -2037,7 +2037,7 @@ class TestCausalConv(unittest.TestCase):
         img_sym = theano.tensor.tensor3('img')
         kern_sym = theano.tensor.tensor3('kern')
 
-        sym_out = causal_conv(img_sym, kern_sym, self.kern.shape, filter_dilation=self.dilation)
+        sym_out = causal_conv1d(img_sym, kern_sym, self.kern.shape, filter_dilation=self.dilation)
 
         causal_func = theano.function([img_sym, kern_sym], sym_out, mode=self.mode)
 
@@ -2046,6 +2046,6 @@ class TestCausalConv(unittest.TestCase):
         utt.assert_allclose(output, self.precomp_top)
 
         def causal_conv_fn(inputs_val, filters_val):
-            return causal_conv(inputs_val, filters_val, self.kern.shape, filter_dilation=1)
+            return causal_conv1d(inputs_val, filters_val, self.kern.shape, filter_dilation=1)
 
         utt.verify_grad(causal_conv_fn, [self.img, self.kern], mode=self.mode, eps=1)

--- a/theano/tensor/nnet/tests/test_abstract_conv.py
+++ b/theano/tensor/nnet/tests/test_abstract_conv.py
@@ -24,7 +24,7 @@ from theano.tensor.nnet.abstract_conv import bilinear_kernel_1D
 from theano.tensor.nnet.abstract_conv import bilinear_kernel_2D
 from theano.tensor.nnet.abstract_conv import bilinear_upsampling
 from theano.tensor.nnet.abstract_conv import separable_conv2d, separable_conv3d
-from theano.tensor.nnet.abstract_conv import dilated_causal_conv
+from theano.tensor.nnet.abstract_conv import causal_conv
 from theano.tensor.nnet.corr import (CorrMM, CorrMM_gradWeights,
                                      CorrMM_gradInputs)
 from theano.tensor.nnet.corr3d import (Corr3dMM, Corr3dMM_gradWeights,
@@ -2017,7 +2017,7 @@ class TestAsymmetricPadding(unittest.TestCase):
         utt.verify_grad(conv_gradinputs, [kern, top], mode=self.mode, eps=1)
 
 
-class TestDilatedCausalConv(unittest.TestCase):
+class TestCausalConv(unittest.TestCase):
     mode = theano.compile.mode.Mode(optimizer='None')
 
     imshp = (3, 2, 5)
@@ -2031,7 +2031,7 @@ class TestDilatedCausalConv(unittest.TestCase):
         img = np.random.random(self.imshp).astype(theano.config.floatX)
         kern = np.random.random(self.kshp).astype(theano.config.floatX)
 
-        sym_out = dilated_causal_conv(img_sym, kern_sym, self.kshp, filter_dilation=1)
+        sym_out = causal_conv(img_sym, kern_sym, self.kshp, filter_dilation=1)
 
         causal_func = theano.function([img_sym, kern_sym], sym_out, mode=self.mode)
 

--- a/theano/tensor/nnet/tests/test_abstract_conv.py
+++ b/theano/tensor/nnet/tests/test_abstract_conv.py
@@ -1908,138 +1908,144 @@ class TestAsymmetricPadding(unittest.TestCase):
 
     mode = theano.compile.mode.Mode(optimizer='None')
 
-    imshp = (3, 2, 4, 4)
-    kshp = (4, 2, 2, 2)
-    topshp = (3, 4, 6, 6)
-    pad = ((1, 2), (2, 1))
+    img_shape = [(2, 2, 4, 4), (3, 2, 4, 2), (3, 3, 5, 3)]
+    kern_shape = [(4, 2, 2, 2), (2, 2, 4, 2), (2, 3, 3, 3)]
+    topgrad_shape = [(2, 4, 6, 6), (3, 2, 3, 4), (3, 2, 6, 1)]
+    border_mode = [((1, 2), (2, 1)), ((1, 1), (0, 3)), ((2, 1), (0, 0))]
 
     def test_fwd(self):
         img_sym = theano.tensor.tensor4('img')
         kern_sym = theano.tensor.tensor4('kern')
 
-        img = np.random.random(self.imshp).astype(theano.config.floatX)
-        kern = np.random.random(self.kshp).astype(theano.config.floatX)
+        for imshp, kshp, pad in zip(self.img_shape, self.kern_shape, self.border_mode):
+            img = np.random.random(imshp).astype(theano.config.floatX)
+            kern = np.random.random(kshp).astype(theano.config.floatX)
 
-        asymmetric_conv_op = self.conv2d(border_mode=self.pad, subsample=(1, 1),
-                                         filter_dilation=(1, 1))
-        asymmetric_out_sym = asymmetric_conv_op(img_sym, kern_sym)
-        asymmetric_func = theano.function([img_sym, kern_sym], asymmetric_out_sym, mode=self.mode)
-        assert any([isinstance(node.op, self.conv2d_op)
-                    for node in asymmetric_func.maker.fgraph.toposort()])
-        asymmetric_output = asymmetric_func(img, kern)
+            asymmetric_conv_op = self.conv2d(border_mode=pad, subsample=(1, 1),
+                                             filter_dilation=(1, 1))
+            asymmetric_out_sym = asymmetric_conv_op(img_sym, kern_sym)
+            asymmetric_func = theano.function([img_sym, kern_sym], asymmetric_out_sym, mode=self.mode)
+            assert any([isinstance(node.op, self.conv2d_op)
+                        for node in asymmetric_func.maker.fgraph.toposort()])
+            asymmetric_output = asymmetric_func(img, kern)
 
-        ref_conv_op = self.conv2d(border_mode="valid", subsample=(1, 1),
-                                  filter_dilation=(1, 1))
-        ref_out_sym = ref_conv_op(img_sym, kern_sym)
-        ref_func = theano.function([img_sym, kern_sym], ref_out_sym, mode=self.mode)
+            ref_conv_op = self.conv2d(border_mode="valid", subsample=(1, 1),
+                                      filter_dilation=(1, 1))
+            ref_out_sym = ref_conv_op(img_sym, kern_sym)
+            ref_func = theano.function([img_sym, kern_sym], ref_out_sym, mode=self.mode)
 
-        exp_imshp = (self.imshp[0], self.imshp[1],
-                     self.imshp[2] + self.pad[0][0] + self.pad[0][1],
-                     self.imshp[3] + self.pad[1][0] + self.pad[1][1])
+            exp_imshp = (imshp[0], imshp[1],
+                         imshp[2] + pad[0][0] + pad[0][1],
+                         imshp[3] + pad[1][0] + pad[1][1])
 
-        exp_img = np.zeros(exp_imshp, dtype=theano.config.floatX)
-        exp_img[:, :, self.pad[0][0]:self.imshp[2] + self.pad[0][0],
-                self.pad[1][0]:self.imshp[3] + self.pad[1][0]] = img
-        ref_output = ref_func(exp_img, kern)
+            exp_img = np.zeros(exp_imshp, dtype=theano.config.floatX)
+            exp_img[:, :, pad[0][0]:imshp[2] + pad[0][0],
+                    pad[1][0]:imshp[3] + pad[1][0]] = img
+            ref_output = ref_func(exp_img, kern)
 
-        utt.assert_allclose(asymmetric_output, ref_output)
+            utt.assert_allclose(asymmetric_output, ref_output)
 
-        utt.verify_grad(asymmetric_conv_op, [img, kern], mode=self.mode, eps=1)
+            utt.verify_grad(asymmetric_conv_op, [img, kern], mode=self.mode, eps=1)
 
     def test_gradweight(self):
         img_sym = theano.tensor.tensor4('img')
         top_sym = theano.tensor.tensor4('top')
 
-        img = np.random.random(self.imshp).astype(theano.config.floatX)
-        top = np.random.random(self.topshp).astype(theano.config.floatX)
+        for imshp, kshp, topshp, pad in zip(self.img_shape, self.kern_shape, self.topgrad_shape, self.border_mode):
+            img = np.random.random(imshp).astype(theano.config.floatX)
+            top = np.random.random(topshp).astype(theano.config.floatX)
 
-        asymmetric_conv_op = self.conv2d_gradw(border_mode=self.pad, subsample=(1, 1),
-                                               filter_dilation=(1, 1))
-        asymmetric_out_sym = asymmetric_conv_op(img_sym, top_sym, self.kshp[-2:])
-        asymmetric_func = theano.function([img_sym, top_sym], asymmetric_out_sym, mode=self.mode)
-        assert any([isinstance(node.op, self.conv2d_gradw_op)
-                    for node in asymmetric_func.maker.fgraph.toposort()])
-        asymmetric_output = asymmetric_func(img, top)
+            asymmetric_conv_op = self.conv2d_gradw(border_mode=pad, subsample=(1, 1),
+                                                   filter_dilation=(1, 1))
+            asymmetric_out_sym = asymmetric_conv_op(img_sym, top_sym, kshp[-2:])
+            asymmetric_func = theano.function([img_sym, top_sym], asymmetric_out_sym, mode=self.mode)
+            assert any([isinstance(node.op, self.conv2d_gradw_op)
+                        for node in asymmetric_func.maker.fgraph.toposort()])
+            asymmetric_output = asymmetric_func(img, top)
 
-        ref_conv_op = self.conv2d_gradw(border_mode="valid", subsample=(1, 1),
-                                        filter_dilation=(1, 1))
-        ref_out_sym = ref_conv_op(img_sym, top_sym, self.kshp[-2:])
-        ref_func = theano.function([img_sym, top_sym], ref_out_sym, mode=self.mode)
+            ref_conv_op = self.conv2d_gradw(border_mode="valid", subsample=(1, 1),
+                                            filter_dilation=(1, 1))
+            ref_out_sym = ref_conv_op(img_sym, top_sym, kshp[-2:])
+            ref_func = theano.function([img_sym, top_sym], ref_out_sym, mode=self.mode)
 
-        exp_imshp = (self.imshp[0], self.imshp[1],
-                     self.imshp[2] + self.pad[0][0] + self.pad[0][1],
-                     self.imshp[3] + self.pad[1][0] + self.pad[1][1])
+            exp_imshp = (imshp[0], imshp[1],
+                         imshp[2] + pad[0][0] + pad[0][1],
+                         imshp[3] + pad[1][0] + pad[1][1])
 
-        exp_img = np.zeros(exp_imshp, dtype=theano.config.floatX)
-        exp_img[:, :, self.pad[0][0]:self.imshp[2] + self.pad[0][0],
-                self.pad[1][0]:self.imshp[3] + self.pad[1][0]] = img
-        ref_output = ref_func(exp_img, top)
+            exp_img = np.zeros(exp_imshp, dtype=theano.config.floatX)
+            exp_img[:, :, pad[0][0]:imshp[2] + pad[0][0],
+                    pad[1][0]:imshp[3] + pad[1][0]] = img
+            ref_output = ref_func(exp_img, top)
 
-        utt.assert_allclose(asymmetric_output, ref_output)
+            utt.assert_allclose(asymmetric_output, ref_output)
 
-        def conv_gradweight(inputs_val, output_val):
-            return asymmetric_conv_op(inputs_val, output_val, tensor.as_tensor_variable(self.kshp[-2:]))
+            def conv_gradweight(inputs_val, output_val):
+                return asymmetric_conv_op(inputs_val, output_val, tensor.as_tensor_variable(kshp[-2:]))
 
-        utt.verify_grad(conv_gradweight, [img, top], mode=self.mode, eps=1)
+            utt.verify_grad(conv_gradweight, [img, top], mode=self.mode, eps=1)
 
     def test_gradinput(self):
         kern_sym = theano.tensor.tensor4('kern')
         top_sym = theano.tensor.tensor4('top')
 
-        kern = np.random.random(self.kshp).astype(theano.config.floatX)
-        top = np.random.random(self.topshp).astype(theano.config.floatX)
+        for imshp, kshp, topshp, pad in zip(self.img_shape, self.kern_shape, self.topgrad_shape, self.border_mode):
+            kern = np.random.random(kshp).astype(theano.config.floatX)
+            top = np.random.random(topshp).astype(theano.config.floatX)
 
-        asymmetric_conv_op = self.conv2d_gradi(border_mode=self.pad, subsample=(1, 1),
-                                               filter_dilation=(1, 1))
-        asymmetric_out_sym = asymmetric_conv_op(kern_sym, top_sym, self.imshp[-2:])
-        asymmetric_func = theano.function([kern_sym, top_sym], asymmetric_out_sym, mode=self.mode)
-        assert any([isinstance(node.op, self.conv2d_gradi_op)
-                    for node in asymmetric_func.maker.fgraph.toposort()])
-        asymmetric_output = asymmetric_func(kern, top)
+            asymmetric_conv_op = self.conv2d_gradi(border_mode=pad, subsample=(1, 1),
+                                                   filter_dilation=(1, 1))
+            asymmetric_out_sym = asymmetric_conv_op(kern_sym, top_sym, imshp[-2:])
+            asymmetric_func = theano.function([kern_sym, top_sym], asymmetric_out_sym, mode=self.mode)
+            assert any([isinstance(node.op, self.conv2d_gradi_op)
+                        for node in asymmetric_func.maker.fgraph.toposort()])
+            asymmetric_output = asymmetric_func(kern, top)
 
-        ref_conv_op = self.conv2d_gradi(border_mode="valid", subsample=(1, 1),
-                                        filter_dilation=(1, 1))
-        exp_imshp = [self.imshp[2] + self.pad[0][0] + self.pad[0][1],
-                     self.imshp[3] + self.pad[1][0] + self.pad[1][1]]
-        ref_out_sym = ref_conv_op(kern_sym, top_sym, exp_imshp)
-        ref_func = theano.function([kern_sym, top_sym], ref_out_sym, mode=self.mode)
+            ref_conv_op = self.conv2d_gradi(border_mode="valid", subsample=(1, 1),
+                                            filter_dilation=(1, 1))
+            exp_imshp = [imshp[2] + pad[0][0] + pad[0][1],
+                         imshp[3] + pad[1][0] + pad[1][1]]
+            ref_out_sym = ref_conv_op(kern_sym, top_sym, exp_imshp)
+            ref_func = theano.function([kern_sym, top_sym], ref_out_sym, mode=self.mode)
 
-        ref_output = ref_func(kern, top)
+            ref_output = ref_func(kern, top)
 
-        ref_output = ref_output[:, :, self.pad[0][0]:self.imshp[2] + self.pad[0][0],
-                                self.pad[1][0]:self.imshp[3] + self.pad[1][0]]
+            ref_output = ref_output[:, :, pad[0][0]:imshp[2] + pad[0][0],
+                                    pad[1][0]:imshp[3] + pad[1][0]]
 
-        utt.assert_allclose(asymmetric_output, ref_output)
+            utt.assert_allclose(asymmetric_output, ref_output)
 
-        def conv_gradinputs(filters_val, output_val):
-            return asymmetric_conv_op(filters_val, output_val, tensor.as_tensor_variable(self.imshp[-2:]))
+            def conv_gradinputs(filters_val, output_val):
+                return asymmetric_conv_op(filters_val, output_val, tensor.as_tensor_variable(imshp[-2:]))
 
-        utt.verify_grad(conv_gradinputs, [kern, top], mode=self.mode, eps=1)
+            utt.verify_grad(conv_gradinputs, [kern, top], mode=self.mode, eps=1)
 
 
 class TestCausalConv(unittest.TestCase):
     mode = theano.compile.mode.Mode(optimizer='None')
 
-    imshp = (3, 2, 5)
-    kshp = (2, 2, 3)
-    topshp = (3, 2, 5)
+    img = np.array([[[2, 4, 9, 5, 8], [0, 0, 4, 0, 5]],
+                    [[2, 5, 8, 5, 5], [1, 3, 0, 7, 9]],
+                    [[7, 0, 7, 1, 0], [0, 1, 4, 7, 2]]]).astype(theano.config.floatX)
+    kern = np.array([[[5, 3, 1], [3, 1, 0]],
+                     [[6, 4, 9], [2, 2, 7]]]).astype(theano.config.floatX)
+    dilation = 2
+    precomp_top = np.array([[[10, 20, 63, 37, 88], [12, 24, 70, 46, 120]],
+                            [[13, 34, 47, 64, 78], [14, 36, 58, 70, 105]],
+                            [[35, 3, 68, 27, 38], [42, 2, 78, 22, 103]]]).astype(theano.config.floatX)
 
     def test_interface(self):
         img_sym = theano.tensor.tensor3('img')
         kern_sym = theano.tensor.tensor3('kern')
 
-        img = np.random.random(self.imshp).astype(theano.config.floatX)
-        kern = np.random.random(self.kshp).astype(theano.config.floatX)
-
-        sym_out = causal_conv(img_sym, kern_sym, self.kshp, filter_dilation=1)
+        sym_out = causal_conv(img_sym, kern_sym, self.kern.shape, filter_dilation=self.dilation)
 
         causal_func = theano.function([img_sym, kern_sym], sym_out, mode=self.mode)
 
-        output = causal_func(img, kern)
+        output = causal_func(self.img, self.kern)
 
-        assert output.shape == self.topshp
+        utt.assert_allclose(output, self.precomp_top)
 
-        # def causal_conv(inputs_val, filters_val):
-        #     return dilated_causal_conv(inputs_val, filters_val, self.kshp, filter_dilation=1)
+        def causal_conv_fn(inputs_val, filters_val):
+            return causal_conv(inputs_val, filters_val, self.kern.shape, filter_dilation=1)
 
-        # utt.verify_grad(causal_conv, [img, kern], mode=self.mode, eps=1)
+        utt.verify_grad(causal_conv_fn, [self.img, self.kern], mode=self.mode, eps=1)

--- a/theano/tensor/nnet/tests/test_corr.py
+++ b/theano/tensor/nnet/tests/test_corr.py
@@ -11,6 +11,7 @@ import theano.tensor as T
 from theano.tests import unittest_tools as utt
 from theano.tensor.nnet import corr, conv
 from theano.tensor.nnet.tests.test_abstract_conv import Grouped_conv_noOptim, TestUnsharedConv
+from theano.tensor.nnet.tests.test_abstract_conv import TestAsymmetricPadding
 
 
 class TestCorr2D(utt.InferShapeTester):
@@ -453,6 +454,16 @@ class TestGroupCorr2d(Grouped_conv_noOptim):
 
 
 class TestUnsharedCorr2d(TestUnsharedConv):
+    if theano.config.mode == "FAST_COMPILE":
+        mode = theano.compile.get_mode("FAST_RUN").excluding('gpuarray')
+    else:
+        mode = None
+    conv2d_op = corr.CorrMM
+    conv2d_gradw_op = corr.CorrMM_gradWeights
+    conv2d_gradi_op = corr.CorrMM_gradInputs
+
+
+class TestAsymmetricCorr(TestAsymmetricPadding):
     if theano.config.mode == "FAST_COMPILE":
         mode = theano.compile.get_mode("FAST_RUN").excluding('gpuarray')
     else:

--- a/theano/tensor/nnet/tests/test_corr.py
+++ b/theano/tensor/nnet/tests/test_corr.py
@@ -11,7 +11,7 @@ import theano.tensor as T
 from theano.tests import unittest_tools as utt
 from theano.tensor.nnet import corr, conv
 from theano.tensor.nnet.tests.test_abstract_conv import Grouped_conv_noOptim, TestUnsharedConv
-from theano.tensor.nnet.tests.test_abstract_conv import TestAsymmetricPadding
+from theano.tensor.nnet.tests.test_abstract_conv import TestAsymmetricPadding, TestCausalConv
 
 
 class TestCorr2D(utt.InferShapeTester):
@@ -471,6 +471,13 @@ class TestAsymmetricCorr(TestAsymmetricPadding):
     conv2d_op = corr.CorrMM
     conv2d_gradw_op = corr.CorrMM_gradWeights
     conv2d_gradi_op = corr.CorrMM_gradInputs
+
+
+class TestCausalCorr(TestCausalConv):
+    if theano.config.mode == "FAST_COMPILE":
+        mode = theano.compile.get_mode("FAST_RUN").excluding('gpuarray')
+    else:
+        mode = None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Related to #5515. I've tried to use a similar approach as in [Keras](https://github.com/fchollet/keras/pull/5489).

This also adds asymmetric padding.

- [x] ~~Dilated Causal wrapper function~~

- [x] ~~Make multiple test cases~~

- [x] ~~Docstrings everywhere~~

- [x] ~~3D case?~~ - NotImplementedError

- [ ] Use cuDNN if the tuple has two same integers. Maybe use cuDNN even otherwise and pre/postprocess the result to simulate asymmetric padding