### PR TITLE
Add data type configuration to algorithms hash for cuDNN convolutions caching system

### DIFF
--- a/theano/gpuarray/c_code/dnn_fwd.c
+++ b/theano/gpuarray/c_code/dnn_fwd.c
@@ -352,7 +352,7 @@ APPLY_SPECIFIC(conv_fwd)(PyGpuArrayObject *input, PyGpuArrayObject *kerns,
     }
     fprintf(stderr, "(using %s%s %s%s%s, ws:%ld, hash:%s)\n",
             algorithm_name,
-            mathtype == CUDNN_TENSOR_OP_MATH ? "[T]" : "",
+            mathtype == CUDNN_TENSOR_OP_MATH ? "(tensor_op)" : "",
             params->choose_time ? "(timed)": "" ,
             reuse_algo ? "(reused)" : "",
             use_cached ? "(cache)": "",

--- a/theano/gpuarray/c_code/dnn_gi.c
+++ b/theano/gpuarray/c_code/dnn_gi.c
@@ -170,7 +170,7 @@ APPLY_SPECIFIC(conv_gi)(PyGpuArrayObject *kerns, PyGpuArrayObject *output,
       char pci_id[16];
       gpucontext_property(c->ctx, GA_CTX_PROP_PCIBUSID, pci_id);
       // check out cache
-      hashkey=dnn_conv_shape(APPLY_SPECIFIC(input), *input, APPLY_SPECIFIC(kerns), kerns, desc, output, groups);
+      hashkey = dnn_conv_shape(APPLY_SPECIFIC(input), *input, APPLY_SPECIFIC(kerns), kerns, desc, output, groups);
       if (hashkey.empty()) {
         cuda_exit(c->ctx);
         return 1;
@@ -307,13 +307,12 @@ APPLY_SPECIFIC(conv_gi)(PyGpuArrayObject *kerns, PyGpuArrayObject *output,
         cuda_exit(c->ctx);
         return 1;
     }
-    // NB: This is printed only when algorithm is chosen at runtime.
-    fprintf(stderr, "(using %s %s%s%s%s, ws:%ld, hash:%s)\n",
+    fprintf(stderr, "(using %s%s %s%s%s, ws:%ld, hash:%s)\n",
             algorithm_name,
+            mathtype == CUDNN_TENSOR_OP_MATH ? "(tensor_op)" : "",
             params->choose_time ? "(timed)": "" ,
             reuse_algo ? "(reused)" : "",
             use_cached ? "(cache)": "",
-            mathtype == CUDNN_TENSOR_OP_MATH ? "(tensor op)" : "",
             worksize,
             hashkey.c_str()
       );

--- a/theano/gpuarray/c_code/dnn_gw.c
+++ b/theano/gpuarray/c_code/dnn_gw.c
@@ -297,13 +297,12 @@ APPLY_SPECIFIC(conv_gw)(PyGpuArrayObject *input, PyGpuArrayObject *output,
       cuda_exit(c->ctx);
       return 1;
     }
-    // NB: This is printed only when algorithm is chosen at runtime.
-    fprintf(stderr, "(using %s %s%s%s%s, ws:%ld, hash:%s)\n",
+    fprintf(stderr, "(using %s%s %s%s%s, ws:%ld, hash:%s)\n",
             algorithm_name,
+            mathtype == CUDNN_TENSOR_OP_MATH ? "(tensor_op)" : "",
             params->choose_time ? "(timed)": "" ,
             reuse_algo ? "(reused)" : "",
             use_cached ? "(cache)": "",
-            mathtype == CUDNN_TENSOR_OP_MATH ? "(tensor op)" : "",
             worksize,
             hashkey.c_str()
      );


### PR DESCRIPTION
While running scripts from #5932 , I discovered an error that can be reproduced with following code and master branch:
File `test12.py`
```python
from __future__ import absolute_import, print_function, division
import numpy as np
import theano.tests.unittest_tools as utt
# Force use of new back-end
from theano.gpuarray.tests.config import mode_with_gpu
from theano.gpuarray import dnn
import theano

utt.seed_rng()

def get_function(inputs_shape, filters_shape, dtype, precision, algo, border_mode='full'):
    inputs_val = np.random.random(inputs_shape).astype(dtype)
    filters_val = np.random.random(filters_shape).astype(dtype)
    inputs_val /= 10
    filters_val /= 10
    inputs = theano.shared(inputs_val)
    filters = theano.shared(filters_val)
    conv = dnn.dnn_conv(img=inputs, kerns=filters, border_mode=border_mode,
                        algo=algo, precision=precision, direction_hint='forward!')
    return theano.function([], conv)


f1 = get_function((2, 3, 5, 5), (2, 3, 40, 4), 'float16', 'float16', 'guess_once')
# Let's change just dtype.
f2 = get_function((2, 3, 5, 5), (2, 3, 40, 4), 'float16', 'float32', 'guess_once')

# Then let's run.
f1()
f2()
```
This produces the following output:
```

(python2) C:\Users\notoraptor\mila\dev\git\theano>python ..\test12.py
Using cuDNN version 7001 on context None
Mapped name None to device cuda: GeForce GTX 1050 (0000:01:00.0)
(using CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM , ws:0, hash:FWD|GPU#0000:01:00.0 -g 1 -dim 2,3,5,5,75,25,5,1 -filt 2,3,40,4 -mode conv -pad 39,3 -subsample 1,1 -dilation 1,1 [unaligned])
(using CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM (cache), ws:0, hash:FWD|GPU#0000:01:00.0 -g 1 -dim 2,3,5,5,75,25,5,1 -filt 2,3,40,4 -mode conv -pad 39,3 -subsample 1,1 -dilation 1,1 [unaligned])
Traceback (most recent call last):
  File "..\test12.py", line 29, in <module>
    f2()
  File "c:\users\notoraptor\mila\dev\git\theano\theano\compile\function_module.py", line 917, in __call__
    storage_map=getattr(self.fn, 'storage_map', None))
  File "c:\users\notoraptor\mila\dev\git\theano\theano\gof\link.py", line 325, in raise_with_op
    reraise(exc_type, exc_value, exc_trace)
  File "c:\users\notoraptor\mila\dev\git\theano\theano\compile\function_module.py", line 903, in __call__
    self.fn() if output_subset is None else\
RuntimeError: error doing cuDNN conv FWD operation: CUDNN_STATUS_BAD_PARAM
Apply node that caused the error: GpuDnnConv{algo='guess_once', inplace=True, num_groups=1}(GpuContiguous.0, GpuContiguous.0, GpuAllocEmpty{dtype='float16', context_name=None}.0, GpuDnnConvDesc{border_mode='full', subsample=(1, 1), dilation=(1, 1), conv_mode='conv', precision='float32', num_groups=1}.0, Constant{1.0}, Constant{0.0})
Toposort index: 20
Inputs types: [GpuArrayType<None>(float16, 4D), GpuArrayType<None>(float16, 4D), GpuArrayType<None>(float16, 4D), <theano.gof.type.CDataType object at 0x0000000007B0ABE0>, Scalar(float32), Scalar(float32)]
Inputs shapes: [(2, 3, 5, 5), (2, 3, 40, 4), (2, 2, 44, 8), 'No shapes', (), ()]
Inputs strides: [(150, 50, 10, 2), (960, 320, 8, 2), (1408, 704, 16, 2), 'No strides', (), ()]
Inputs values: ['not shown', 'not shown', 'not shown', <capsule object NULL at 0x0000000007E8E9C0>, 1.0, 0.0]
Outputs clients: [['output']]

HINT: Re-running with most Theano optimization disabled could give you a back-trace of when this node was created. This can be done with by setting the Theano flag 'optimizer=fast_compile'. If that does not work, Theano optimizations can be disabled with 'optimizer=None'.
HINT: Use the Theano flag 'exception_verbosity=high' for a debugprint and storage map footprint of this apply node.
```

So, `f2()` reuses the algorithm cached by `f1()` but then fails with a `CUDNN_STATUS_BAD_PARAM`. The only difference between `f1()` and `f2()` is the data type configuration (true half config for `f1()`, pseudo half config for `f2()`).

Then, if we run the same code but with `f2()` before `f1()`, everything works:
```

(python2) C:\Users\notoraptor\mila\dev\git\theano>python ..\test21.py
Using cuDNN version 7001 on context None
Mapped name None to device cuda: GeForce GTX 1050 (0000:01:00.0)
(using CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM , ws:1920, hash:FWD|GPU#0000:01:00.0 -g 1 -dim 2,3,5,5,75,25,5,1 -filt 2,3,40,4 -mode conv -pad 39,3 -subsample 1,1 -dilation 1,1 [unaligned])
(using CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM (cache), ws:1920, hash:FWD|GPU#0000:01:00.0 -g 1 -dim 2,3,5,5,75,25,5,1 -filt 2,3,40,4 -mode conv -pad 39,3 -subsample 1,1 -dilation 1,1 [unaligned])
```

We can remark that the worksizw (which is cached with the algorithm) computed by `f1()` (true half config) is 0, but the one computed by `f2()` (pseudo half config) is 1920. As the first called function puts its found algorithm to the cache, that means the second may try to use this algorithm with the associated worksize. But it seems worksize can vary depending on data type configuration, which may make the second called function fail if cached worksize is smaller than the worksize she needs.

To fix it, this PR suggests to add data type configuration to the algorithm hash. There may be other solutions, but I don't yet find a better one.

What do you think ? @nouiz @abergeron @borisfom 

Some remarks:
- We can't currently add the worksize itself to the hash, because we must compute the hash to look for the algorithm in the cache, but we must look for the algorithm in the cache and fail to find it before getting a new algorithm and then computing required worksize.
- Another solution may be to not add worksize to the cache. But I don't know if getting worksize is an expensive computation.