### PR TITLE
Automatically add dnn.bin_path to PATH at runtime on Windows

### DIFF
--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -49,6 +49,7 @@ from .opt import (gpu_seqopt, register_opt, pool_db, pool_db2,
 from .opt_util import alpha_merge, output_merge, inplace_allocempty, pad_dims, unpad_dims
 
 from theano.configdefaults import SUPPORTED_DNN_CONV_ALGO_RUNTIME
+import theano.pathparse
 
 DNN_CONV_ALGO_CHOOSE_ONCE = ['guess_once', 'time_once']
 DNN_CONV_ALGO_CHOOSE_TIME = ['time_once', 'time_on_shape_change']
@@ -60,6 +61,9 @@ except ImportError:
 
 # Update these names when new versions of cudnn are supported.
 WIN32_CUDNN_NAMES = ['cudnn64_7.dll', 'cudnn64_6.dll', 'cudnn64_5.dll']
+
+if sys.platform == 'win32':
+    theano.pathparse.PathParser(theano.config.dnn.bin_path)
 
 
 def _load_lib(name):

--- a/theano/pathparse.py
+++ b/theano/pathparse.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import, print_function, division
+import os
+import sys
+
+
+class PathParser(object):
+    """
+    Class that allows to modify system's PATH environment variable
+    at runtime. Currently used in ``theano.gpuarray.dnn`` module
+    on Windows only.
+
+    **Examples**:
+
+    ..code-block:: python
+
+        theano.pathparse.PathParser(pathToAdd1, pathToAdd2, ...)
+        # PATH is then automatically updated for this execution.
+
+
+    ..code-block:: python
+
+        paths = theano.pathparse.PathParser()
+        paths.add(path1)
+        paths.add(path2)
+        # PATH is updated after each call to ``add()``.
+
+    """
+    paths = set()
+
+    def _add(self, path):
+        path = path.strip()
+        if path:
+            if sys.platform == 'win32':
+                # Windows is case-insensitive.
+                path = path.lower()
+            self.paths.add(os.path.abspath(path))
+
+    def _update(self):
+        os.environ['PATH'] = os.pathsep.join(sorted(self.paths))
+
+    def _parse(self):
+        for path in os.environ['PATH'].split(os.pathsep):
+            self._add(path)
+
+    def __init__(self, *paths):
+        self._parse()
+        for path in paths:
+            self._add(path)
+        self._update()
+
+    def add(self, path):
+        self._add(path)
+        self._update()
+
+    def _debug(self):
+        for path in sorted(self.paths):
+            print(path)


### PR DESCRIPTION
Fix #6330 

Add `dnn.bin_path` to system's `PATH` environment variable on Windows only at runtime, so that user does not need to do it himself anymore. This works well on my computer (Windows 10 64 bits).

@abergeron @nouiz 