### PR TITLE
Check shapes of spatial transform theta parameters

### DIFF
--- a/theano/gpuarray/c_code/dnn_sptf_grid.c
+++ b/theano/gpuarray/c_code/dnn_sptf_grid.c
@@ -53,15 +53,6 @@ APPLY_SPECIFIC(dnn_sptf_grid)(PyGpuArrayObject * theta,
         return 1;
     }
 
-    if ( PyGpuArray_DIM( theta, 1 ) != 2 || PyGpuArray_DIM( theta, 2 ) != 3 )
-    {
-        PyErr_Format( PyExc_RuntimeError,
-            "GpuDnnTransformerGrid: incorrect dimensions for theta, expected (%d, %d, %d), got (%d, %d, %d)",
-            PyGpuArray_DIMS( theta )[0], 2, 3, PyGpuArray_DIMS( theta )[0],
-            PyGpuArray_DIMS( theta )[1], PyGpuArray_DIMS( theta )[2] );
-        return 1;
-    }
-
     if ( PyArray_NDIM( out_dims ) != 1 || PyArray_SIZE( out_dims ) != 4 )
     {
         PyErr_SetString( PyExc_MemoryError,
@@ -74,6 +65,16 @@ APPLY_SPECIFIC(dnn_sptf_grid)(PyGpuArrayObject * theta,
     num_channels = (int) *( (npy_int64 *) PyArray_GETPTR1( out_dims, 1 ) );
     height = (int) *( (npy_int64 *) PyArray_GETPTR1( out_dims, 2 ) );
     width = (int) *( (npy_int64 *) PyArray_GETPTR1( out_dims, 3 ) );
+
+    if ( PyGpuArray_DIM( theta, 0 ) != num_images ||
+         PyGpuArray_DIM( theta, 1 ) != 2 || PyGpuArray_DIM( theta, 2 ) != 3 )
+    {
+        PyErr_Format( PyExc_RuntimeError,
+            "GpuDnnTransformerGrid: incorrect dimensions for theta, expected (%d, %d, %d), got (%d, %d, %d)",
+            num_images, 2, 3, PyGpuArray_DIMS( theta )[0],
+            PyGpuArray_DIMS( theta )[1], PyGpuArray_DIMS( theta )[2] );
+        return 1;
+    }
 
     // Set transformed output dimensions to setup the descriptor
     desc_dims[0] = num_images;


### PR DESCRIPTION
Hi @joaovictortr. Thanks for making the spatial transform from cuDNN available. I have a small suggestion for the size check of the `theta` parameter. The current test checks the second and third dimensions, but doesn't check if the number of rows in `theta` is the same as the number of rows in the input. This patch would change the shape check to make sure that the number of rows in `theta` matches the input shape.

---

If `theta` is shorter than the input, the cuDNN function will currently return random values for all the inputs that fall outside `theta`'s range. Here's an example:
```python
import numpy as np
import theano
import theano.gpuarray
import theano.tensor as T

# input with 2 rows
x_val = np.ones(shape=(2, 3, 5, 5)).astype(theano.config.floatX)
# theta with 1 row
theta_val = np.array([[[1, 0, 0], [0, 1, 0]]]).astype(theano.config.floatX)

print('theta shape', theta_val.shape)
print('x shape', x_val.shape)

x = T.tensor4()
theta = T.tensor3()

f = theano.function([x, theta], theano.gpuarray.dnn.dnn_spatialtf(x, theta))
res = f(x_val, theta_val)
print('spatialtf result')
print(res)
```
This produces the output below. The result is correct for the first row of the input, but the second row looks like a random transformation (it's different every time):
```
theta shape (1, 2, 3)
x shape (2, 3, 5, 5)
spatialtf result
[[[[ 1.          1.          1.          1.          1.        ]
   [ 1.          1.          1.          1.          1.        ]
   [ 1.          1.          1.          1.          1.        ]
   [ 1.          1.          1.          1.          1.        ]
   [ 1.          1.          1.          1.          1.        ]]

  [[ 1.          1.          1.          1.          1.        ]
   [ 1.          1.          1.          1.          1.        ]
   [ 1.          1.          1.          1.          1.        ]
   [ 1.          1.          1.          1.          1.        ]
   [ 1.          1.          1.          1.          1.        ]]

  [[ 1.          1.          1.          1.          1.        ]
   [ 1.          1.          1.          1.          1.        ]
   [ 1.          1.          1.          1.          1.        ]
   [ 1.          1.          1.          1.          1.        ]
   [ 1.          1.          1.          1.          1.        ]]]


 [[[ 1.          1.          1.          1.          0.        ]
   [ 1.          1.          1.          0.5         0.        ]
   [ 1.          1.          1.          0.          0.        ]
   [ 1.          0.93939394  0.33333333  0.          0.        ]
   [ 0.87878788  0.60606061  0.          0.          0.        ]]

  [[ 1.          1.          1.          1.          0.        ]
   [ 1.          1.          1.          0.5         0.        ]
   [ 1.          1.          1.          0.          0.        ]
   [ 1.          0.93939394  0.33333333  0.          0.        ]
   [ 0.87878788  0.60606061  0.          0.          0.        ]]

  [[ 1.          1.          1.          1.          0.        ]
   [ 1.          1.          1.          0.5         0.        ]
   [ 1.          1.          1.          0.          0.        ]
   [ 1.          0.93939394  0.33333333  0.          0.        ]
   [ 0.87878788  0.60606061  0.          0.          0.        ]]]]
```