### PR TITLE
Fixing math_type for F32 and cache update

### DIFF
--- a/theano/gpuarray/c_code/dnn_fwd.c
+++ b/theano/gpuarray/c_code/dnn_fwd.c
@@ -360,7 +360,7 @@ APPLY_SPECIFIC(conv_fwd)(PyGpuArrayObject *input, PyGpuArrayObject *kerns,
         dnn_conv_update_cache(hashkey, prev_algo);
 
       if (params->choose_once)
-      reuse_algo = 1;
+        reuse_algo = 1;
     }
 
   } // params->choose_algo

--- a/theano/gpuarray/c_code/dnn_fwd.c
+++ b/theano/gpuarray/c_code/dnn_fwd.c
@@ -231,7 +231,8 @@ APPLY_SPECIFIC(conv_fwd)(PyGpuArrayObject *input, PyGpuArrayObject *kerns,
           return -1;
         }
         // set the 'tensor math ok' flag
-        c_set_math_type_for_conv(desc, CUDNN_TENSOR_OP_MATH);
+        if (input->ga.typecode == GA_HALF)
+          c_set_math_type_for_conv(desc, CUDNN_TENSOR_OP_MATH);
 
         // We don't sync the buffer as we don't care about the values.
         err = cudnnFindConvolutionForwardAlgorithmEx(
@@ -265,12 +266,11 @@ APPLY_SPECIFIC(conv_fwd)(PyGpuArrayObject *input, PyGpuArrayObject *kerns,
         #endif
 
         algo = choice.algo;
-        prev_algo.algo = (int)algo;
-        prev_algo.wsSize = worksize = choice.memory;
+        worksize = choice.memory;
 #if CUDNN_MAJOR >= 7
-        prev_algo.mathType = mathtype = choice.mathType;
+        if (input->ga.typecode == GA_HALF)
+          mathtype = choice.mathType;
 #endif
-
       } else {
         err = cudnnGetConvolutionForwardAlgorithm(
           params->handle, APPLY_SPECIFIC(input), APPLY_SPECIFIC(kerns),
@@ -283,9 +283,6 @@ APPLY_SPECIFIC(conv_fwd)(PyGpuArrayObject *input, PyGpuArrayObject *kerns,
           cuda_exit(c->ctx);
           return 1;
         }
-        prev_algo.algo = algo;
-        // no tensor_op returned from Get()
-        prev_algo.mathType = mathtype = CUDNN_DEFAULT_MATH;
       }
     }
   }
@@ -334,18 +331,17 @@ APPLY_SPECIFIC(conv_fwd)(PyGpuArrayObject *input, PyGpuArrayObject *kerns,
     }
   }
 
-  if (params->choose_algo && (!params->choose_once || !reuse_algo)) {
-    // algo may have changed due to fallback, we must update it.
+  if (params->choose_algo && !reuse_algo) {
+    // save for next time/cache
     prev_algo.algo = algo;
-    // save worksize for next time/cache
     prev_algo.wsSize = worksize;
-
-    // Add to the cache if we choose on shape change, or first time if we choose once.
-    dnn_conv_update_cache(hashkey, prev_algo);
-  }
+    prev_algo.mathType = mathtype;
+    // Add to the cache if we choose on shape change, or first time if
+    // we choose once.
+    if (!use_cached)
+      dnn_conv_update_cache(hashkey, prev_algo);
 
 #ifdef DEBUG
-  if (params->choose_algo) {
     if (0 != theano_enum_to_string_cudnnConvolutionFwdAlgo_t(algo, algorithm_name)) {
       cuda_exit(c->ctx);
       return 1;
@@ -359,12 +355,11 @@ APPLY_SPECIFIC(conv_fwd)(PyGpuArrayObject *input, PyGpuArrayObject *kerns,
             worksize,
             hashkey.c_str()
       );
-  }
 #endif
-
-  if (params->choose_once) {
-    reuse_algo = 1;
-  }
+    
+    if (params->choose_once)
+      reuse_algo = 1;
+  } // params->choose_algo && !reuse_algo
 
   {
     gpudata *workspace = 0;


### PR DESCRIPTION
Added conditions to exclude TENSOR_OP (HMMA) convo algos when operands  are 32-bit - since they lose precision. 
Also, streamlined saving old algo and cache updates - I think there was a bug in cache update condition there, too. 