### PR TITLE
Fix rpath for cuDNN module.

### DIFF
--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -227,7 +227,7 @@ dnn_available.msg = None
 
 def CUDNNDataType(name, freefunc=None):
     cargs = []
-    if config.dnn.bin_path:
+    if config.dnn.bin_path and sys.platform != 'win32':
         cargs.append('-Wl,-rpath,' + config.dnn.bin_path)
 
     return CDataType(name, freefunc,
@@ -256,7 +256,7 @@ class DnnVersion(Op):
         return [config.dnn.library_path]
 
     def c_compile_args(self):
-        if config.dnn.bin_path:
+        if config.dnn.bin_path and sys.platform != 'win32':
             return ['-Wl,-rpath,' + config.dnn.bin_path]
         return []
 
@@ -385,7 +385,7 @@ class DnnBase(COp):
         return [config.dnn.library_path]
 
     def c_compile_args(self):
-        if config.dnn.bin_path:
+        if config.dnn.bin_path and sys.platform != 'win32':
             return ['-Wl,-rpath,' + config.dnn.bin_path]
         return []
 
@@ -430,7 +430,7 @@ class GpuDnnConvDesc(COp):
         return [config.dnn.library_path]
 
     def c_compile_args(self):
-        if config.dnn.bin_path:
+        if config.dnn.bin_path and sys.platform != 'win32':
             return ['-Wl,-rpath,' + config.dnn.bin_path]
         return []
 

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -228,10 +228,7 @@ dnn_available.msg = None
 def CUDNNDataType(name, freefunc=None):
     cargs = []
     if config.dnn.bin_path:
-        if sys.platform == 'darwin':
-            cargs.append('-Wl,-rpath,' + config.dnn.bin_path)
-        else:
-            cargs.append('-Wl,-rpath,"' + config.dnn.bin_path + '"')
+        cargs.append('-Wl,-rpath,' + config.dnn.bin_path)
 
     return CDataType(name, freefunc,
                      headers=['cudnn.h'],
@@ -260,10 +257,7 @@ class DnnVersion(Op):
 
     def c_compile_args(self):
         if config.dnn.bin_path:
-            if sys.platform == 'darwin':
-                return ['-Wl,-rpath,' + config.dnn.bin_path]
-            else:
-                return ['-Wl,-rpath,"' + config.dnn.bin_path + '"']
+            return ['-Wl,-rpath,' + config.dnn.bin_path]
         return []
 
     def c_support_code(self):
@@ -392,10 +386,7 @@ class DnnBase(COp):
 
     def c_compile_args(self):
         if config.dnn.bin_path:
-            if sys.platform == 'darwin':
-                return ['-Wl,-rpath,' + config.dnn.bin_path]
-            else:
-                return ['-Wl,-rpath,"' + config.dnn.bin_path + '"']
+            return ['-Wl,-rpath,' + config.dnn.bin_path]
         return []
 
     def c_code_cache_version(self):
@@ -440,10 +431,7 @@ class GpuDnnConvDesc(COp):
 
     def c_compile_args(self):
         if config.dnn.bin_path:
-            if sys.platform == 'darwin':
-                return ['-Wl,-rpath,' + config.dnn.bin_path]
-            else:
-                return ['-Wl,-rpath,"' + config.dnn.bin_path + '"']
+            return ['-Wl,-rpath,' + config.dnn.bin_path]
         return []
 
     def do_constant_folding(self, node):


### PR DESCRIPTION
This PR fixes rpath for cuDNN ops by removing any quotes around paths. We should not need quotes on Windows anymore when #6356 will be merged.

NB: We should check if this PR does not break anything in buildbot. We also need Jenkins tests to pass, probably on all platforms ?

@abergeron @nouiz 