### PR TITLE
Implement scipy.ndimage.interpolation:zoom operator

### DIFF
--- a/theano/tensor/scipy_ndimage.py
+++ b/theano/tensor/scipy_ndimage.py
@@ -1,0 +1,47 @@
+import theano
+from theano.gradient import DisconnectedType
+from scipy.ndimage.interpolation import zoom
+import numpy as np
+
+class Zoom(theano.Op):
+    # Properties attribute
+    __props__ = ()
+
+    def __init__(self):
+        super(Zoom, self).__init__()
+
+    def make_node(self, x, ref):
+        x = theano.tensor.as_tensor_variable(x)
+        ref = theano.tensor.as_tensor_variable(ref)
+        return theano.Apply(self, [x, ref], [x.type()])
+
+    # Python implementation:
+    def perform(self, node, inputs, outputs_storage):
+        x, ref = inputs
+        z = outputs_storage[0]
+        assert x.ndim == ref.ndim
+        assert x.shape[0] == 1
+        #
+        resize_factors = [
+            ref.shape[2] / x.shape[2],
+            ref.shape[3] / x.shape[3]
+            ]
+        #
+        final_shape = (1, x.shape[1], ref.shape[2], ref.shape[3])
+        z[0] = np.empty(final_shape, dtype=np.float32)
+
+        # Loop over channels
+        for i in range(x.shape[1]):
+            z[0][0,i] = zoom(x[0,i], resize_factors, order=0)
+
+    def infer_shape(self, node, i0_shapes):
+        return i0_shapes[1],
+
+    def connection_pattern(self, node):
+        return [[True], [False]]
+
+    def grad(self, inputs, output_grads):
+        op = Zoom()
+        x, ref = inputs
+        grads = output_grads[0]
+        return op(output_grads[0], x), DisconnectedType()()

--- a/theano/tensor/scipy_ndimage.py
+++ b/theano/tensor/scipy_ndimage.py
@@ -1,7 +1,11 @@
+from __future__ import absolute_import, print_function, division
+
+import numpy as np
+from scipy.ndimage.interpolation import zoom
+
 import theano
 from theano.gradient import DisconnectedType
-from scipy.ndimage.interpolation import zoom
-import numpy as np
+
 
 class Zoom(theano.Op):
     # Properties attribute
@@ -32,7 +36,7 @@ class Zoom(theano.Op):
 
         # Loop over channels
         for i in range(x.shape[1]):
-            z[0][0,i] = zoom(x[0,i], resize_factors, order=0)
+            z[0][0, i] = zoom(x[0, i], resize_factors, order=0)
 
     def infer_shape(self, node, i0_shapes):
         return i0_shapes[1],
@@ -43,5 +47,4 @@ class Zoom(theano.Op):
     def grad(self, inputs, output_grads):
         op = Zoom()
         x, ref = inputs
-        grads = output_grads[0]
         return op(output_grads[0], x), DisconnectedType()()

--- a/theano/tensor/tests/test_scipy_ndimage.py
+++ b/theano/tensor/tests/test_scipy_ndimage.py
@@ -1,25 +1,35 @@
+from __future__ import absolute_import, print_function, division
+
 import unittest
+from scipy.ndimage.interpolation import zoom
+import numpy as np
+from numpy.testing import assert_array_equal
+
+import theano as T
 from theano.tensor.scipy_ndimage import Zoom
 from theano.tests.unittest_tools import verify_grad
-import theano as T
-from scipy.ndimage.interpolation import zoom
-from numpy.testing import assert_array_equal
-import numpy as np
+
 
 def getFn():
-    x   = T.tensor.tensor4()
+    x = T.tensor.tensor4()
     ref = T.tensor.tensor4()
     op = Zoom()
     return T.function([x, ref], op(x, ref))
+
 
 class T_SharedRandomStreams(unittest.TestCase):
     def test_Zoom_single_channel_factor_2(self):
         NCHANS = 1
         ZFACTOR = 2
-        insize  = (1, NCHANS, 32, 32)
-        outsize = (1, NCHANS, int(insize[2] * ZFACTOR), int(insize[3] * ZFACTOR))
+        insize = (1, NCHANS, 32, 32)
+        outsize = (
+            1,
+            NCHANS,
+            int(insize[2] * ZFACTOR),
+            int(insize[3] * ZFACTOR)
+            )
         #
-        x   = np.random.uniform(size=insize).astype(np.float32)
+        x = np.random.uniform(size=insize).astype(np.float32)
         ref = np.random.uniform(size=outsize).astype(np.float32)
         f = getFn()
         #
@@ -27,15 +37,20 @@ class T_SharedRandomStreams(unittest.TestCase):
         assert out.shape == outsize
         for i in range(NCHANS):
             expected = zoom(x, (1, 1, ZFACTOR, ZFACTOR), order=0)
-            assert_array_equal(out[0,i], expected[0,i])
+            assert_array_equal(out[0, i], expected[0, i])
 
     def test_Zoom_single_channel_factor_1p875(self):
         NCHANS = 1
         ZFACTOR = 1.875
-        insize  = (1, NCHANS, 32, 32)
-        outsize = (1, NCHANS, int(insize[2] * ZFACTOR), int(insize[3] * ZFACTOR))
+        insize = (1, NCHANS, 32, 32)
+        outsize = (
+            1,
+            NCHANS,
+            int(insize[2] * ZFACTOR),
+            int(insize[3] * ZFACTOR)
+            )
         #
-        x   = np.random.uniform(size=insize).astype(np.float32)
+        x = np.random.uniform(size=insize).astype(np.float32)
         ref = np.random.uniform(size=outsize).astype(np.float32)
         f = getFn()
         #
@@ -43,15 +58,20 @@ class T_SharedRandomStreams(unittest.TestCase):
         assert out.shape == outsize
         for i in range(NCHANS):
             expected = zoom(x, (1, 1, ZFACTOR, ZFACTOR), order=0)
-            assert_array_equal(out[0,i], expected[0,i])
+            assert_array_equal(out[0, i], expected[0, i])
 
     def test_Zoom_single_channel_factor_1(self):
         NCHANS = 1
         ZFACTOR = 1
-        insize  = (1, NCHANS, 32, 32)
-        outsize = (1, NCHANS, int(insize[2] * ZFACTOR), int(insize[3] * ZFACTOR))
+        insize = (1, NCHANS, 32, 32)
+        outsize = (
+            1,
+            NCHANS,
+            int(insize[2] * ZFACTOR),
+            int(insize[3] * ZFACTOR)
+            )
         #
-        x   = np.random.uniform(size=insize).astype(np.float32)
+        x = np.random.uniform(size=insize).astype(np.float32)
         ref = np.random.uniform(size=outsize).astype(np.float32)
         f = getFn()
         #
@@ -59,15 +79,20 @@ class T_SharedRandomStreams(unittest.TestCase):
         assert out.shape == outsize
         for i in range(NCHANS):
             expected = zoom(x, (1, 1, ZFACTOR, ZFACTOR), order=0)
-            assert_array_equal(out[0,i], expected[0,i])
+            assert_array_equal(out[0, i], expected[0, i])
 
     def test_Zoom_three_channels_factor_2(self):
         NCHANS = 3
         ZFACTOR = 1
-        insize  = (1, NCHANS, 32, 32)
-        outsize = (1, NCHANS, int(insize[2] * ZFACTOR), int(insize[3] * ZFACTOR))
+        insize = (1, NCHANS, 32, 32)
+        outsize = (
+            1,
+            NCHANS,
+            int(insize[2] * ZFACTOR),
+            int(insize[3] * ZFACTOR)
+            )
         #
-        x   = np.random.uniform(size=insize).astype(np.float32)
+        x = np.random.uniform(size=insize).astype(np.float32)
         ref = np.random.uniform(size=outsize).astype(np.float32)
         f = getFn()
         #
@@ -75,30 +100,40 @@ class T_SharedRandomStreams(unittest.TestCase):
         assert out.shape == outsize
         for i in range(NCHANS):
             expected = zoom(x, (1, 1, ZFACTOR, ZFACTOR), order=0)
-            assert_array_equal(out[0,i], expected[0,i])
+            assert_array_equal(out[0, i], expected[0, i])
 
     def test_Zoom_gradient_single_channel_factor_1(self):
         NCHANS = 1
         ZFACTOR = 1
-        insize  = (1, NCHANS, 32, 32)
-        outsize = (1, NCHANS, int(insize[2] * ZFACTOR), int(insize[3] * ZFACTOR))
+        insize = (1, NCHANS, 32, 32)
+        outsize = (
+            1,
+            NCHANS,
+            int(insize[2] * ZFACTOR),
+            int(insize[3] * ZFACTOR)
+            )
         #
-        x   = np.random.uniform(size=insize).astype(np.float32)
+        x = np.random.uniform(size=insize).astype(np.float32)
         ref = np.random.uniform(size=outsize).astype(np.float32)
         op = Zoom()
         #
-        verify_grad(op,[x, ref])
+        verify_grad(op, [x, ref])
 
     # TODO: Test failing
     def test_Zoom_gradient_single_channel_factor_2(self):
         NCHANS = 1
         ZFACTOR = 2
-        insize  = (1, NCHANS, 32, 32)
-        outsize = (1, NCHANS, int(insize[2] * ZFACTOR), int(insize[3] * ZFACTOR))
+        insize = (1, NCHANS, 32, 32)
+        outsize = (
+            1,
+            NCHANS,
+            int(insize[2] * ZFACTOR),
+            int(insize[3] * ZFACTOR)
+            )
         # inputs
-        x   = np.random.uniform(size=insize).astype(np.float32)
+        x = np.random.uniform(size=insize).astype(np.float32)
         ref = np.random.uniform(size=outsize).astype(np.float32)
         # op
         op = Zoom()
         #
-        verify_grad(op,[x, ref])
+        verify_grad(op, [x, ref])

--- a/theano/tensor/tests/test_scipy_ndimage.py
+++ b/theano/tensor/tests/test_scipy_ndimage.py
@@ -1,0 +1,104 @@
+import unittest
+from theano.tensor.scipy_ndimage import Zoom
+from theano.tests.unittest_tools import verify_grad
+import theano as T
+from scipy.ndimage.interpolation import zoom
+from numpy.testing import assert_array_equal
+import numpy as np
+
+def getFn():
+    x   = T.tensor.tensor4()
+    ref = T.tensor.tensor4()
+    op = Zoom()
+    return T.function([x, ref], op(x, ref))
+
+class T_SharedRandomStreams(unittest.TestCase):
+    def test_Zoom_single_channel_factor_2(self):
+        NCHANS = 1
+        ZFACTOR = 2
+        insize  = (1, NCHANS, 32, 32)
+        outsize = (1, NCHANS, int(insize[2] * ZFACTOR), int(insize[3] * ZFACTOR))
+        #
+        x   = np.random.uniform(size=insize).astype(np.float32)
+        ref = np.random.uniform(size=outsize).astype(np.float32)
+        f = getFn()
+        #
+        out = f(x, ref)
+        assert out.shape == outsize
+        for i in range(NCHANS):
+            expected = zoom(x, (1, 1, ZFACTOR, ZFACTOR), order=0)
+            assert_array_equal(out[0,i], expected[0,i])
+
+    def test_Zoom_single_channel_factor_1p875(self):
+        NCHANS = 1
+        ZFACTOR = 1.875
+        insize  = (1, NCHANS, 32, 32)
+        outsize = (1, NCHANS, int(insize[2] * ZFACTOR), int(insize[3] * ZFACTOR))
+        #
+        x   = np.random.uniform(size=insize).astype(np.float32)
+        ref = np.random.uniform(size=outsize).astype(np.float32)
+        f = getFn()
+        #
+        out = f(x, ref)
+        assert out.shape == outsize
+        for i in range(NCHANS):
+            expected = zoom(x, (1, 1, ZFACTOR, ZFACTOR), order=0)
+            assert_array_equal(out[0,i], expected[0,i])
+
+    def test_Zoom_single_channel_factor_1(self):
+        NCHANS = 1
+        ZFACTOR = 1
+        insize  = (1, NCHANS, 32, 32)
+        outsize = (1, NCHANS, int(insize[2] * ZFACTOR), int(insize[3] * ZFACTOR))
+        #
+        x   = np.random.uniform(size=insize).astype(np.float32)
+        ref = np.random.uniform(size=outsize).astype(np.float32)
+        f = getFn()
+        #
+        out = f(x, ref)
+        assert out.shape == outsize
+        for i in range(NCHANS):
+            expected = zoom(x, (1, 1, ZFACTOR, ZFACTOR), order=0)
+            assert_array_equal(out[0,i], expected[0,i])
+
+    def test_Zoom_three_channels_factor_2(self):
+        NCHANS = 3
+        ZFACTOR = 1
+        insize  = (1, NCHANS, 32, 32)
+        outsize = (1, NCHANS, int(insize[2] * ZFACTOR), int(insize[3] * ZFACTOR))
+        #
+        x   = np.random.uniform(size=insize).astype(np.float32)
+        ref = np.random.uniform(size=outsize).astype(np.float32)
+        f = getFn()
+        #
+        out = f(x, ref)
+        assert out.shape == outsize
+        for i in range(NCHANS):
+            expected = zoom(x, (1, 1, ZFACTOR, ZFACTOR), order=0)
+            assert_array_equal(out[0,i], expected[0,i])
+
+    def test_Zoom_gradient_single_channel_factor_1(self):
+        NCHANS = 1
+        ZFACTOR = 1
+        insize  = (1, NCHANS, 32, 32)
+        outsize = (1, NCHANS, int(insize[2] * ZFACTOR), int(insize[3] * ZFACTOR))
+        #
+        x   = np.random.uniform(size=insize).astype(np.float32)
+        ref = np.random.uniform(size=outsize).astype(np.float32)
+        op = Zoom()
+        #
+        verify_grad(op,[x, ref])
+
+    # TODO: Test failing
+    def test_Zoom_gradient_single_channel_factor_2(self):
+        NCHANS = 1
+        ZFACTOR = 2
+        insize  = (1, NCHANS, 32, 32)
+        outsize = (1, NCHANS, int(insize[2] * ZFACTOR), int(insize[3] * ZFACTOR))
+        # inputs
+        x   = np.random.uniform(size=insize).astype(np.float32)
+        ref = np.random.uniform(size=outsize).astype(np.float32)
+        # op
+        op = Zoom()
+        #
+        verify_grad(op,[x, ref])


### PR DESCRIPTION
Implementation of `scipy.ndimage.interpolation:zoom` function as a Theano operator.

This was discussed briefly in #6387 

IMO there are three things to fix:

- test `test_Zoom_gradient_single_channel_factor_2`  fails, most likely the way gradient is computed is wrong 
- The operator accepts two tensors, and will zoom the first tensor so that it has the same shape than the second. It would be better if the operator accepts a tensor and a resize factor/resize shape. I implemented it in the first way because it was the easiest given my limited knowledge of Theano, but we should be able to fix that pretty easily.
- interpolation order is hardcoded to 0, expose it as parameter

