### PR TITLE
libgpuarray full checkout to parse version

### DIFF
--- a/.jenkins/jenkins_buildbot_mac.sh
+++ b/.jenkins/jenkins_buildbot_mac.sh
@@ -27,7 +27,7 @@ LIBDIR=${WORKSPACE}/local
 
 # Make fresh clones of libgpuarray (with no history since we don't need it)
 rm -rf libgpuarray
-git clone --depth 1 "https://github.com/Theano/libgpuarray.git"
+git clone "https://github.com/Theano/libgpuarray.git"
 
 # Clean up previous installs (to make sure no old files are left)
 rm -rf $LIBDIR

--- a/.jenkins/jenkins_buildbot_python2.sh
+++ b/.jenkins/jenkins_buildbot_python2.sh
@@ -16,7 +16,7 @@ LIBDIR=${WORKSPACE}/local
 
 # Make fresh clones of libgpuarray (with no history since we don't need it)
 rm -rf libgpuarray
-git clone --depth 1 "https://github.com/Theano/libgpuarray.git"
+git clone "https://github.com/Theano/libgpuarray.git"
 
 # Clean up previous installs (to make sure no old files are left)
 rm -rf $LIBDIR

--- a/.jenkins/jenkins_buildbot_python2_debug.sh
+++ b/.jenkins/jenkins_buildbot_python2_debug.sh
@@ -16,7 +16,7 @@ LIBDIR=${WORKSPACE}/local
 
 # Make fresh clones of libgpuarray (with no history since we don't need it)
 rm -rf libgpuarray
-git clone --depth 1 "https://github.com/Theano/libgpuarray.git"
+git clone "https://github.com/Theano/libgpuarray.git"
 
 # Clean up previous installs (to make sure no old files are left)
 rm -rf $LIBDIR

--- a/.jenkins/jenkins_buildbot_python3.sh
+++ b/.jenkins/jenkins_buildbot_python3.sh
@@ -22,7 +22,7 @@ LIBDIR=${WORKSPACE}/local
 
 # Make fresh clones of libgpuarray (with no history since we don't need it)
 rm -rf libgpuarray
-git clone --depth 1 "https://github.com/Theano/libgpuarray.git"
+git clone "https://github.com/Theano/libgpuarray.git"
 
 # Clean up previous installs (to make sure no old files are left)
 rm -rf $LIBDIR

--- a/.jenkins/jenkins_buildbot_windows.bat
+++ b/.jenkins/jenkins_buildbot_windows.bat
@@ -24,7 +24,7 @@ set PATH=%PATH%;%LIBDIR%\bin
 
 REM Make fresh clones of libgpuarray (with no history since we dont need it)
 rmdir libgpuarray /s/q
-git clone --depth 1 "https://github.com/Theano/libgpuarray.git"
+git clone "https://github.com/Theano/libgpuarray.git"
 
 REM Clean up previous installs (to make sure no old files are left)
 rmdir %LIBDIR% /s/q

--- a/.jenkins/jenkins_pr_build_cache.sh
+++ b/.jenkins/jenkins_pr_build_cache.sh
@@ -16,7 +16,7 @@ LIBDIR=${WORKSPACE}/local
 
 # Make fresh clones of libgpuarray (with no history since we don't need it)
 rm -rf libgpuarray
-git clone --depth 1 "https://github.com/Theano/libgpuarray.git"
+git clone "https://github.com/Theano/libgpuarray.git"
 
 # Clean up previous installs (to make sure no old files are left)
 rm -rf $LIBDIR

--- a/.jenkins/jenkins_pr_gpu.sh
+++ b/.jenkins/jenkins_pr_gpu.sh
@@ -23,7 +23,7 @@ LIBDIR=${WORKSPACE}/local
 
 # Make fresh clones of libgpuarray (with no history since we don't need it)
 rm -rf libgpuarray
-git clone -b `cat .jenkins/gpuarray-branch` --depth 1 "https://github.com/Theano/libgpuarray.git"
+git clone -b `cat .jenkins/gpuarray-branch` "https://github.com/Theano/libgpuarray.git"
 
 # Clean up previous installs (to make sure no old files are left)
 rm -rf $LIBDIR

--- a/.jenkins/jenkins_pr_mac.sh
+++ b/.jenkins/jenkins_pr_mac.sh
@@ -28,7 +28,7 @@ LIBDIR=${WORKSPACE}/local
 
 # Make fresh clones of libgpuarray (with no history since we don't need it)
 rm -rf libgpuarray
-git clone -b `cat .jenkins/gpuarray-branch` --depth 1 "https://github.com/Theano/libgpuarray.git"
+git clone -b `cat .jenkins/gpuarray-branch` "https://github.com/Theano/libgpuarray.git"
 
 # Clean up previous installs (to make sure no old files are left)
 rm -rf $LIBDIR

--- a/.jenkins/jenkins_pr_win.bat
+++ b/.jenkins/jenkins_pr_win.bat
@@ -20,7 +20,7 @@ set PATH=%PATH%;%LIBDIR%\bin
 REM Make fresh clones of libgpuarray (with no history since we dont need it)
 rmdir libgpuarray /s/q
 set /p GPUARRAY_BRANCH=<.jenkins/gpuarray-branch
-git clone -b %GPUARRAY_BRANCH% --depth 1 "https://github.com/Theano/libgpuarray.git"
+git clone -b %GPUARRAY_BRANCH% "https://github.com/Theano/libgpuarray.git"
 
 REM Clean up previous installs (to make sure no old files are left)
 rmdir %LIBDIR% /s/q


### PR DESCRIPTION
Recent changes in pygpu version parsing do not support `--depth=1` checkouts:
```
 File "theano/gpuarray/__init__.py", line 49, in pygpu_parse_version
   major = int(pieces[0])
ValueError: invalid literal for int() with base 10: '0+untagged'
```