### PR TITLE
Implement truncated normal with box-muller

### DIFF
--- a/theano/gpuarray/rng_mrg.py
+++ b/theano/gpuarray/rng_mrg.py
@@ -271,7 +271,7 @@ class GPUA_mrg_uniform(GpuKernelBase, mrg_uniform_base):
         if (n_streams > n_elements)
           n_streams = n_elements;
 
-        {
+        if (n_elements > 0){
           size_t ls = 0, gs = 0;
           int err = GpuKernel_sched(&%(kname)s, n_streams, &ls, &gs);
           if (err != GA_NO_ERROR) {
@@ -303,7 +303,7 @@ class GPUA_mrg_uniform(GpuKernelBase, mrg_uniform_base):
                    """ % dict(fail=sub['fail']))
 
     def c_code_cache_version(self):
-        return (16,)
+        return (17,)
 
 
 @register_opt2([mrg_uniform], 'fast_compile')

--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -1115,7 +1115,7 @@ class MRG_RandomStreams(object):
         elif n_odd_samples % 2 == 1:
             samples = norm_samples[:-1]
         else:
-            samples = nrom_samples
+            samples = norm_samples
         samples = tensor.reshape(samples, newshape=size, ndim=ndim)
         samples *= std
         samples += avg

--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -1028,8 +1028,8 @@ class MRG_RandomStreams(object):
         return self.choice(size=n, a=None, replace=False, p=pvals,
                            dtype=dtype, nstreams=nstreams, ndim=ndim, **kwargs)
 
-    def normal(self, size, avg=0.0, std=1.0, truncate=False,
-               ndim=None, dtype=None, nstreams=None, **kwargs):
+    def normal(self, size, avg=0.0, std=1.0, ndim=None, dtype=None,
+               nstreams=None, truncate=False, **kwargs):
         """
         Sample a tensor of values from a normal distribution.
 

--- a/theano/sandbox/tests/test_rng_mrg.py
+++ b/theano/sandbox/tests/test_rng_mrg.py
@@ -501,63 +501,6 @@ def test_normal_truncation():
                   prefix='mrg ', allow_01=True, inputs=input,
                   mean_rtol=rtol, std_tol=std_tol)
 
-        sys.stdout.flush()
-
-
-@attr('slow')
-def test_truncated_normal():
-    # just a copy of test_normal0 for truncated normal
-    steps = 50
-    std = 2.
-
-    if (config.mode in ['DEBUG_MODE', 'DebugMode', 'FAST_COMPILE'] or
-            config.mode == 'Mode' and config.linker in ['py']):
-        sample_size = (25, 30)
-        default_rtol = .02
-    else:
-        sample_size = (999, 50)
-        default_rtol = .01
-    sample_size_odd = (sample_size[0], sample_size[1] - 1)
-    x = tensor.matrix()
-
-    test_cases = [
-        (sample_size, sample_size, [], [], -5., default_rtol, default_rtol),
-        (x.shape, sample_size, [x],
-         [np.zeros(sample_size, dtype=config.floatX)],
-         -5., default_rtol, default_rtol),
-        # test odd value
-        (x.shape, sample_size_odd, [x],
-         [np.zeros(sample_size_odd, dtype=config.floatX)],
-         -5., default_rtol, default_rtol),
-        (sample_size, sample_size, [], [],
-         np.arange(np.prod(sample_size),
-                   dtype='float32').reshape(sample_size),
-         10. * std / np.sqrt(steps), default_rtol),
-        # test empty size (scalar)
-        ((), (), [], [], -5., default_rtol, 0.02),
-        # test with few samples at the same time
-        ((1,), (1,), [], [], -5., default_rtol, 0.02),
-        ((3,), (3,), [], [], -5., default_rtol, 0.02),
-    ]
-
-    for size, const_size, var_input, input, avg, rtol, std_tol in test_cases:
-        R = MRG_RandomStreams(234)
-        # Note: we specify `nstreams` to avoid a warning.
-        n = R.truncated_normal(size=size, avg=avg, std=std,
-                               nstreams=rng_mrg.guess_n_streams(size, warn=False))
-        f = theano.function(var_input, n)
-
-        # Increase the number of steps if size implies only a few samples
-        if np.prod(const_size) < 10:
-            steps_ = steps * 60
-        else:
-            steps_ = steps
-        basictest(f, steps_, const_size, target_avg=avg, target_std=std,
-                  prefix='mrg ', allow_01=True, inputs=input,
-                  mean_rtol=rtol, std_tol=std_tol)
-
-        sys.stdout.flush()
-
 
 def basic_multinomialtest(f, steps, sample_size, target_pvals, n_samples,
                           prefix="", mean_rtol=0.04):

--- a/theano/sandbox/tests/test_rng_mrg.py
+++ b/theano/sandbox/tests/test_rng_mrg.py
@@ -501,6 +501,63 @@ def test_normal_truncation():
                   prefix='mrg ', allow_01=True, inputs=input,
                   mean_rtol=rtol, std_tol=std_tol)
 
+        sys.stdout.flush()
+
+
+@attr('slow')
+def test_truncated_normal():
+    # just a copy of test_normal0 for truncated normal
+    steps = 50
+    std = 2.
+
+    if (config.mode in ['DEBUG_MODE', 'DebugMode', 'FAST_COMPILE'] or
+            config.mode == 'Mode' and config.linker in ['py']):
+        sample_size = (25, 30)
+        default_rtol = .02
+    else:
+        sample_size = (999, 50)
+        default_rtol = .01
+    sample_size_odd = (sample_size[0], sample_size[1] - 1)
+    x = tensor.matrix()
+
+    test_cases = [
+        (sample_size, sample_size, [], [], -5., default_rtol, default_rtol),
+        (x.shape, sample_size, [x],
+         [np.zeros(sample_size, dtype=config.floatX)],
+         -5., default_rtol, default_rtol),
+        # test odd value
+        (x.shape, sample_size_odd, [x],
+         [np.zeros(sample_size_odd, dtype=config.floatX)],
+         -5., default_rtol, default_rtol),
+        (sample_size, sample_size, [], [],
+         np.arange(np.prod(sample_size),
+                   dtype='float32').reshape(sample_size),
+         10. * std / np.sqrt(steps), default_rtol),
+        # test empty size (scalar)
+        ((), (), [], [], -5., default_rtol, 0.02),
+        # test with few samples at the same time
+        ((1,), (1,), [], [], -5., default_rtol, 0.02),
+        ((3,), (3,), [], [], -5., default_rtol, 0.02),
+    ]
+
+    for size, const_size, var_input, input, avg, rtol, std_tol in test_cases:
+        R = MRG_RandomStreams(234)
+        # Note: we specify `nstreams` to avoid a warning.
+        n = R.truncated_normal(size=size, avg=avg, std=std,
+                               nstreams=rng_mrg.guess_n_streams(size, warn=False))
+        f = theano.function(var_input, n)
+
+        # Increase the number of steps if size implies only a few samples
+        if np.prod(const_size) < 10:
+            steps_ = steps * 60
+        else:
+            steps_ = steps
+        basictest(f, steps_, const_size, target_avg=avg, target_std=std,
+                  prefix='mrg ', allow_01=True, inputs=input,
+                  mean_rtol=rtol, std_tol=std_tol)
+
+        sys.stdout.flush()
+
 
 def basic_multinomialtest(f, steps, sample_size, target_pvals, n_samples,
                           prefix="", mean_rtol=0.04):


### PR DESCRIPTION
This is an implementation of the box-muller transform for a normal distribution truncated at two standard deviations (as requested in issue #6381).

I did not quite get why there would be need to distinguish between integer and tensor sizes, given that theano optimises the graph and probably includes constant folding. Therefore, I have introduced my own interpretation of the normal code (which I personally find more readable, if I'm allowed to be smug for a second). If one of two approaches turn out to be better/faster/more readable/more whatever, quite a bit of code can be reused and a refactoring might be advisable.