### PR TITLE
[WIP] Fixed PushOutScanOutput for truncated gradient.

### DIFF
--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -744,6 +744,16 @@ class PushOutScanOutput(gof.Optimizer):
                             self.push_out_inner_vars(fgraph, inner_dot_inputs,
                                                      node, args)
 
+                        # Here we cut the sequences to n_steps to make this
+                        # optimization work even when we truncate the
+                        # gradients.
+                        # Breaks scanOp_save_mem
+                        #import ipdb; ipdb.set_trace()
+                        if outer_dot_inputs[0].shape[0] != args.n_steps:
+                            outer_dot_inputs[0] = outer_dot_inputs[0][:args.n_steps]
+                        if outer_dot_inputs[1].shape[0] != args.n_steps:
+                            outer_dot_inputs[1] = outer_dot_inputs[1][:args.n_steps]
+
                         # Collapse some of the dimensions of the tensors
                         # so that they become matrices. This is because a
                         # dot is usually faster on two large matrices than

--- a/theano/scan_module/scan_opt.py
+++ b/theano/scan_module/scan_opt.py
@@ -748,7 +748,6 @@ class PushOutScanOutput(gof.Optimizer):
                         # optimization work even when we truncate the
                         # gradients.
                         # Breaks scanOp_save_mem
-                        #import ipdb; ipdb.set_trace()
                         if outer_dot_inputs[0].shape[0] != args.n_steps:
                             outer_dot_inputs[0] = outer_dot_inputs[0][:args.n_steps]
                         if outer_dot_inputs[1].shape[0] != args.n_steps:

--- a/theano/scan_module/tests/test_scan_opt.py
+++ b/theano/scan_module/tests/test_scan_opt.py
@@ -436,11 +436,10 @@ class TestPushOutputTruncatedGradient(unittest.TestCase):
         h0 = theano.shared(np.zeros((4, nhu), config.floatX), name='h0')
         seq = T.dot(x, Wxh)
 
-        y, _ = theano.scan(
-                fn=lambda i, h: i + T.dot(h, Whh),
-                sequences=[seq],
-                outputs_info=h0,
-                truncate_gradient=3)
+        y, _ = theano.scan(fn=lambda i, h: i + T.dot(h, Whh),
+                           sequences=[seq],
+                           outputs_info=h0,
+                           truncate_gradient=3)
         grad = theano.grad(y.sum(), Whh)
         fn = theano.function([x], grad)
         g1 = grad.tag.test_value

--- a/theano/scan_module/tests/test_scan_opt.py
+++ b/theano/scan_module/tests/test_scan_opt.py
@@ -418,3 +418,31 @@ class TestPushOutSumOfDot():
         output_no_opt = f_no_opt(input1_value, input2_value, input3_value)
 
         utt.assert_allclose(output_opt, output_no_opt)
+
+
+class TestPushOutputTruncatedGradient(unittest.TestCase):
+
+    def test_truncated_gradient(self):
+        theano.config.compute_test_value = 'warn'
+        nin = 2
+        nhu = 5
+
+        x = theano.tensor.tensor3('x')
+        x.tag.test_value = np.random.randn(10, 4, nin)
+        Wxh = theano.shared(np.random.randn(nin, nhu).astype(config.floatX),
+                            name='Wxh')
+        Whh = theano.shared(np.random.randn(nhu, nhu).astype(config.floatX),
+                            name='Whh')
+        h0 = theano.shared(np.zeros((4, nhu), config.floatX), name='h0')
+        seq = T.dot(x, Wxh)
+
+        y, _ = theano.scan(
+                fn=lambda i, h: i + T.dot(h, Whh),
+                sequences=[seq],
+                outputs_info=h0,
+                truncate_gradient=3)
+        grad = theano.grad(y.sum(), Whh)
+        fn = theano.function([x], grad)
+        g1 = grad.tag.test_value
+        g2 = fn(x.tag.test_value)
+        np.testing.assert_allclose(g1, g2)


### PR DESCRIPTION
Fixes partially #4652

Now the code doesn't throw an error as in the issue, but the `ScanSaveMem` opt breaks now:

```ERROR (theano.gof.opt): SeqOptimizer apply <theano.scan_module.scan_opt.ScanSaveMem object at 0x7f328b3ae110>
ERROR (theano.gof.opt): Traceback:
ERROR (theano.gof.opt): Traceback (most recent call last):
  File "/u/laurent/ccw/Theano/theano/gof/opt.py", line 241, in apply
    sub_prof = optimizer.optimize(fgraph)
  File "/u/laurent/ccw/Theano/theano/gof/opt.py", line 87, in optimize
    ret = self.apply(fgraph, *args, **kwargs)
  File "/u/laurent/ccw/Theano/theano/scan_module/scan_opt.py", line 1631, in apply
    self.process_node(fgraph, node)
  File "/u/laurent/ccw/Theano/theano/scan_module/scan_opt.py", line 1556, in process_node
    nw_pos = inv_compress_map[idx]
KeyError: 2
```