### PR TITLE
Fix memory leak in fallback sdot

### DIFF
--- a/theano/tensor/blas_headers.py
+++ b/theano/tensor/blas_headers.py
@@ -1033,7 +1033,7 @@ def openblas_threads_text():
 
 def blas_header_version():
     # Version for the base header
-    version = (5,)
+    version = (6,)
     if detect_macos_sdot_bug():
         if detect_macos_sdot_bug.fix_works:
             # Version with fix

--- a/theano/tensor/blas_headers.py
+++ b/theano/tensor/blas_headers.py
@@ -1033,7 +1033,7 @@ def openblas_threads_text():
 
 def blas_header_version():
     # Version for the base header
-    version = (6,)
+    version = (7,)
     if detect_macos_sdot_bug():
         if detect_macos_sdot_bug.fix_works:
             # Version with fix

--- a/theano/tensor/c_code/alt_blas_template.c
+++ b/theano/tensor/c_code/alt_blas_template.c
@@ -307,6 +307,8 @@ void %(precision)sgemv_(
     PyArray_MatrixProduct2(vector_x, vector_y, dot_product);
     if (PyErr_Occurred())
         alt_fatal_error("NumPy %(precision)sdot_ implementation: unable to compute dot.");
+    // PyArray_MatrixProduct2 adds an extra reference to the output array.
+    Py_XDECREF(dot_product);
     // Get result.
     Py_XDECREF(dot_product);
     Py_XDECREF(vector_y);

--- a/theano/tensor/c_code/alt_blas_template.c
+++ b/theano/tensor/c_code/alt_blas_template.c
@@ -305,11 +305,12 @@ void %(precision)sgemv_(
 
     // Compute matrix product: (1, N) * (N, 1) => (1, 1)
     PyArray_MatrixProduct2(vector_x, vector_y, dot_product);
-    if (PyErr_Occurred())
-        alt_fatal_error("NumPy %(precision)sdot_ implementation: unable to compute dot.");
     // PyArray_MatrixProduct2 adds an extra reference to the output array.
     Py_XDECREF(dot_product);
-    // Get result.
+
+    if (PyErr_Occurred())
+        alt_fatal_error("NumPy %(precision)sdot_ implementation: unable to compute dot.");
+
     Py_XDECREF(dot_product);
     Py_XDECREF(vector_y);
     Py_XDECREF(vector_x);


### PR DESCRIPTION
I forgot to add an extra call to `Py_XDECREF()` after calling `PyArray_MatrixProduct2()`.

@nouiz @abergeron 