### PR TITLE
Fix omp_get_num_threads scope error in CPU CTC wrapper

### DIFF
--- a/theano/tensor/nnet/c_code/ctc_wrapper.c
+++ b/theano/tensor/nnet/c_code/ctc_wrapper.c
@@ -14,7 +14,7 @@ void ctc_context_init(ctc_context_t * context)
     memset(options, 0, sizeof(struct ctcOptions));
     options->loc = CTC_CPU;
 #if defined(_OPENMP)
-    options->num_threads = omp_get_num_threads();
+    options->num_threads = omp_get_max_threads();
 #else
     options->num_threads = 1;
 #endif

--- a/theano/tensor/nnet/c_code/ctc_wrapper.c
+++ b/theano/tensor/nnet/c_code/ctc_wrapper.c
@@ -110,10 +110,12 @@ void create_flat_labels( PyArrayObject * label_matrix, int ** flat_labels,
 int APPLY_SPECIFIC(ctc_cost_cpu)(PyArrayObject *  in_activations,
                                  PyArrayObject *  in_labels,
                                  PyArrayObject *  in_input_lengths,
-                                 const int openmp_enabled,
                                  PyArrayObject ** out_costs,
-                                 PyArrayObject ** out_gradients)
+                                 PyArrayObject ** out_gradients,
+                                 PARAMS_TYPE * params)
 {
+    const int openmp_enabled = params->openmp;
+
     ctc_context_t ctc_object;
     ctc_context_t * context = &ctc_object;
     ctc_context_init( context, openmp_enabled );

--- a/theano/tensor/nnet/c_code/ctc_wrapper.c
+++ b/theano/tensor/nnet/c_code/ctc_wrapper.c
@@ -8,16 +8,19 @@ typedef struct ctc_context {
     int * label_lengths;
 } ctc_context_t;
 
-void ctc_context_init(ctc_context_t * context)
+void ctc_context_init(ctc_context_t * context, const int openmp_enabled)
 {
     struct ctcOptions * options = &(context->options);
     memset(options, 0, sizeof(struct ctcOptions));
     options->loc = CTC_CPU;
-#if defined(_OPENMP)
-    options->num_threads = omp_get_max_threads();
-#else
     options->num_threads = 1;
+
+#if defined(_OPENMP)
+    if (openmp_enabled) {
+        options->num_threads = omp_get_max_threads();
+    }
 #endif
+
     context->workspace = NULL;
     context->input_lengths = NULL;
     context->flat_labels = NULL;
@@ -107,12 +110,13 @@ void create_flat_labels( PyArrayObject * label_matrix, int ** flat_labels,
 int APPLY_SPECIFIC(ctc_cost_cpu)(PyArrayObject *  in_activations,
                                  PyArrayObject *  in_labels,
                                  PyArrayObject *  in_input_lengths,
+                                 const int openmp_enabled,
                                  PyArrayObject ** out_costs,
                                  PyArrayObject ** out_gradients)
 {
     ctc_context_t ctc_object;
     ctc_context_t * context = &ctc_object;
-    ctc_context_init( context );
+    ctc_context_init( context, openmp_enabled );
 
     if ( !PyArray_IS_C_CONTIGUOUS( in_activations ) )
     {

--- a/theano/tensor/nnet/ctc.py
+++ b/theano/tensor/nnet/ctc.py
@@ -1,11 +1,11 @@
 from __future__ import (division, absolute_import, print_function)
 import os
 import sys
+import theano
 import theano.tensor as T
 from theano import config
 from theano import gof
-from theano.scalar import as_scalar
-from theano.gof import local_optimizer
+from theano.gof import (local_optimizer, ParamsType)
 from theano.gof.cmodule import GCC_compiler
 from theano.tensor.opt import register_canonicalize
 from theano.tensor.extra_ops import cpu_contiguous
@@ -102,8 +102,9 @@ class ConnectionistTemporalClassification(gof.COp, gof.OpenMPOp):
         If set to True, enables the computation of gradients of the CTC loss function.
     """
     __props__ = ('compute_grad',)
+    params_type = ParamsType(openmp=theano.scalar.bool)
 
-    _cop_num_inputs = 4
+    _cop_num_inputs = 3
     _cop_num_outputs = 2
 
     func_file = os.path.join('c_code', 'ctc_wrapper.c')
@@ -119,6 +120,7 @@ class ConnectionistTemporalClassification(gof.COp, gof.OpenMPOp):
         gof.OpenMPOp.__init__(self, openmp=openmp)
 
         self.compute_grad = compute_grad
+        self.openmp = gof.OpenMPOp(self).openmp
         # Return only the cost. Gradient will be returned by grad()
         self.default_output = 0
 
@@ -176,16 +178,13 @@ class ConnectionistTemporalClassification(gof.COp, gof.OpenMPOp):
         if t_input_lengths.ndim != 1:
             raise ValueError('input_lengths must have 1 dimension.')
 
-        openmp_enabled = 1 if gof.OpenMPOp(self).openmp is not None else 0
-        openmp_enabled = as_scalar(openmp_enabled).astype('int32')
-
         costs = T.fvector(name="ctc_cost")
         outputs = [costs]
         if self.compute_grad:
             gradients = T.ftensor3(name="ctc_grad")
             outputs += [gradients]
 
-        return gof.Apply(self, inputs=[t_activations, t_labels, t_input_lengths, openmp_enabled],
+        return gof.Apply(self, inputs=[t_activations, t_labels, t_input_lengths],
                          outputs=outputs)
 
     def L_op(self, inputs, outputs, output_grads):
@@ -197,8 +196,7 @@ class ConnectionistTemporalClassification(gof.COp, gof.OpenMPOp):
         total_grad = T.basic.batched_dot(grad_op, gradients.dimshuffle(1, 0, 2)).dimshuffle(1, 0, 2)
         return [total_grad,
                 grad_undefined(self, 1, inputs[1]),
-                grad_undefined(self, 2, inputs[2]),
-                grad_undefined(self, 3, inputs[3])]
+                grad_undefined(self, 2, inputs[2])]
 
 
 def ctc(activations, labels, input_lengths):
@@ -244,6 +242,5 @@ def local_ctc_no_grad(node):
     if isinstance(node.op, ConnectionistTemporalClassification):
         if len(node.outputs) > 1:
             if len(node.outputs[1].clients) == 0:   # gradient is not used
-                activations, labels, input_lengths, _ = node.inputs
-                return [ConnectionistTemporalClassification(compute_grad=False)(activations, labels, input_lengths), None]
+                return [ConnectionistTemporalClassification(compute_grad=False)(*node.inputs), None]
     return False

--- a/theano/tensor/nnet/ctc.py
+++ b/theano/tensor/nnet/ctc.py
@@ -120,7 +120,6 @@ class ConnectionistTemporalClassification(gof.COp, gof.OpenMPOp):
         gof.OpenMPOp.__init__(self, openmp=openmp)
 
         self.compute_grad = compute_grad
-        self.openmp = gof.OpenMPOp(self).openmp
         # Return only the cost. Gradient will be returned by grad()
         self.default_output = 0
 


### PR DESCRIPTION
Fix omp_get_num_threads scope error in CPU CTC wrapper. The error was caused due to a call to 'omp_get_num_threads' outside of a parallel region.

Issue: #6399 