### PR TITLE
Bugfix: spaces in temp path prevents cudnn init

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1782,8 +1782,9 @@ class Compiler(object):
         try:
             fd, path = tempfile.mkstemp(suffix='.c', prefix=tmp_prefix)
             exe_path = path[:-2]
-            path = "\"" + path + "\""
-            exe_path = "\"" + exe_path + "\""
+            if os.name == 'nt':
+                path = "\"" + path + "\""
+                exe_path = "\"" + exe_path + "\""
             try:
                 # Python3 compatibility: try to cast Py3 strings as Py2 strings
                 try:

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1782,6 +1782,8 @@ class Compiler(object):
         try:
             fd, path = tempfile.mkstemp(suffix='.c', prefix=tmp_prefix)
             exe_path = path[:-2]
+            path = "\"" + path + "\""
+            exe_path = "\"" + exe_path + "\""
             try:
                 # Python3 compatibility: try to cast Py3 strings as Py2 strings
                 try:


### PR DESCRIPTION
When initializing theano with cudnn, `_try_compile_tmp` is eventually run to verify compiling a test program with gcc. This function requests a temporary path for the test program from the `mkstemp` function of tempfile.py. Rarely, this can return a path that has spaces in it. If this happens, gcc cannot parse it correctly and throws an error, which will look something like:

```
RuntimeError: You enabled cuDNN, but we aren't able to use it: cannot compile with cuDNN. We got this error:
g++.exe: error: c:\program: No such file or directory
```

The proposed change encloses the temp path in quotes, allowing gcc to parse it even if it contains spaces.

For an example case: I was running python through an ssh client which accesses the home directory through a symlink in C:\Program Files\openssh\. `mkstemp` defaulted to the working directory (because I didn't have any of the default directories such as C:\temp) and returned the path including the space in "Program Files", which crashed gcc.