### PR TITLE
Fix broadcasting in sparse dot

### DIFF
--- a/theano/sparse/tests/test_basic.py
+++ b/theano/sparse/tests/test_basic.py
@@ -464,6 +464,12 @@ class SparseInferShapeTester(utt.InferShapeTester):
                                config.floatX, 3))],
                 Dot)
 
+    def test_dot_broadcast(self):
+        A = sp.matrix('csr')
+        b = tensor.vector()
+        bc = sp.dot(A, b[:, None]).broadcastable
+        assert bc == (False, True)
+
     def test_structured_dot(self):
         x = SparseType('csc', dtype=config.floatX)()
         y = SparseType('csc', dtype=config.floatX)()


### PR DESCRIPTION
Broadcasting is inconsistent between dense and sparse dot:
```python
A = tt.matrix()
b = tt.vector()
tt.dot(A, b[:, None]).broadcastable
# (False, True)

# But
A = theano.sparse.matrix('csr')
b = tt.vector()
theano.sparse.dot(A, b[:, None]).broadcastable
# (False, False)
```
This PR fixes this behaviour by taking into account the broadcastability of dense arguments in `theano.sparse.dot`.