### PR TITLE
Fix GPU initialization checking on buildbot.

### DIFF
--- a/.jenkins/jenkins_buildbot_windows.bat
+++ b/.jenkins/jenkins_buildbot_windows.bat
@@ -54,7 +54,9 @@ mkdir %BUILDBOT_DIR%
 echo "Directory of stdout/stderr %BUILDBOT_DIR%"
 
 REM Exit if theano.gpuarray import fails
-python -c "import theano.gpuarray; theano.gpuarray.use('%DEVICE%')" || exit /b
+REM NB: As we define `set THEANO_FLAGS=init_gpu_device=cuda` above,
+REM     importing theano.gpuarray will automatically initialize GPU.
+python -c "import theano.gpuarray; exit(1 - int(theano.gpuarray.pygpu_activated))" || exit /b
 
 REM Fast run and float32
 set FILE=%BUILDBOT_DIR%\theano_python2_fastrun_f32_tests.xml

--- a/.jenkins/jenkins_buildbot_windows.bat
+++ b/.jenkins/jenkins_buildbot_windows.bat
@@ -14,7 +14,7 @@ set SUITE=--xunit-testsuite-name=
 
 set THEANO_PARAM=theano --with-timer --timer-top-n 10
 
-set THEANO_FLAGS=init_gpu_device=cuda
+set THEANO_FLAGS=init_gpu_device=cuda,dnn.base_path="%CUDNNPATH%"
 
 REM Build libgpuarray
 set GPUARRAY_CONFIG="Release"
@@ -59,5 +59,5 @@ python -c "import theano.gpuarray; theano.gpuarray.use('%DEVICE%')" || exit /b
 REM Fast run and float32
 set FILE=%BUILDBOT_DIR%\theano_python2_fastrun_f32_tests.xml
 set NAME=win_fastrun_f32
-set THEANO_FLAGS=%THEANO_FLAGS%,compiledir=%COMPILEDIR:\=\\%,mode=FAST_RUN,warn.ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,floatX=float32,dnn.base_path=%CUDNNPATH%,gcc.cxxflags='-I%LIBDIR:\=\\%\\include -L%LIBDIR:\=\\%\\lib'
+set THEANO_FLAGS=%THEANO_FLAGS%,compiledir=%COMPILEDIR:\=\\%,mode=FAST_RUN,warn.ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,floatX=float32,gcc.cxxflags='-I%LIBDIR:\=\\%\\include -L%LIBDIR:\=\\%\\lib'
 python bin\theano-nose %THEANO_PARAM% %XUNIT%%FILE% %SUITE%%NAME%

--- a/.jenkins/jenkins_buildbot_windows.bat
+++ b/.jenkins/jenkins_buildbot_windows.bat
@@ -59,5 +59,5 @@ python -c "import theano.gpuarray; theano.gpuarray.use('%DEVICE%')" || exit /b
 REM Fast run and float32
 set FILE=%BUILDBOT_DIR%\theano_python2_fastrun_f32_tests.xml
 set NAME=win_fastrun_f32
-set THEANO_FLAGS=%THEANO_FLAGS%,compiledir=%COMPILEDIR:\=\\%,mode=FAST_RUN,warn.ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,floatX=float32,dnn.base_path="%CUDNNPATH%",gcc.cxxflags='-I%LIBDIR:\=\\%\\include -L%LIBDIR:\=\\%\\lib'
+set THEANO_FLAGS=%THEANO_FLAGS%,compiledir=%COMPILEDIR:\=\\%,mode=FAST_RUN,warn.ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,floatX=float32,dnn.base_path=%CUDNNPATH%,gcc.cxxflags='-I%LIBDIR:\=\\%\\include -L%LIBDIR:\=\\%\\lib'
 python bin\theano-nose %THEANO_PARAM% %XUNIT%%FILE% %SUITE%%NAME%

--- a/.jenkins/jenkins_buildbot_windows.bat
+++ b/.jenkins/jenkins_buildbot_windows.bat
@@ -54,9 +54,7 @@ mkdir %BUILDBOT_DIR%
 echo "Directory of stdout/stderr %BUILDBOT_DIR%"
 
 REM Exit if theano.gpuarray import fails
-REM NB: As we define `set THEANO_FLAGS=init_gpu_device=cuda` above,
-REM     importing theano.gpuarray will automatically initialize GPU.
-python -c "import theano.gpuarray; exit(1 - int(theano.gpuarray.pygpu_activated))" || exit /b
+python -c "import theano.gpuarray; theano.gpuarray.use('%DEVICE%')" || exit /b
 
 REM Fast run and float32
 set FILE=%BUILDBOT_DIR%\theano_python2_fastrun_f32_tests.xml

--- a/.jenkins/jenkins_pr_win.bat
+++ b/.jenkins/jenkins_pr_win.bat
@@ -9,7 +9,7 @@ REM Set cache dir and copy from master
 set COMPILEDIR=%WORKSPACE%\cache
 REM C:\Windows\System32\robocopy /E /purge C:\Jenkins\theano_cache\buildbot_windows %COMPILEDIR% > nul
 
-set THEANO_FLAGS=init_gpu_device=cuda
+set THEANO_FLAGS=init_gpu_device=cuda,dnn.base_path="%CUDNNPATH%"
 
 REM Build libgpuarray
 set GPUARRAY_CONFIG="Release"
@@ -52,6 +52,5 @@ python -c "import theano.gpuarray; theano.gpuarray.use('%DEVICE%')" || exit /b
 
 set THEANO_PARAM=theano --with-timer --timer-top-n 10 --with-xunit --xunit-file=theano_win_pr_tests.xml
 set NAME=pr_win
-set THEANO_FLAGS=%THEANO_FLAGS%,mode=FAST_RUN,floatX=float32,on_opt_error=raise,on_shape_error=raise,cmodule.age_thresh_use=604800,compiledir=%COMPILEDIR:\=\\%,dnn.base_path=%CUDNNPATH%,gcc.cxxflags='-I%LIBDIR:\=\\%\\include -L%LIBDIR:\=\\%\\lib'
-dir %CUDNNPATH%\include || exit /b
+set THEANO_FLAGS=%THEANO_FLAGS%,mode=FAST_RUN,floatX=float32,on_opt_error=raise,on_shape_error=raise,cmodule.age_thresh_use=604800,compiledir=%COMPILEDIR:\=\\%,gcc.cxxflags='-I%LIBDIR:\=\\%\\include -L%LIBDIR:\=\\%\\lib'
 python bin\theano-nose %THEANO_PARAM% --xunit-testsuite-name=%NAME%

--- a/.jenkins/jenkins_pr_win.bat
+++ b/.jenkins/jenkins_pr_win.bat
@@ -52,5 +52,6 @@ python -c "import theano.gpuarray; theano.gpuarray.use('%DEVICE%')" || exit /b
 
 set THEANO_PARAM=theano --with-timer --timer-top-n 10 --with-xunit --xunit-file=theano_win_pr_tests.xml
 set NAME=pr_win
-set THEANO_FLAGS=%THEANO_FLAGS%,mode=FAST_RUN,floatX=float32,on_opt_error=raise,on_shape_error=raise,cmodule.age_thresh_use=604800,compiledir=%COMPILEDIR:\=\\%,dnn.base_path="%CUDNNPATH%",gcc.cxxflags='-I%LIBDIR:\=\\%\\include -L%LIBDIR:\=\\%\\lib'
+set THEANO_FLAGS=%THEANO_FLAGS%,mode=FAST_RUN,floatX=float32,on_opt_error=raise,on_shape_error=raise,cmodule.age_thresh_use=604800,compiledir=%COMPILEDIR:\=\\%,dnn.base_path=%CUDNNPATH%,gcc.cxxflags='-I%LIBDIR:\=\\%\\include -L%LIBDIR:\=\\%\\lib'
+dir %CUDNNPATH%\include || exit /b
 python bin\theano-nose %THEANO_PARAM% --xunit-testsuite-name=%NAME%

--- a/theano/gpuarray/__init__.py
+++ b/theano/gpuarray/__init__.py
@@ -17,6 +17,8 @@ error = _logger.error
 info = _logger.info
 
 pygpu_activated = False
+# Used to skip initialization checking when we are in the same processus.
+theano_gpu_is_already_active = False
 try:
     import pygpu
     import pygpu.gpuarray
@@ -58,7 +60,8 @@ def pygpu_parse_version(version_string):
 
 def init_dev(dev, name=None, preallocate=None):
     global pygpu_activated
-    if os.environ.get('THEANO_GPU_IS_ALREADY_ACTIVE', '') == 'Yes':
+    global theano_gpu_is_already_active
+    if not theano_gpu_is_already_active and os.environ.get('THEANO_GPU_IS_ALREADY_ACTIVE', '') == 'Yes':
         raise RuntimeError("You can't initialize the GPU in a subprocess if the parent process already did it")
     if not config.cxx:
         raise RuntimeError("The new gpu-backend need a c++ compiler.")
@@ -95,6 +98,7 @@ def init_dev(dev, name=None, preallocate=None):
             single_stream=config.gpuarray.single_stream,
             **args)
         os.environ['THEANO_GPU_IS_ALREADY_ACTIVE'] = 'Yes'
+        theano_gpu_is_already_active = True
         context.dev = dev
         init_dev.devmap[dev] = context
         reg_context(name, context)


### PR DESCRIPTION
In the Windows buildbot, we test GPU initialization with `"import theano.gpuarray; theano.gpuarray.use('%DEVICE%')"`, But we set `THEANO_FLAGS=init_gpu_device=cuda` before (see top of file), thus `import theano.gpuarray` will automatically initialize the GPU, then the second instruction (`theano.gpuarray.use(%DEVICE%)`) will force a second initialization, that is forbidden by the @abergeron 's PR (first initialization will set OS env var `THEANO_GPU_IS_ALREADY_ACTIVE`, and second initialization will fail because that OS env var will be already set).

We must either: find a better way to distinguish mutiple initalization accross different processes vs multiiple initialization inside the same process, or update jenkins scripts to prevent multiple initialization inside the same process (I guess that case is not desired, neither). I choose to update the jenskins script for Windows buildbot.

PS: I guess some other Jenkins scripts should fail too, as they used the same strategy, but I did not yet change them.

@nouiz @abergeron @slefrancois @lamblin  