### PR TITLE
See gh-6543. Sometimes, np.asarray(self.data) fail with a read error …

### DIFF
--- a/theano/gpuarray/type.py
+++ b/theano/gpuarray/type.py
@@ -603,7 +603,10 @@ class GpuArrayConstant(_operators, Constant):
         try:
             np_data = np.asarray(self.data)
         except gpuarray.GpuArrayException:
-            np_data = self.data
+            try:
+                np_data = str(self.data)
+            except Exception:
+                np_data = 'Unknown'
         return "GpuArrayConstant{%s}" % np_data
 
 


### PR DESCRIPTION
…from the hardware. So here try some fall back that won't hide the current error being raised.