### PR TITLE
lazylinker_c: Make sure that the version number is flushed to disk

### DIFF
--- a/theano/gof/lazylinker_c.py
+++ b/theano/gof/lazylinker_c.py
@@ -127,7 +127,8 @@ except ImportError:
                                              preargs=args)
             # Save version into the __init__.py file.
             init_py = os.path.join(loc, '__init__.py')
-            open(init_py, 'w').write('_version = %s\n' % version)
+            with open(init_py, 'w') as f:
+                f.write('_version = %s\n' % version)
             # If we just compiled the module for the first time, then it was
             # imported at the same time: we need to make sure we do not
             # reload the now outdated __init__.pyc below.


### PR DESCRIPTION
I managed to trigger a run where 'import theano' failed to read the version number. Closing the file descriptor where the version of lazylinker is written, appeared to fix it.