### PR TITLE
Fix non-cudnn reductions that were all subtly broken by 91bc16c3.

### DIFF
--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -3783,7 +3783,7 @@ def local_dnn_reduction(node):
     with inherit_stack_trace(node.outputs):
         ret = GpuDnnReduction(scal,
                               node.op.axis,
-                              node.op.acc_dtype,
+                              node.op._acc_dtype(node.inputs[0].dtype),
                               node.op.dtype,
                               False)(node.inputs[0])
         return [post(ret)]

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -1207,7 +1207,7 @@ def local_gpua_careduce(op, context_name, inputs, outputs):
             return False
         x, = inputs
         idtype = x.dtype
-        adtype = getattr(op, 'acc_dtype', idtype)
+        adtype = getattr(op, 'acc_dtype', None)
         odtype = getattr(op, 'dtype', outputs[0].dtype)
 
         # Force accumulator to float32 for float32 inputs since tree


### PR DESCRIPTION
This was particularly visible for float16 since they would just stop working, but it also caused a reduction in precision for all other data types which could have lead to wrong results.

This was only avoided by the fact that we use cudnn all the time so only DEBUG_MODE was able to sniff this out since it runs the intermediate graph before we switch to cudnn reductions.

91bc16c3