### PR TITLE
Make Theano work under pypy (WIP)

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -1684,7 +1684,10 @@ def std_lib_dirs_and_libs():
     else:
         if platform.python_implementation() == 'PyPy':
             # Assume Linux (note: Ubuntu doesn't ship this .so)
-            libname = "pypy-c"
+            if sys.version_info < (3,):
+                libname = "pypy-c"
+            else:
+                libname = "pypy3-c"
             # Unfortunately the only convention of this .so is that it appears
             # next to the location of the interpreter binary.
             libdir = os.path.dirname(os.path.realpath(sys.executable))

--- a/theano/gof/type.py
+++ b/theano/gof/type.py
@@ -613,6 +613,7 @@ if platform.python_implementation() != 'PyPy':
     _cdata_type = ctypes.py_object.from_address(
         ctypes.addressof(ctypes.pythonapi.PyCapsule_Type)).value
 
+
 class _make_cdata(Op):
     __props__ = ('rtype',)
 

--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -13,6 +13,7 @@ import logging
 import sys
 import time
 import warnings
+import platform
 
 from theano.configparser import (config, _config_var_list)
 
@@ -983,7 +984,11 @@ class VM_Linker(link.LocalLinker):
                 if oidx in update_in_from_out:
                     update_storage.append(update_in_from_out[oidx])
 
-            c0 = sys.getrefcount(node_n_inputs)
+            # PyPy has no sys.getrefcount, so ignore this check if not running
+            # under CPython.
+            if platform.python_implementation() == 'CPython':
+                c0 = sys.getrefcount(node_n_inputs)
+
             vm = CVM(
                 nodes,
                 thunks,
@@ -1006,7 +1011,9 @@ class VM_Linker(link.LocalLinker):
                 update_storage=update_storage,
                 dependencies=dependency_map_list,
             )
-            assert c0 == sys.getrefcount(node_n_inputs)
+
+            if platform.python_implementation() == 'CPython':
+                assert c0 == sys.getrefcount(node_n_inputs)
         else:
             lazy = self.lazy
             if lazy is None:


### PR DESCRIPTION
In trying to find an ML library to work on pypy, I figured out some hacks to get it working (at least superficially with runtime compiled cpyext modules). 

There seems to be a few problems that need to be resolved before it would work out of the box:

1. A single usage of the ctypes.pythonapi.PyCapsule_Type

2. A single usage of sys.getrefcount (to check that there isn't leaks)

3. Missing build information to runtime load the compiled .so python module
- The correct binary .so filename looks to be able to be constructed using distutils.sysconfig.get_config_var("SO") (or EXT_SUFFIX in python3)
- Expects libpython.so (or equivalent) in the distutils.sysconfig.get_config_var("LIBDIR") location which does not exist
- distutils.sysconfig.get_config_var("LDLIBRARY") does not resolve in pypy currently -- but should in theory point to libpypy-c