### PR TITLE
Fix gh-6609. Do not do bool-bool when not needed anymore.

### DIFF
--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -6325,7 +6325,16 @@ def add_calculate(num, denum, aslist=False, out_type=None):
         zero = theano._asarray(0, dtype=out_type.dtype)
     # zero = 0.0 if out_type is None else theano._asarray(0,
     # dtype=out_type.dtype)
-    v = reduce(np.add, num, zero) - reduce(np.add, denum, zero)
+    if out_type and out_type.dtype == 'bool':
+        if len(denum) == 0:
+            # NumPy 1.14 do not accept to do "bool - bool"
+            v = reduce(np.add, num, zero)
+        else:
+            raise Exception(
+                "bool subtraction not supported. This should not happen as"
+                " an earlier error should have been raised")
+    else:
+        v = reduce(np.add, num, zero) - reduce(np.add, denum, zero)
     if aslist:
         if np.all(v == 0):
             return []

--- a/theano/tensor/tests/test_opt.py
+++ b/theano/tensor/tests/test_opt.py
@@ -266,6 +266,11 @@ def test_add_canonizer_problem0():
     f = function([label], r)
     f(3)
 
+    # This was crashing in the past.
+    c0 = theano.tensor.constant([True])
+    c1 = theano.tensor.constant([True])
+    theano.function([], c0 + c1)
+
 
 class test_greedy_distribute(unittest.TestCase):
     def test_main(self):


### PR DESCRIPTION
The Sub class do not allow this. So raise an error if we would need the "-" operator.