### PR TITLE
float64 support for GpuCholesky, GpuCusolverSolve, GpuCublasTriangularSolve and their L_op

### DIFF
--- a/theano/gpuarray/basic_ops.py
+++ b/theano/gpuarray/basic_ops.py
@@ -1713,6 +1713,7 @@ KERNEL void eye(GLOBAL_MEM %(ctype)s *a, ga_size a_off,
     def c_code_cache_version(self):
         return (10,)
 
+
 class GpuTri(GpuKernelBase, Op):
     """
     Tri for GPU.

--- a/theano/gpuarray/basic_ops.py
+++ b/theano/gpuarray/basic_ops.py
@@ -1712,3 +1712,113 @@ KERNEL void eye(GLOBAL_MEM %(ctype)s *a, ga_size a_off,
 
     def c_code_cache_version(self):
         return (10,)
+
+class GpuTri(GpuKernelBase, Op):
+    """
+    Tri for GPU.
+
+    """
+    __props__ = ('dtype', 'context_name')
+    _f16_ok = True
+
+    def __init__(self, dtype=None, context_name=None):
+        if dtype is None:
+            dtype = config.floatX
+        self.dtype = dtype
+        self.context_name = context_name
+
+    def get_params(self, node):
+        return get_context(self.context_name)
+
+    def make_node(self, n, m, k):
+        n = tensor.as_tensor_variable(n)
+        m = tensor.as_tensor_variable(m)
+        k = tensor.as_tensor_variable(k)
+        assert n.ndim == 0
+        assert m.ndim == 0
+        assert k.ndim == 0
+        otype = GpuArrayType(dtype=self.dtype,
+                             broadcastable=(False, False),
+                             context_name=self.context_name)
+
+        return Apply(self, [n, m, k], [otype()])
+
+    def infer_shape(self, node, in_shapes):
+        out_shape = [node.inputs[0], node.inputs[1]]
+        return [out_shape]
+
+    def grad(self, inp, grads):
+        return [grad_undefined(self, i, inp[i])
+                for i in xrange(3)]
+
+    def gpu_kernels(self, node, name):
+        code = """#include "cluda.h"
+
+KERNEL void tri(GLOBAL_MEM %(ctype)s *a, ga_size a_off,
+                ga_size n, ga_size m, ga_ssize k) {
+    a = (GLOBAL_MEM %(ctype)s *)(((GLOBAL_MEM char *)a) + a_off);
+    ga_ssize coff = max(k, (ga_ssize) 0);
+    ga_ssize roff = -min(k, (ga_ssize) 0);
+    for (ga_size i = LID_0; i < min(n - roff,n); i += LDIM_0) {
+        for (ga_size j = 0; j <= min(i + coff,m-1); j++) {
+          a[(i + roff)*m + j] = %(write_a)s(1);
+        }
+    }
+}""" % dict(ctype=pygpu.gpuarray.dtype_to_ctype(self.dtype),
+            name=name, write_a=write_w(self.dtype))
+        return [Kernel(
+                code=code, name="tri",
+                params=[gpuarray.GpuArray, gpuarray.SIZE, gpuarray.SIZE,
+                        gpuarray.SIZE, gpuarray.SSIZE],
+                flags=Kernel.get_flags(self.dtype),
+                objvar='k_tri_' + name)]
+
+    def c_code(self, node, name, inp, out, sub):
+        if len(inp) == 2:
+            n, m = inp
+            k = 0
+        elif len(inp) == 3:
+            n, m, k = inp
+
+        z, = out
+        fail = sub['fail']
+        ctx = sub['params']
+        typecode = pygpu.gpuarray.dtype_to_typecode(self.dtype)
+        kname = self.gpu_kernels(node, name)[0].objvar
+        s = """
+        size_t dims[2] = {0, 0};
+        size_t ls, gs;
+        ssize_t k;
+        int err;
+
+        dims[0] = ((dtype_%(n)s*)PyArray_DATA(%(n)s))[0];
+        dims[1] = ((dtype_%(m)s*)PyArray_DATA(%(m)s))[0];
+        k = ((dtype_%(k)s*)PyArray_DATA(%(k)s))[0];
+
+        Py_CLEAR(%(z)s);
+
+        %(z)s = pygpu_zeros(2, dims,
+                            %(typecode)s,
+                            GA_C_ORDER,
+                            %(ctx)s, Py_None);
+        if (%(z)s == NULL) {
+            %(fail)s
+        }
+
+        ls = 1;
+        gs = 256;
+        err = tri_call(1, &gs, &ls, 0, %(z)s->ga.data, %(z)s->ga.offset,
+                       dims[0], dims[1], k);
+        if (err != GA_NO_ERROR) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "gpuarray error: kTri: %%s. n%%lu, m=%%lu.",
+                         GpuKernel_error(&%(kname)s, err),
+                         (unsigned long)dims[0], (unsigned long)dims[1]);
+            %(fail)s;
+        }
+        """ % locals()
+
+        return s
+
+    def c_code_cache_version(self):
+        return (10,)

--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -66,6 +66,26 @@ if cusolver_available:
                                                         ldb, int(devInfo))
         cusolver.cusolverCheckStatus(status)
 
+    # DPOTRS
+    # TODO: Are they still missing in skucda?
+    cusolver._libcusolver.cusolverDnDpotrs.restype = int
+    cusolver._libcusolver.cusolverDnDpotrs.argtypes = [cusolver.ctypes.c_void_p,
+                                                       cusolver.ctypes.c_int,
+                                                       cusolver.ctypes.c_int,
+                                                       cusolver.ctypes.c_int,
+                                                       cusolver.ctypes.c_void_p,
+                                                       cusolver.ctypes.c_int,
+                                                       cusolver.ctypes.c_void_p,
+                                                       cusolver.ctypes.c_int,
+                                                       cusolver.ctypes.c_void_p]
+
+    def cusolverDnDpotrs(handle, uplo, n, nrhs, A, lda,
+                         B, ldb, devInfo):
+        status = cusolver._libcusolver.cusolverDnDpotrs(handle, uplo, n, nrhs,
+                                                        int(A), lda, int(B),
+                                                        ldb, int(devInfo))
+        cusolver.cusolverCheckStatus(status)
+        
 
 def attach_cusolver_handle_to_context(ctx):
     handle = getattr(ctx, 'cusolver_handle', None)
@@ -389,6 +409,11 @@ def gpu_solve(A, b, A_structure='general', trans='N'):
 
     return GpuCusolverSolve(A_structure, trans)(A, b)
 
+# added these to make the module consistent to theano/tensor/slinalg.py
+def gpu_solve_lower_triangular(A,b):
+    return GpuCublasTriangularSolve(True,'N')(A,b)
+def gpu_solve_upper_triangular(A,b):
+    return GpuCublasTriangularSolve(False,'N')(A,b)
 
 class GpuCholesky(Op):
     """

--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -420,13 +420,8 @@ class GpuCublasTriangularSolve(Op):
         trans_solve_op = GpuCublasTriangularSolve(not self.lower)
         b_bar = trans_solve_op(A.T, c_bar)
 
-        # FIXME: tensor.outer does not appear to use GPU
-        def gpu_outer(x,y):
-            return tensor.dot(x.dimshuffle(0,'x'),y.dimshuffle('x',0))
+        A_bar = -tensor.outer(b_bar, c) if c.ndim == 1 else -b_bar.dot(c.T)
 
-        A_bar = -gpu_outer(b_bar, c) if c.ndim == 1 else -b_bar.dot(c.T)
-
-        # FIXME: tensor.tril / tensor.triu has no GPU implementation
         if self.lower:
             A_bar = tensor.tril(A_bar)
         else:
@@ -584,9 +579,6 @@ class GpuCholesky(Op):
             chol_x = chol_x.T
             dz = dz.T
 
-        # FIXME: tensor.tril / tensor.triu / tensor.diagonal / tensor.diag
-        # has no GPU implementation
-            
         def tril_and_halve_diagonal(mtx):
             """Extracts lower triangle of square matrix and halves diagonal."""
             return tensor.tril(mtx) - tensor.diag(tensor.diagonal(mtx) / 2.)

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -1412,11 +1412,13 @@ def local_gpua_dot22scalar(op, context_name, inputs, outputs):
 def local_gpua_eye(op, context_name, inputs, outputs):
     return GpuEye(dtype=op.dtype, context_name=context_name)
 
+
 @register_opt('fast_compile')
 @op_lifter([tensor.basic.Tri])
 @register_opt2([tensor.basic.Tri], 'fast_compile')
 def local_gpua_tri(op, context_name, inputs, outputs):
     return GpuTri(dtype=op.dtype, context_name=context_name)
+
 
 @register_opt('fast_compile')
 @op_lifter([tensor.nnet.CrossentropySoftmaxArgmax1HotWithBias])
@@ -2589,7 +2591,7 @@ def local_gpua_images2neibs(op, context_name, inputs, outputs):
 @op_lifter([slinalg.Solve])
 @register_opt2([theano.tensor.slinalg.Solve], 'fast_compile')
 def local_gpu_solve(op, context_name, inputs, outputs):
-    if inputs[0].dtype not in ['float16', 'float32','float64']:
+    if inputs[0].dtype not in ['float16', 'float32', 'float64']:
         return
     if op.A_structure not in MATRIX_STRUCTURES_SOLVE:
         return
@@ -2615,7 +2617,8 @@ def local_gpu_solve(op, context_name, inputs, outputs):
 def local_inplace_gpu_solve(node):
     if isinstance(node.op, GpuCusolverSolve) and not node.op.inplace:
         with inherit_stack_trace(node.outputs):
-            return [GpuCusolverSolve(A_structure=node.op.A_structure, trans=node.op.trans,
+            return [GpuCusolverSolve(A_structure=node.op.A_structure,
+                                     trans=node.op.trans,
                                      inplace=True)(*node.inputs)]
 
 

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -52,7 +52,7 @@ from .basic_ops import (as_gpuarray_variable, infer_context_name,
                         HostFromGpu, GpuFromHost,
                         GpuSplit, GpuContiguous, gpu_contiguous,
                         GpuAlloc, GpuAllocEmpty, GpuReshape,
-                        GpuEye, gpu_join, GpuJoin)
+                        GpuEye, GpuTri, gpu_join, GpuJoin)
 from .blas import (gpu_dot22, GpuGemm, GpuGer, GpuGemmBatch,
                    gpugemm_no_inplace, gpugemm_inplace,
                    gpugemmbatch_no_inplace,
@@ -389,7 +389,8 @@ class GraphToGPU(Optimizer):
             if (not move_to_GPU and
                     isinstance(node.op, (theano.tensor.Alloc,
                                          theano.tensor.AllocEmpty,
-                                         theano.tensor.basic.Eye))):
+                                         theano.tensor.basic.Eye,
+                                         theano.tensor.basic.Tri))):
                 # If the Alloc[Empty] have a client that will be moved
                 # to the GPU, we should move the Alloc* on the GPU.
 
@@ -1411,6 +1412,11 @@ def local_gpua_dot22scalar(op, context_name, inputs, outputs):
 def local_gpua_eye(op, context_name, inputs, outputs):
     return GpuEye(dtype=op.dtype, context_name=context_name)
 
+@register_opt('fast_compile')
+@op_lifter([tensor.basic.Tri])
+@register_opt2([tensor.basic.Tri], 'fast_compile')
+def local_gpua_tri(op, context_name, inputs, outputs):
+    return GpuTri(dtype=op.dtype, context_name=context_name)
 
 @register_opt('fast_compile')
 @op_lifter([tensor.nnet.CrossentropySoftmaxArgmax1HotWithBias])

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -2583,7 +2583,7 @@ def local_gpua_images2neibs(op, context_name, inputs, outputs):
 @op_lifter([slinalg.Solve])
 @register_opt2([theano.tensor.slinalg.Solve], 'fast_compile')
 def local_gpu_solve(op, context_name, inputs, outputs):
-    if inputs[0].dtype not in ['float16', 'float32']:
+    if inputs[0].dtype not in ['float16', 'float32','float64']:
         return
     if op.A_structure not in MATRIX_STRUCTURES_SOLVE:
         return
@@ -2617,7 +2617,7 @@ def local_inplace_gpu_solve(node):
 def local_gpu_cholesky(op, context_name, inputs, outputs):
     if not cusolver_available:
         return
-    if inputs[0].dtype not in ['float16', 'float32']:
+    if inputs[0].dtype not in ['float16', 'float32', 'float64']:
         return
     op = GpuCholesky(lower=op.lower, inplace=op.destructive)
     if inputs[0].dtype == 'float16':

--- a/theano/gpuarray/tests/test_basic_ops.py
+++ b/theano/gpuarray/tests/test_basic_ops.py
@@ -444,6 +444,7 @@ def test_gpueye():
         yield check, dtype, 5, 3, 6
         yield check, dtype, 3, 5, -6
 
+
 def test_hostfromgpu_shape_i():
     # Test that the shape is lifted over hostfromgpu
 
@@ -498,13 +499,14 @@ def test_Gpujoin_inplace():
         assert x.get_value(borrow=True, return_internal_type=True) is f(0)
     assert np.allclose(f(0), [3, 4, 5])
 
+
 def test_gpu_tril_triu():
     def check_l(m, k=0):
         m_symb = T.matrix(dtype=m.dtype)
         k_symb = T.iscalar()
 
-        f = theano.function([m_symb,k_symb],
-                            T.tril(m_symb,k_symb),
+        f = theano.function([m_symb, k_symb],
+                            T.tril(m_symb, k_symb),
                             mode=mode_with_gpu)
         result = f(m, k)
         assert np.allclose(result, np.tril(m, k))
@@ -515,8 +517,8 @@ def test_gpu_tril_triu():
     def check_u(m, k=0):
         m_symb = T.matrix(dtype=m.dtype)
         k_symb = T.iscalar()
-        f = theano.function([m_symb,k_symb],
-                            T.triu(m_symb,k_symb),
+        f = theano.function([m_symb, k_symb],
+                            T.triu(m_symb, k_symb),
                             mode=mode_with_gpu)
         result = f(m, k)
         assert np.allclose(result, np.triu(m, k))
@@ -529,16 +531,7 @@ def test_gpu_tril_triu():
 
     for dtype in ['float64', 'float32', 'float16']:
         # try a big one
-        m = np.asarray(test_rng.rand(5000,5000) * 2 - 1, dtype=dtype)
-        yield check_l, m, 0
-        yield check_l, m, 1
-        yield check_l, m, -1
-
-        yield check_u, m, 0
-        yield check_u, m, 1
-        yield check_u, m, -1
-        
-        m = np.asarray(test_rng.rand(10,10) * 2 - 1, dtype=dtype)
+        m = np.asarray(test_rng.rand(5000, 5000) * 2 - 1, dtype=dtype)
         yield check_l, m, 0
         yield check_l, m, 1
         yield check_l, m, -1
@@ -547,7 +540,7 @@ def test_gpu_tril_triu():
         yield check_u, m, 1
         yield check_u, m, -1
 
-        m = np.asarray(test_rng.rand(10,5) * 2 - 1, dtype=dtype)
+        m = np.asarray(test_rng.rand(10, 10) * 2 - 1, dtype=dtype)
         yield check_l, m, 0
         yield check_l, m, 1
         yield check_l, m, -1
@@ -555,6 +548,16 @@ def test_gpu_tril_triu():
         yield check_u, m, 0
         yield check_u, m, 1
         yield check_u, m, -1
+
+        m = np.asarray(test_rng.rand(10, 5) * 2 - 1, dtype=dtype)
+        yield check_l, m, 0
+        yield check_l, m, 1
+        yield check_l, m, -1
+
+        yield check_u, m, 0
+        yield check_u, m, 1
+        yield check_u, m, -1
+
 
 def test_gputri():
     def check(dtype, N, M_=None, k=0):
@@ -583,7 +586,7 @@ def test_gputri():
         yield check, dtype, 1000, 1000, 0
         yield check, dtype, 1000, 1000, -400
         yield check, dtype, 1000, 1000, 400
-        
+
         yield check, dtype, 5
         # M != N, k = 0
         yield check, dtype, 3, 5

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -143,10 +143,8 @@ class TestCusolver(unittest.TestCase):
         if config.floatX == "float64":
             eps = 2e-8
 
-        if A_structure == 'lower_triangular':
-            solve_op = GpuCublasTriangularSolve(lower=False)
-        elif A_structure == 'lower_triangular':
-            solve_op = GpuCublasTriangularSolve(lower=True)
+        if A_structure in ('lower_triangular', 'upper_triangular'):
+            solve_op = GpuCublasTriangularSolve(lower=lower)
         else:
             solve_op = GpuCusolverSolve(A_structure="general")
         utt.verify_grad(solve_op, [A_val, b_val], 3, rng, eps=eps)

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -7,14 +7,13 @@ from numpy.linalg.linalg import LinAlgError
 
 import theano
 from theano import config
-from theano.gpuarray.linalg import (GpuCusolverSolve,GpuCublasTriangularSolve,
+from theano.gpuarray.linalg import (GpuCusolverSolve, GpuCublasTriangularSolve,
                                     GpuCholesky, GpuMagmaCholesky,
                                     GpuMagmaEigh, GpuMagmaMatrixInverse,
                                     GpuMagmaQR, GpuMagmaSVD,
                                     cusolver_available, gpu_matrix_inverse,
                                     gpu_cholesky,
                                     gpu_solve, gpu_solve_lower_triangular,
-                                    gpu_solve_upper_triangular,
                                     gpu_svd, gpu_qr)
 from theano.tensor.nlinalg import (SVD, MatrixInverse, QRFull,
                                    QRIncomplete, eigh, matrix_inverse, qr)
@@ -25,6 +24,7 @@ from .. import gpuarray_shared_constructor
 from .config import mode_with_gpu, mode_without_gpu
 from .test_basic_ops import rand
 from nose.tools import assert_raises
+
 
 class TestCusolver(unittest.TestCase):
 
@@ -163,6 +163,7 @@ class TestCusolver(unittest.TestCase):
         # check lower=True case
         self.verify_solve_grad(4, 3, 'general', lower=True, rng=rng)
 
+
 class TestGpuCholesky(unittest.TestCase):
 
     def setUp(self):
@@ -253,6 +254,7 @@ class TestGpuCholesky(unittest.TestCase):
         A_val = -M_val.dot(M_val.T)
         fn = self.get_gpu_cholesky_func(True, False)
         self.assertRaises(LinAlgError, fn, A_val)
+
 
 class TestGpuCholesky64(unittest.TestCase):
 
@@ -599,6 +601,7 @@ class TestMagma(unittest.TestCase):
             for node in fn.maker.fgraph.toposort()
         ])
 
+
 # mostly copied from theano/tensor/tests/test_slinalg.py
 def test_cholesky_grad():
     rng = np.random.RandomState(utt.fetch_seed())
@@ -628,6 +631,7 @@ def test_cholesky_grad_indef():
     # chol_f = function([x], grad(gpu_cholesky(x).sum(), [x]))
     # assert np.all(np.isnan(chol_f(matrix)))
 
+
 def test_lower_triangular_and_cholesky_grad():
     # Random lower triangular system is ill-conditioned.
     #
@@ -645,12 +649,12 @@ def test_lower_triangular_and_cholesky_grad():
     r = rng.randn(N, N).astype(config.floatX)
     y = rng.rand(N, 1).astype(config.floatX)
 
-    def f(r,y):
+    def f(r, y):
         PD = r.dot(r.T)
         L = gpu_cholesky(PD)
-        A = gpu_solve_lower_triangular(L,y)
-        AAT = theano.tensor.dot(A,A.T)
+        A = gpu_solve_lower_triangular(L, y)
+        AAT = theano.tensor.dot(A, A.T)
         B = AAT + theano.tensor.eye(N)
         LB = gpu_cholesky(B)
         return theano.tensor.sum(theano.tensor.log(theano.tensor.diag(LB)))
-    yield (lambda: utt.verify_grad(f, [r,y], 3, rng))
+    yield (lambda: utt.verify_grad(f, [r, y], 3, rng))

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -140,7 +140,13 @@ class TestCusolver(unittest.TestCase):
         eps = None
         if config.floatX == "float64":
             eps = 2e-8
-        solve_op = GpuCusolverSolve(A_structure=A_structure)
+
+        if A_structure == 'lower_triangular':
+            solve_op = GpuCublasTriangularSolve(lower=False)
+        elif A_structure == 'lower_triangular':
+            solve_op = GpuCublasTriangularSolve(lower=True)
+        else:
+            solve_op = GpuCusolverSolve(A_structure="general")
         utt.verify_grad(solve_op, [A_val, b_val], 3, rng, eps=eps)
 
     def test_solve_grad(self):

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -22,7 +22,7 @@ from theano.tests import unittest_tools as utt
 from .. import gpuarray_shared_constructor
 from .config import mode_with_gpu, mode_without_gpu
 from .test_basic_ops import rand
-
+from nose.tools import assert_raises
 
 class TestCusolver(unittest.TestCase):
 
@@ -621,7 +621,7 @@ def test_cholesky_grad_indef():
     matrix = np.array([[1, 0.2], [0.2, -2]]).astype(config.floatX)
     cholesky = GpuCholesky(lower=True)
     chol_f = theano.function([x], theano.tensor.grad(gpu_cholesky(x).sum(), [x]))
-    with assert_raises(scipy.linalg.LinAlgError):
+    with assert_raises(LinAlgError):
         chol_f(matrix)
     # cholesky = GpuCholesky(lower=True, on_error='nan')
     # chol_f = function([x], grad(gpu_cholesky(x).sum(), [x]))

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -624,7 +624,7 @@ def test_cholesky_grad_indef():
     x = theano.tensor.matrix()
     matrix = np.array([[1, 0.2], [0.2, -2]]).astype(config.floatX)
     cholesky = GpuCholesky(lower=True)
-    chol_f = theano.function([x], theano.tensor.grad(gpu_cholesky(x).sum(), [x]))
+    chol_f = theano.function([x], theano.tensor.grad(cholesky(x).sum(), [x]))
     with assert_raises(LinAlgError):
         chol_f(matrix)
     # cholesky = GpuCholesky(lower=True, on_error='nan')

--- a/theano/gpuarray/tests/test_linalg.py
+++ b/theano/gpuarray/tests/test_linalg.py
@@ -145,8 +145,7 @@ class TestCusolver(unittest.TestCase):
 
     def test_solve_grad(self):
         rng = np.random.RandomState(utt.fetch_seed())
-        # structures = ['general', 'lower_triangular', 'upper_triangular']
-        structures = ['general']
+        structures = ['general', 'lower_triangular', 'upper_triangular']
         for A_structure in structures:
             lower = (A_structure == 'lower_triangular')
             # self.verify_solve_grad(5, None, A_structure, lower, rng)


### PR DESCRIPTION
* Add float64 support for GpuCholesky, GpuCusolverSolve, GpuCublasTriangularSolve
* Add L_op to GpuCholesky, GpuCusolverSolve, GpuCublasTriangularSolve based on the implementation in slinalg.py
* Add GpuTri op so that the whole thing run on GPU

Tested with my own GPU on both float64, float32 using 

```
$ nosetests test_linalg.py
$ nosetests test_basic_ops.py
```

under theano/gpuarray/tests and my own code that needs gradient of cholesky factorization and triangular solve.
