### PR TITLE
Fix syntax error in format string in gpuarray/multinomial.py

### DIFF
--- a/theano/gpuarray/multinomial.py
+++ b/theano/gpuarray/multinomial.py
@@ -183,7 +183,7 @@ KERNEL void k_multi_warp_multinomial(
         do
         {
             nb_threads*=2;
-            if (nb_multi % %nb_threads == 0)
+            if (nb_multi %% nb_threads == 0)
                 nb_blocks = nb_multi/nb_threads;
             else
                 nb_blocks = (int)((float)nb_multi/(float)nb_threads + 1.);


### PR DESCRIPTION
I got this error on master when using a multinomial op:

 ```
~/.local/lib/python3.7/site-packages/Theano-1.0.3+21.g813faf6a9.dirty-py3.7.egg/theano/gpuarray/multinomial.py in c_code(self, node, name, inp, outputs, sub)
    226 
    227     } // END NESTED SCOPE
--> 228         """ % locals()
    229 
    230         return s

TypeError: ('The following error happened while compiling the node', GPUAMultinomialFromUniform{odtype='int64'}(GpuAdvancedSubtensor.0, GPUA_mrg_uniform{GpuArrayType<None>(float32, vector),inplace}.1), '\n', 'not enough arguments for format string')
```

The change fixes it for me.
