### PR TITLE
fixed bilinear_kernel_1D to return a float32 tensor

### DIFF
--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -1766,7 +1766,7 @@ def bilinear_kernel_1D(ratio, normalize=True):
     kern = T.concatenate([half_kern, half_kern[-2::-1]])
 
     if normalize:
-        kern /= ratio
+        kern /= np.cast[theano.config.floatX](ratio)
     return kern
 
 


### PR DESCRIPTION
The current implementation returns a float64 tensor which raises a warning/error when the warn_float64 flag is set. I fixed it by casting `ratio` to float32 before the division.