### PR TITLE
Be compatible with Numpy 1.16

### DIFF
--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -1375,7 +1375,7 @@ class CLinker(link.Linker):
 
         # We must always add the numpy ABI version here as
         # DynamicModule always add the include <numpy/arrayobject.h>
-        if np.lib.NumpyVersion(np.__version__)<'1.16.0a':
+        if np.lib.NumpyVersion(np.__version__) < '1.16.0a':
             ndarray_c_version = np.core.multiarray._get_ndarray_c_version()
         else:
             ndarray_c_version = np.core._multiarray_umath._get_ndarray_c_version()

--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -1375,8 +1375,12 @@ class CLinker(link.Linker):
 
         # We must always add the numpy ABI version here as
         # DynamicModule always add the include <numpy/arrayobject.h>
+        if np.lib.NumpyVersion(np.__version__)<'1.16.0a':
+            ndarray_c_version = np.core.multiarray._get_ndarray_c_version()
+        else:
+            ndarray_c_version = np.core._multiarray_umath._get_ndarray_c_version()
         sig.append('NPY_ABI_VERSION=0x%X' %
-                   np.core.multiarray._get_ndarray_c_version())
+                   ndarray_c_version)
         if c_compiler:
             sig.append('c_compiler_str=' + c_compiler.version_str())
 


### PR DESCRIPTION
Since Debian unstable moved to Numpy 1.16, all compiles have been failing with "module 'numpy.core.multiarray' has no attribute '_get_ndarray_c_version'":
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=918090
https://ci.debian.net/data/autopkgtest/unstable/amd64/t/theano/1576998/log.gz

Probably because that function was moved by this Numpy commit:
https://github.com/numpy/numpy/commit/31df302656b88df2937c5ac338c96b1a0ec6d687

I do **not** yet know whether this is the only incompatibility, as I have not yet tried the full set of tests with Numpy 1.16; I will report any others I find.