### PR TITLE
added test for output shape of frac bilinear upsampling

### DIFF
--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, print_function, division
 import logging
 from six import reraise, integer_types
 import sys
-from math import gcd
+from fractions import gcd
 
 import theano
 

--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, print_function, division
 import logging
 from six import reraise, integer_types
 import sys
-from fractions import gcd
+from math import gcd
 
 import theano
 

--- a/theano/tensor/nnet/tests/test_abstract_conv.py
+++ b/theano/tensor/nnet/tests/test_abstract_conv.py
@@ -1327,7 +1327,7 @@ class TestBilinearUpsampling(unittest.TestCase):
         utt.assert_allclose(f_up_x(), num_up_x, rtol=1e-6)
 
     def test_fractional_bilinear_upsampling_shape(self):
-        x = np.random.rand(1, 1, 200, 200).astype('float32')
+        x = np.random.rand(1, 1, 200, 200).astype(theano.config.floatX)
         resize = (24, 20)
         z = bilinear_upsampling(tensor.as_tensor_variable(x), frac_ratio=resize, use_1D_kernel=False)
         utt.assert_allclose(z.shape.eval(), (1, 1, 240, 240))

--- a/theano/tensor/nnet/tests/test_abstract_conv.py
+++ b/theano/tensor/nnet/tests/test_abstract_conv.py
@@ -1330,7 +1330,8 @@ class TestBilinearUpsampling(unittest.TestCase):
         x = np.random.rand(1, 1, 200, 200).astype(theano.config.floatX)
         resize = (24, 20)
         z = bilinear_upsampling(tensor.as_tensor_variable(x), frac_ratio=resize, use_1D_kernel=False)
-        utt.assert_allclose(z.shape.eval(mode='FAST_RUN'), (1, 1, 240, 240))
+        out = theano.function([], z.shape, mode='FAST_RUN')()
+        utt.assert_allclose(out, (1, 1, 240, 240))
 
 
 class TestConv2dTranspose(unittest.TestCase):

--- a/theano/tensor/nnet/tests/test_abstract_conv.py
+++ b/theano/tensor/nnet/tests/test_abstract_conv.py
@@ -1326,6 +1326,12 @@ class TestBilinearUpsampling(unittest.TestCase):
         f_up_x = theano.function([], up_x, mode=self.compile_mode)
         utt.assert_allclose(f_up_x(), num_up_x, rtol=1e-6)
 
+    def test_fractional_bilinear_upsampling_shape(self):
+        x = np.random.rand(1, 1, 200, 200).astype('float32')
+        resize = (24, 20)
+        z = bilinear_upsampling(tensor.as_tensor_variable(x), frac_ratio=resize, use_1D_kernel=False)
+        utt.assert_allclose(z.shape.eval(), (1, 1, 240, 240))
+
 
 class TestConv2dTranspose(unittest.TestCase):
     mode = None

--- a/theano/tensor/nnet/tests/test_abstract_conv.py
+++ b/theano/tensor/nnet/tests/test_abstract_conv.py
@@ -1330,7 +1330,7 @@ class TestBilinearUpsampling(unittest.TestCase):
         x = np.random.rand(1, 1, 200, 200).astype(theano.config.floatX)
         resize = (24, 20)
         z = bilinear_upsampling(tensor.as_tensor_variable(x), frac_ratio=resize, use_1D_kernel=False)
-        utt.assert_allclose(z.shape.eval(), (1, 1, 240, 240))
+        utt.assert_allclose(z.shape.eval(mode='FAST_RUN'), (1, 1, 240, 240))
 
 
 class TestConv2dTranspose(unittest.TestCase):


### PR DESCRIPTION
I added a test to check the output shape error [here](https://github.com/Theano/Theano/pull/6673#issuecomment-453591187). Also, fractions.gcd is deprecated so I changed to math.gcd as its suggestion.