### PR TITLE
Add an `nondeterministic` option to control `MergeOptimization`

### DIFF
--- a/theano/gof/tests/test_opt.py
+++ b/theano/gof/tests/test_opt.py
@@ -317,6 +317,18 @@ class TestMergeOptimizer:
         MergeOptimizer().optimize(g)
         assert str(g) == "[Op1(*1 -> Op2(x, y), *1, Op2(x, z))]"
 
+    def test_nondeterministic(self):
+        x, y, z = inputs()
+        op2.nondeterministic = True
+        e = op1(op2(x, y), op2(x, y), op2(x, z),
+                op1(x, y), op1(x, y))
+        g = FunctionGraph([x, y, z], [e])
+        MergeOptimizer().optimize(g)
+        op2.nondeterministic = False
+        assert str(g) == (
+            "[Op1(Op2(x, y), Op2(x, y), "
+            "Op2(x, z), *1 -> Op1(x, y), *1)]")
+
     def test_constant_merging(self):
         x = MyVariable('x')
         y = Constant(MyType(), 2, name='y')


### PR DESCRIPTION
`Op`s that do not produce deterministic output (e.g. those that produce random samples) can set `Op.nondeterministic = True` and cause `MergeOptimizer` to gracefully ignore the corresponding nodes.

Also, the variable name overwriting in `MergeFeature` has been moved to a step after the actual node replacement in `MergeOptimizer`.  The name is currently being overwritten in-place and before replacement, so, if the replacement fails, the node is left in an unstable state (i.e. with an unnecessarily altered name).