### PR TITLE
Eliminate FutureWarning from numpy

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -6608,7 +6608,7 @@ class AllocDiag(Op):
                            idxs + np.maximum(0, offset)])
 
         # Fill in final 2 axes with x
-        result[diagonal_slice] = x
+        result[tuple(diagonal_slice)] = x
 
         if len(x.shape) > 1:
             # Re-order axes so they correspond to diagonals at axis1, axis2


### PR DESCRIPTION
Currently, running the following code

```python
import theano.tensor as T
x = T.as_tensor_variable([1., 2., 3.])
mat = T.AllocDiag()(x)
print(mat.eval())
```

runs as expected but triggers a `FutureWarning` from `numpy`:

```
/anaconda3/lib/python3.7/site-packages/theano/tensor/basic.py:6611: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  result[diagonal_slice] = x
[[1. 0. 0.]
 [0. 2. 0.]
 [0. 0. 3.]]
```

Simply casting `diagonal_slice` to `tuple` returns the correct output but eliminates the warning.