### PR TITLE
Eliminate FutureWarning

### DIFF
--- a/theano/tensor/subtensor.py
+++ b/theano/tensor/subtensor.py
@@ -2194,7 +2194,7 @@ class BaseAdvancedSubtensor(Op):
     def perform(self, node, inputs, out_):
         out, = out_
         check_advanced_indexing_dimensions(inputs[0], inputs[1:])
-        rval = inputs[0].__getitem__(inputs[1:])
+        rval = inputs[0].__getitem__(tuple(inputs[1:]))
         # When there are no arrays, we are not actually doing advanced
         # indexing, so __getitem__ will not return a copy.
         # Since no view_map is set, we need to copy the returned value


### PR DESCRIPTION
This PR is very similar to #6703. Currently, running the following code

```python
import theano.tensor as T
x = T.as_tensor_variable([1., 2., 3.])
print(x[x > 1].eval())
```

runs as expected but triggers a `FutureWarning` from `numpy`:

```
/anaconda3/lib/python3.7/site-packages/theano/tensor/basic.py:6611: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
    rval = inputs[0].__getitem__(inputs[1:])
[2. 3.]
```

Casting `inputs[1:]` to `tuple` returns the correct output but eliminates the warning.