### PR TITLE
Fix deprecation warning.

### DIFF
--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -465,7 +465,7 @@ class _tensor_py_operators(object):
                     (hasattr(args_el, 'dtype') and args_el.dtype == 'bool')):
                 return True
             if (not isinstance(args_el, theano.tensor.Variable) and
-                    isinstance(args_el, collections.Iterable)):
+                    isinstance(args_el, collections.abc.Iterable)):
                 for el in args_el:
                     if includes_bool(el):
                         return True

--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function, division
 try:
     from collections.abc import Iterable
-except AttributeError:
+except (ImportError, AttributeError):
     from collections import Iterable
 import copy
 import traceback as tb

--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import, print_function, division
-import collections
+try:
+    from collections.abc import Iterable
+except AttributeError:
+    from collections import Iterable
 import copy
 import traceback as tb
 import warnings
@@ -465,7 +468,7 @@ class _tensor_py_operators(object):
                     (hasattr(args_el, 'dtype') and args_el.dtype == 'bool')):
                 return True
             if (not isinstance(args_el, theano.tensor.Variable) and
-                    isinstance(args_el, collections.abc.Iterable)):
+                    isinstance(args_el, Iterable)):
                 for el in args_el:
                     if includes_bool(el):
                         return True


### PR DESCRIPTION
Change the import of `Iterable` from `collections.Iterable` to `collections.abc.Iterable` to future-proof against Python 3.7.8.

Caught this warning when running the PyMC3 tests.