### PR TITLE
use string_types instead of str in get_substream_rstates dtype assertion

### DIFF
--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, print_function, division
 import warnings
 
 import numpy as np
-from six import integer_types
+from six import integer_types, string_types
 from six.moves import xrange
 
 import theano
@@ -768,7 +768,7 @@ class MRG_RandomStreams(object):
         and they are spaced by 2**72 samples.
 
         """
-        assert isinstance(dtype, str)
+        assert isinstance(dtype, string_types)
         assert n_streams < 2**72
         assert n_streams > 0
         rval = np.zeros((n_streams, 6), dtype='int32')


### PR DESCRIPTION
Using Theano 1.0.4 via Keras 2.2.5 under Python 2.7.12, calling `keras.model.model_from_json()` for model deserialization fails at this assertion in theano at `get_substream_rstates` because `json.loads()` as called by Keras is returning a dict with unicode objects as values. This PR fixes the problem.