### PR TITLE
Adapt to changed ceil, floor, and trunc ufuncs in numpy 1.17.0.

### DIFF
--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -247,6 +247,15 @@ class _tensor_py_operators(object):
     def __rpow__(self, other):
         return theano.tensor.basic.pow(other, self)
 
+    def __ceil__(self):
+        return theano.tensor.ceil(self)
+
+    def __floor__(self):
+        return theano.tensor.floor(self)
+
+    def __trunc__(self):
+        return theano.tensor.trunc(self)
+
     # TRANSPOSE
     T = property(lambda self: theano.tensor.basic.transpose(self))
 


### PR DESCRIPTION
Resolves this error:
```
ERROR: theano.tensor.tests.test_var.test_numpy_method
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/builddir/build/BUILD/Theano-rel-1.0.4/theano/tensor/tests/test_var.py", line 23, in test_numpy_method
    y = fct(x)
TypeError: must be real number, not TensorVariable
```