### PR TITLE
Remove restrictive type assertion

### DIFF
--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -166,8 +166,7 @@ class NumpyAutocaster(object):
 
     def __call__(self, x):
         # Make sure we only deal with scalars.
-        assert (isinstance(x, six.integer_types) or
-                isinstance(x, builtin_float) or
+        assert (isinstance(x, (six.integer_types, builtin_float)) or
                 (isinstance(x, np.ndarray) and x.ndim == 0))
 
         if config.cast_policy == 'numpy':
@@ -281,7 +280,7 @@ def convert(x, dtype=None):
             x_ = np.asarray(x)
             if x_.size == 0 and not hasattr(x, 'dtype'):
                 x_ = np.asarray(x, dtype=config.floatX)
-    assert type(x_) in [np.ndarray, np.memmap]
+    assert issubclass(type(x_), (np.ndarray, np.memmap))
     return x_
 
 


### PR DESCRIPTION
An overly restrictive `assert` in [`theano/scalar/basic.py`](https://github.com/theano/Theano/blob/master/theano/scalar/basic.py#L284) prevents the use of `ndarray` subclasses.  This PR simply updates the `assert` so that it considers subclasses.