### PR TITLE
DOC: Allow building with Sphinx >= 2.0

### DIFF
--- a/doc/scripts/docgen.py
+++ b/doc/scripts/docgen.py
@@ -60,6 +60,7 @@ if __name__ == '__main__':
 
     def call_sphinx(builder, workdir):
         import sphinx
+        import sphinx.cmd.build
         if options['--check']:
             extraopts = ['-W']
         else:
@@ -70,7 +71,7 @@ if __name__ == '__main__':
         inopt = [docpath, workdir]
         if files is not None:
             inopt.extend(files)
-        ret = sphinx.build_main(['', '-b', builder] + extraopts + inopt)
+        ret = sphinx.cmd.build.build_main(['-b', builder] + extraopts + inopt)
         if ret != 0:
             sys.exit(ret)
 

--- a/doc/scripts/docgen.py
+++ b/doc/scripts/docgen.py
@@ -60,7 +60,6 @@ if __name__ == '__main__':
 
     def call_sphinx(builder, workdir):
         import sphinx
-        import sphinx.cmd.build
         if options['--check']:
             extraopts = ['-W']
         else:
@@ -71,7 +70,14 @@ if __name__ == '__main__':
         inopt = [docpath, workdir]
         if files is not None:
             inopt.extend(files)
-        ret = sphinx.cmd.build.build_main(['-b', builder] + extraopts + inopt)
+        try:
+            import sphinx.cmd.build
+            ret = sphinx.cmd.build.build_main(
+                ['-b', builder] + extraopts + inopt)
+        except ImportError:
+            # Sphinx < 1.7 - build_main drops first argument
+            ret = sphinx.build_main(
+                ['', '-b', builder] + extraopts + inopt)
         if ret != 0:
             sys.exit(ret)
 


### PR DESCRIPTION
Needed as build_main is no longer top-level:
https://www.sphinx-doc.org/en/master/extdev/deprecated.html
https://bugs.debian.org/955065