### PR TITLE
MAINT: Avoid SyntaxWarnings on import in Python 3.8

### DIFF
--- a/theano/compile/mode.py
+++ b/theano/compile/mode.py
@@ -261,7 +261,7 @@ class Mode(object):
     def __init__(self, linker=None, optimizer='default'):
         if linker is None:
             linker = config.linker
-        if optimizer is 'default':
+        if type(optimizer)==str and optimizer == 'default':
             optimizer = config.optimizer
         Mode.__setstate__(self, (linker, optimizer))
 

--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -1540,12 +1540,12 @@ class COp(Op):
         undef_macros = []
 
         for i, inp in enumerate(inputs):
-            define_macros.append("#define INPUT_%d %s" (i, inp))
-            undef_macros.append("#undef INPUT_%d", (i,))
+            define_macros.append("#define INPUT_%d %s" % (i, inp))
+            undef_macros.append("#undef INPUT_%d" % (i,))
 
         for i, out in enumerate(outputs):
-            define_macros.append("#define OUTPUT_%d %s" (i, inp))
-            undef_macros.append("#undef OUTPUT_%d", (i,))
+            define_macros.append("#define OUTPUT_%d %s" % (i, inp))
+            undef_macros.append("#undef OUTPUT_%d" % (i,))
 
     def c_init_code_struct(self, node, name, sub):
         """

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -1284,7 +1284,7 @@ def local_optimizer(tracks, inplace=False, requirements=()):
 
         """
         if tracks is not None:
-            if len(tracks) is 0:
+            if len(tracks) == 0:
                 raise ValueError("Use None instead of an empty list to apply to all nodes.", f.__module__, f.__name__)
             for t in tracks:
                 if not (isinstance(t, op.Op) or issubclass(t, op.PureOp)):

--- a/theano/gof/tests/test_link.py
+++ b/theano/gof/tests/test_link.py
@@ -113,7 +113,7 @@ class TestPerformLinker(unittest.TestCase):
     def test_input_output_same(self):
         x, y, z = inputs()
         fn = perform_linker(FunctionGraph([x], [x])).make_function()
-        assert 1.0 is fn(1.0)
+        assert 1.0 == fn(1.0)
 
     def test_input_dependency0(self):
         x, y, z = inputs()

--- a/theano/tensor/nnet/bn.py
+++ b/theano/tensor/nnet/bn.py
@@ -642,7 +642,7 @@ class AbstractBatchNormTrainGrad(Op):
         # some inputs should be disconnected
         results = [g_wrt_x, g_wrt_dy, g_wrt_scale, g_wrt_x_mean, g_wrt_x_invstd,
                    theano.gradient.DisconnectedType()()]
-        return [theano.gradient.DisconnectedType()() if r is 0 else r
+        return [theano.gradient.DisconnectedType()() if (type(r)==int and r==0) else r
                 for r in results]
 
     def connection_pattern(self, node):

--- a/theano/tensor/nnet/tests/test_conv.py
+++ b/theano/tensor/nnet/tests/test_conv.py
@@ -95,7 +95,7 @@ class TestConv2D(utt.InferShapeTester):
         # REFERENCE IMPLEMENTATION
         s = 1.
         orig_image_data = image_data
-        if border_mode is not 'full':
+        if border_mode != 'full':
             s = -1.
         out_shape2d = np.array(N_image_shape[-2:]) +\
             s * np.array(N_filter_shape[-2:]) - s

--- a/theano/tests/test_determinism.py
+++ b/theano/tests/test_determinism.py
@@ -57,7 +57,7 @@ def test_determinism_1():
             updates.append((s, val))
 
         for var in theano.gof.graph.ancestors(update for _, update in updates):
-            if var.name is not None and var.name is not 'b':
+            if var.name is not None and var.name != 'b':
                 if var.name[0] != 's' or len(var.name) != 2:
                     var.name = None
 


### PR DESCRIPTION
get_io_macros is still broken after this (it doesn't return its results),
but as nobody else seems to have noticed it's probably unused

The "is vs ==" ones don't seem to be a problem in practice,
but let's not scare the user unnecessarily

https://bugs.debian.org/950463