### PR TITLE
MAINT: Be compatible with numpy 1.17 and scipy 1.3

### DIFF
--- a/doc/library/tensor/basic.txt
+++ b/doc/library/tensor/basic.txt
@@ -552,7 +552,7 @@ TensorVariable
     .. method:: nonzero_values(self)
     .. method:: sort(self, axis=-1, kind='quicksort', order=None)
     .. method:: argsort(self, axis=-1, kind='quicksort', order=None)
-    .. method:: clip(self, a_min, a_max)
+    .. method:: clip(self, a_min, a_max) with a_min <= a_max
     .. method:: conf()
     .. method:: repeat(repeats, axis=None)
     .. method:: round(mode="half_away_from_zero")
@@ -1349,6 +1349,9 @@ Condition
     `max` clipped to `max` and all elements less than `min` clipped to `min`.
 
     Normal broadcasting rules apply to each of `x`, `min`, and `max`.
+
+    Note that there is no warning for inputs that are the wrong way round
+    (`min > max`), and that results in this case may differ from ``numpy.clip``.
 
 Bit-wise
 --------

--- a/theano/gof/tests/test_compute_test_value.py
+++ b/theano/gof/tests/test_compute_test_value.py
@@ -288,9 +288,10 @@ class TestComputeTestValue(unittest.TestCase):
                 frame_infos = traceback.extract_tb(tb)
                 # We should be in the "fx" function defined above
                 expected = 'test_compute_test_value.py'
-                assert any((os.path.split(frame_info[0])[1] == expected
-                            and frame_info[2] == 'fx') for frame_info
-                            in frame_infos), frame_infos
+                assert any((os.path.split(
+                    frame_info[0])[1] == expected and
+                    frame_info[2] == 'fx') for frame_info in
+                    frame_infos), frame_infos
 
         finally:
             theano.config.compute_test_value = orig_compute_test_value

--- a/theano/gof/tests/test_compute_test_value.py
+++ b/theano/gof/tests/test_compute_test_value.py
@@ -285,12 +285,12 @@ class TestComputeTestValue(unittest.TestCase):
             except ValueError:
                 # Get traceback
                 tb = sys.exc_info()[2]
-                # Get frame info 4 layers up
-                frame_info = traceback.extract_tb(tb)[-5]
+                frame_infos = traceback.extract_tb(tb)
                 # We should be in the "fx" function defined above
                 expected = 'test_compute_test_value.py'
-                assert os.path.split(frame_info[0])[1] == expected, frame_info
-                assert frame_info[2] == 'fx'
+                assert any((os.path.split(frame_info[0])[1] == expected
+                            and frame_info[2] == 'fx') for frame_info
+                            in frame_infos), frame_infos
 
         finally:
             theano.config.compute_test_value = orig_compute_test_value

--- a/theano/sparse/tests/test_basic.py
+++ b/theano/sparse/tests/test_basic.py
@@ -160,7 +160,15 @@ def sparse_random_inputs(format, shape, n=1, out_dtype=None, p=0.5, gap=None,
     if unsorted_indices:
         for idx in range(n):
             d = data[idx]
-            d = d[list(range(d.shape[0]))]
+            # these flip the matrix, but it's random anyway
+            if format == 'csr':
+                d = scipy.sparse.csr_matrix(
+                    (d.data, d.shape[1] - 1 - d.indices, d.indptr),
+                    shape=d.shape)
+            if format == 'csc':
+                d = scipy.sparse.csc_matrix(
+                    (d.data, d.shape[0] - 1 - d.indices, d.indptr),
+                    shape=d.shape)
             assert not d.has_sorted_indices
             data[idx] = d
     if explicit_zero:

--- a/theano/tensor/sort.py
+++ b/theano/tensor/sort.py
@@ -45,6 +45,10 @@ class SortOp(theano.Op):
     def perform(self, node, inputs, output_storage):
         a = inputs[0]
         axis = inputs[1]
+        if axis is not None:
+            if axis != int(axis):
+                raise ValueError("sort axis must be an integer or None")
+            axis = int(axis)
         z = output_storage[0]
         z[0] = np.sort(a, axis, self.kind, self.order)
 
@@ -172,6 +176,10 @@ class ArgSortOp(theano.Op):
     def perform(self, node, inputs, output_storage):
         a = inputs[0]
         axis = inputs[1]
+        if axis is not None:
+            if axis != int(axis):
+                raise ValueError("sort axis must be an integer or None")
+            axis = int(axis)
         z = output_storage[0]
         z[0] = theano._asarray(np.argsort(a, axis, self.kind, self.order),
                                dtype=node.outputs[0].dtype)

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -2835,7 +2835,7 @@ ClipTester = makeTester(
               correct6=(randint(5, 5).astype('int64'),
                         np.array(-1, dtype='int64'),
                         np.array(1, dtype='int64')),
-              # min > max case removed as numpy has changed
+              # min > max case moved below as numpy has changed
               correct8=(randint(0, 5).astype('uint8'),
                         np.array(2, dtype='uint8'),
                         np.array(4, dtype='uint8')),
@@ -2843,6 +2843,18 @@ ClipTester = makeTester(
                         np.array(2, dtype='uint16'),
                         np.array(4, dtype='uint16')),)
     # I can't think of any way to make this fail at runtime
+    )
+
+
+# min > max case - numpy.clip has changed but we haven't
+# https://github.com/Theano/Theano/issues/6715
+BackwardsClipTester = makeTester(
+    name='BackwardsClipTester',
+    op=clip,
+    expected=lambda x, y, z: np.where(x < y, y, np.minimum(x, z)),
+    good=dict(correct7=((5 * rand(5, 5)).astype('float64'),
+                        np.array(1, dtype='float64'),
+                        np.array(-1, dtype='float64')),)
     )
 
 

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -2835,11 +2835,7 @@ ClipTester = makeTester(
               correct6=(randint(5, 5).astype('int64'),
                         np.array(-1, dtype='int64'),
                         np.array(1, dtype='int64')),
-              # min > max. messed up behaviour, but
-              # should be same as NumPy's
-              correct7=((5 * rand(5, 5)).astype('float64'),
-                        np.array(1, dtype='float64'),
-                        np.array(-1, dtype='float64')),
+              # min > max case removed as numpy has changed
               correct8=(randint(0, 5).astype('uint8'),
                         np.array(2, dtype='uint8'),
                         np.array(4, dtype='uint8')),

--- a/theano/tensor/tests/test_raw_random.py
+++ b/theano/tensor/tests/test_raw_random.py
@@ -678,10 +678,10 @@ class T_random_function(utt.InferShapeTester):
         numpy_val1c = as_floatX(numpy_rng.uniform(low=[-4.], high=[-1]))
         assert np.all(val0c == numpy_val0c)
         assert np.all(val1c == numpy_val1c)
-        self.assertRaises(ValueError, fc, post1c, [-4., -2], [-1, 0], [1])
+        #self.assertRaises(ValueError, fc, post1c, [-4., -2], [-1, 0], [1])
         self.assertRaises(ValueError, fc, post1c, [-4., -2], [-1, 0], [1, 2])
         self.assertRaises(ValueError, fc, post1c, [-4., -2], [-1, 0], [2, 1])
-        self.assertRaises(ValueError, fc, post1c, [-4., -2], [-1], [1])
+        #self.assertRaises(ValueError, fc, post1c, [-4., -2], [-1], [1])
         # TODO: do we want that?
         #self.assertRaises(ValueError, fc, post1c, [-4., -2], [-1], [2])
 

--- a/theano/tensor/tests/test_shared_randomstreams.py
+++ b/theano/tensor/tests/test_shared_randomstreams.py
@@ -466,10 +466,10 @@ class T_SharedRandomStreams(unittest.TestCase):
         numpy_val1c = numpy_rng.uniform(low=[-4.], high=[-1])
         assert np.all(val0c == numpy_val0c)
         assert np.all(val1c == numpy_val1c)
-        self.assertRaises(ValueError, fc, [-4., -2], [-1, 0], [1])
+        #self.assertRaises(ValueError, fc, [-4., -2], [-1, 0], [1])
         self.assertRaises(ValueError, fc, [-4., -2], [-1, 0], [1, 2])
         self.assertRaises(ValueError, fc, [-4., -2], [-1, 0], [2, 1])
-        self.assertRaises(ValueError, fc, [-4., -2], [-1], [1])
+        #self.assertRaises(ValueError, fc, [-4., -2], [-1], [1])
         # TODO: do we want that?
         #self.assertRaises(ValueError, fc, [-4., -2], [-1], [2])
 

--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -247,6 +247,15 @@ class _tensor_py_operators(object):
     def __rpow__(self, other):
         return theano.tensor.basic.pow(other, self)
 
+    def __ceil__(self):
+        return theano.tensor.ceil(self)
+
+    def __floor__(self):
+        return theano.tensor.floor(self)
+
+    def __trunc__(self):
+        return theano.tensor.trunc(self)
+
     # TRANSPOSE
     T = property(lambda self: theano.tensor.basic.transpose(self))
 


### PR DESCRIPTION
Fixes #6715 and most of #6719 (= [Debian 955471](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=955471)).  Includes and supersedes #6721.

Tested (affected tests, not a full run) in:
- Debian unstable (Python 3.8, numpy 1.17, scipy 1.3)
- Debian stable (Python 3.7, numpy 1.16, scipy 1.1)

ClipTester: As noted in #6715, numpy changed its behaviour when min > max, but theano didn't.  Removed the test of this case, but not warning for it because clip is a scalar op and we don't want a warning for every entry of a large matrix.

random test_vector_args (both instances): numpy, and hence theano, now accepts size=(1,) even if low/high aren't scalars.  Removed test cases that assume it doesn't.

sparse (both instances): Only a problem with the test setup - the method it used to use for producing a non-index-sorted test matrix now produces an index-sorted matrix.  Switched to a different setup method.

TestComputeTestValue: As previously noted, test was looking at the wrong stack level.  Switched to checking all stack levels to be compatible with both versions.

sort (both instances): numpy now enforces that sort axes are of integer type, not just integer value.  Added a check for integer value then cast to int.

test_numpy_method: Fix taken from #6721.