### PR TITLE
Fix collections warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ Theano.suo
 .ropeproject
 core
 .idea
+.python-version

--- a/bin/theano_nose.py
+++ b/bin/theano_nose.py
@@ -23,6 +23,7 @@ import os
 import nose
 import textwrap
 import sys
+import warnings
 from nose.plugins import Plugin
 
 def main_function():
@@ -59,7 +60,7 @@ def main_function():
     batch_size = None
     if len(batch_args):
         if len(batch_args) > 1:
-            _logger.warn(
+            _logger.warning(
                 'Multiple --batch arguments detected, using the last one '
                 'and ignoring the first ones.')
 
@@ -103,7 +104,7 @@ def main_function():
             from numpy.testing.noseclasses import KnownFailure
             addplugins.append(KnownFailure())
         except ImportError:
-            _logger.warn(
+            _logger.warning(
                 'KnownFailure plugin from NumPy could not be imported. '
                 'Use --without-knownfailure to disable this warning.')
     else:
@@ -125,7 +126,7 @@ def main_function():
     except TypeError as e:
         if "got an unexpected keyword argument 'addplugins'" in e.message:
             # This means nose is too old and does not support plugins
-            _logger.warn(
+            _logger.warning(
                 'KnownFailure plugin from NumPy can\'t'
                 ' be used as nosetests is too old. '
                 'Use --without-knownfailure to disable this warning.')
@@ -204,6 +205,8 @@ def main():
     if '--help' in sys.argv or '-h' in sys.argv:
         help()
     else:
+        warnings.simplefilter("default")  # Enable warnings before importing theano
+        os.environ["PYTHONWARNINGS"] = "default"  # Also affect subprocesses
         result = main_function()
         sys.exit(result)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+# pip install --upgrade pip setuptools virtualenv virtualenvwrapper virtualenv-clone wheel
+# pip install -r requirements.txt && pyenv rehash
+
+# mpi4py
+nose
+numpy
+parameterized
+reindent
+requests
+scipy
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # pip install --upgrade pip setuptools virtualenv virtualenvwrapper virtualenv-clone wheel
 # pip install -r requirements.txt && pyenv rehash
 
+cython
 # mpi4py
 nose
 numpy
@@ -9,3 +10,4 @@ reindent
 requests
 scipy
 six
+sympy

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 """
 NAME                = 'Theano'
 MAINTAINER          = "LISA laboratory, University of Montreal"

--- a/theano/compat/__init__.py
+++ b/theano/compat/__init__.py
@@ -11,13 +11,13 @@ try:
     from collections.abc import (Callable, Iterable, Mapping, ValuesView,
                                  MutableMapping as DictMixin)
 except ImportError:
-    # this raises an DeprecationWarning on py37 and will become
-    # and Exception in py39. Importing from collections.abc
-    # won't work on py27
+    # This raises a DeprecationWarning in py3.7 that will become an Exception in
+    # py3.10 although the scary warning still says "in 3.9 it will stop working".
+    # Importing from collections.abc won't work on py2.7.
     from collections import (Callable, Iterable, Mapping, ValuesView,
                              MutableMapping as DictMixin)
 
-__all__ = ['PY3', 'b', 'BytesIO', 'next', 'configparser', 'reload']
+__all__ = ['PY3', 'b', 'BytesIO', 'Callable', 'next', 'configparser', 'reload']
 
 if PY3:
     from operator import truediv as operator_div

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -15,7 +15,7 @@ from theano.gradient import DisconnectedType
 
 
 class OpFromGraph(gof.Op):
-    """
+    r"""
     This creates an ``Op`` from inputs and outputs lists of variables.
     The signature is similar to :func:`theano.function <theano.function>`
     and the resulting ``Op``'s perform will do the same operation as::

--- a/theano/compile/debugmode.py
+++ b/theano/compile/debugmode.py
@@ -1910,6 +1910,7 @@ class _Linker(gof.link.LocalLinker):
                         if thunk_py:
                             dmap = getattr(node.op, 'destroy_map', {})
                             vmap = getattr(node.op, 'view_map', {})
+                            # FIXME: This overwrites the outer loop variable `i`.
                             for i, r in enumerate(node.inputs):
                                 # if thunk_py ran, and we still got
                                 # this far, it means that the

--- a/theano/compile/function.py
+++ b/theano/compile/function.py
@@ -243,7 +243,7 @@ def function(inputs, outputs=None, mode=None, updates=None, givens=None,
 
     if name is None:
         # Determine possible file names
-        source_file = re.sub('\.pyc?', '.py', __file__)
+        source_file = re.sub(r'\.pyc?', '.py', __file__)
         compiled_file = source_file + 'c'
 
         stack = tb.extract_stack()

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -1827,7 +1827,7 @@ AddConfigVar("compiledir_format",
 
 def default_compiledirname():
     formatted = theano.config.compiledir_format % compiledir_format_dict
-    safe = re.sub("[\(\)\s,]+", "_", formatted)
+    safe = re.sub(r"[()\s,]+", "_", formatted)
     return safe
 
 

--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -2393,8 +2393,8 @@ class GCC_compiler(Compiler):
             not_found_libraries = re.findall('-l["."-_a-zA-Z0-9]*', compile_stderr)
             for nf_lib in not_found_libraries:
                 print('library ' + nf_lib[2:] + ' is not found.')
-                if re.search('-lPYTHON["."0-9]*', nf_lib, re.IGNORECASE):
-                    py_string = re.search('-lpython["."0-9]*', nf_lib, re.IGNORECASE).group()[8:]
+                if re.search('-lPYTHON[".0-9]*', nf_lib, re.IGNORECASE):
+                    py_string = re.search('-lpython[".0-9]*', nf_lib, re.IGNORECASE).group()[8:]
                     if py_string != '':
                         print(
                             'Check if package python-dev ' + py_string + ' or python-devel ' + py_string + ' is installed.'

--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -1596,6 +1596,7 @@ class COp(Op):
 
                 def_macros, undef_macros = self.get_c_macros(node, name)
                 def_sub, undef_sub = self.get_sub_macros(sub)
+                # FIXME: get_io_macros() doesn't return anything. Unpacking will raise a TypeError.
                 def_io, undef_io = self.get_io_macros(inp, out)
 
                 return '\n'.join([def_macros, def_sub, def_io,
@@ -1614,6 +1615,7 @@ class COp(Op):
 
             def_macros, undef_macros = self.get_c_macros(node, name)
             def_sub, undef_sub = self.get_sub_macros(sub)
+            # FIXME: get_io_macros() doesn't return anything. Unpacking will raise a TypeError.
             def_io, undef_io = self.get_io_macros(inputs, outputs)
 
             return '\n'.join([def_macros, def_sub, def_io,

--- a/theano/gof/unify.py
+++ b/theano/gof/unify.py
@@ -322,7 +322,7 @@ def unify_walk(a, b, U):
 
 @comm_guard(OrVariable, NotVariable)  # noqa
 def unify_walk(o, n, U):
-    """
+    r"""
     OrV(list1) == NV(list2) == OrV(list1 \ list2)
 
     """

--- a/theano/gof/utils.py
+++ b/theano/gof/utils.py
@@ -307,7 +307,7 @@ def uniq(seq):
 
 
 def difference(seq1, seq2):
-    """
+    r"""
     Returns all elements in seq1 which are not in seq2: i.e ``seq1\seq2``.
 
     """

--- a/theano/gpuarray/tests/test_subtensor.py
+++ b/theano/gpuarray/tests/test_subtensor.py
@@ -321,7 +321,7 @@ class test_gpuextractdiag(unittest.TestCase):
 
 class TestGpuAllocDiag(test_basic.TestAllocDiag):
     def __init__(self, name):
-        return test_basic.TestAllocDiag.__init__(
+        test_basic.TestAllocDiag.__init__(
             self, name,
             alloc_diag=GpuAllocDiag,
             mode=mode_with_gpu

--- a/theano/tensor/nlinalg.py
+++ b/theano/tensor/nlinalg.py
@@ -75,7 +75,7 @@ pinv = MatrixPinv()
 
 
 class MatrixInverse(Op):
-    """Computes the inverse of a matrix :math:`A`.
+    r"""Computes the inverse of a matrix :math:`A`.
 
     Given a square matrix :math:`A`, ``matrix_inverse`` returns a square
     matrix :math:`A_{inv}` such that the dot product :math:`A \cdot A_{inv}`
@@ -149,7 +149,7 @@ matrix_inverse = MatrixInverse()
 
 
 def matrix_dot(*args):
-    """ Shorthand for product between several dots.
+    r""" Shorthand for product between several dots.
 
     Given :math:`N` matrices :math:`A_0, A_1, .., A_N`, ``matrix_dot`` will
     generate the matrix product between all in the given order, namely

--- a/theano/tensor/nnet/conv.py
+++ b/theano/tensor/nnet/conv.py
@@ -157,7 +157,7 @@ def conv2d(input, filters, image_shape=None, filter_shape=None,
 
 
 class ConvOp(OpenMPOp):
-    """
+    r"""
     This Op serves a dual purpose: it can implement a vanilla 2D convolution
     (as taught in any signal processing class) or implement the
     convolutional layers found in Convolutional Neural Networks.

--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -409,7 +409,7 @@ softmax_grad = SoftmaxGrad()
 
 
 class Softmax(gof.Op):
-    """
+    r"""
     Softmax activation function
     :math:`\\varphi(\\mathbf{x})_j =
     \\frac{e^{\mathbf{x}_j}}{\sum_{k=1}^K e^{\mathbf{x}_k}}`
@@ -600,7 +600,7 @@ softmax_op = Softmax()
 
 
 class LogSoftmax(gof.Op):
-    """
+    r"""
     LogSoftmax activation function
     :math:`\\varphi(\\mathbf{x})_j =
     \\e^{(\mathbf{x}_j - log{\sum_{k=1}^K e^{\mathbf{x}_k})}}
@@ -1412,7 +1412,7 @@ crossentropy_categorical_1hot_grad = CrossentropyCategorical1HotGrad()
 
 
 class CrossentropyCategorical1Hot(gof.Op):
-    """
+    r"""
     Compute the cross entropy between a coding distribution and
     a true distribution of the form [0, 0, ... 0, 1, 0, ..., 0].
 
@@ -2051,7 +2051,7 @@ def sigmoid_binary_crossentropy(output, target):
 
 
 def categorical_crossentropy(coding_dist, true_dist):
-    """
+    r"""
     Return the cross-entropy between an approximating distribution and a true
     distribution.
 

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -4613,9 +4613,9 @@ class Canonizer(gof.LocalOptimizer):
     --------
     >>> import theano.tensor as T
     >>> from theano.tensor.opt import Canonizer
-    >>> add_canonizer = Canonizer(T.add, T.sub, T.neg, \\
+    >>> add_canonizer = Canonizer(T.add, T.sub, T.neg, \
     ...                           lambda n, d: sum(n) - sum(d))
-    >>> mul_canonizer = Canonizer(T.mul, T.true_div, T.inv, \\
+    >>> mul_canonizer = Canonizer(T.mul, T.true_div, T.inv, \
     ...                           lambda n, d: prod(n) / prod(d))
 
     Examples of optimizations mul_canonizer can perform:

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -4582,7 +4582,7 @@ register_canonicalize(gof.OpRemove(T.tensor_copy), name='remove_tensor_copy')
 
 
 class Canonizer(gof.LocalOptimizer):
-    """
+    r"""
     Simplification tool. The variable is a local_optimizer. It is best used
     with a TopoOptimizer in in_to_out order.
 
@@ -4650,7 +4650,7 @@ class Canonizer(gof.LocalOptimizer):
         return [self.main, self.inverse, self.reciprocal]
 
     def get_num_denum(self, input):
-        """
+        r"""
         This extract two lists, num and denum, such that the input is:
         self.inverse(self.main(\*num), self.main(\*denum)). It returns
         the two lists in a (num, denum) pair.
@@ -4751,7 +4751,7 @@ class Canonizer(gof.LocalOptimizer):
         return num, denum
 
     def merge_num_denum(self, num, denum):
-        """
+        r"""
         Utility function which takes two lists, num and denum, and
         returns something which is equivalent to inverse(main(\*num),
         main(\*denum)), but depends on the length of num and the length

--- a/theano/tensor/subtensor.py
+++ b/theano/tensor/subtensor.py
@@ -1932,7 +1932,7 @@ class AdvancedIncSubtensor1(Op):
             raise TypeError(
                 'cannot %s x subtensor with ndim=%s'
                 ' by y with ndim=%s to x subtensor with ndim=%s ' % (
-                    opname, x_.type.ndim, y_.type.ndim))
+                    opname, x_.type.ndim, y_.type.ndim, '?'))  # FIXME: too few args for format string
 
         return Apply(self, [x_, y_, ilist_], [x_.type()])
 

--- a/theano/tensor/tests/mlp_test.py
+++ b/theano/tensor/tests/mlp_test.py
@@ -93,7 +93,7 @@ class LogisticRegression(object):
         self.params = [self.W]
 
     def negative_log_likelihood(self, y):
-        """Return the mean of the negative log-likelihood of the prediction
+        r"""Return the mean of the negative log-likelihood of the prediction
         of this model under a given target distribution.
 
         .. math::

--- a/theano/tensor/tests/test_basic.py
+++ b/theano/tensor/tests/test_basic.py
@@ -7605,7 +7605,7 @@ class TestAllocDiag(unittest.TestCase):
             mode = theano.compile.mode.get_default_mode()
         self.mode = mode
 
-        return super(TestAllocDiag, self).__init__(name)
+        super(TestAllocDiag, self).__init__(name)
 
     def _generator(self):
         dims = 4

--- a/theano/tensor/tests/test_subtensor.py
+++ b/theano/tensor/tests/test_subtensor.py
@@ -80,7 +80,7 @@ class T_subtensor(unittest.TestCase, utt.TestOptimizationMixin):
         self.fast_compile = theano.config.mode == 'FAST_COMPILE'
         self.ops = (sub, inc_sub, adv_sub1, adv_incsub1,
                     adv_bool_sub, adv_bool_inc_sub)
-        return super(T_subtensor, self).__init__(name)
+        super(T_subtensor, self).__init__(name)
 
     def function(self, inputs, outputs, accept_inplace=False,
                  op=None, mode=None, N=1, N_fast=None):


### PR DESCRIPTION
Fixes the scary deprecation warnings that clients see, as mentioned in #6755, and some of the other warnings in the code.

* The `compat/__init__.py` DeprecationWarning about 'collections' was already fixed in 1b9804b65ecd008cfb424752e65aced92b63ff92, not yet on PyPI.
* The `misc/frozendict.py` DeprecationWarning about 'collections' just needed to add `'Callable'` to `__all__` in that module.

For a speedy way to test this fix, make a pyenv virtualenv, use this `requirements.txt` file (my best guess on it) to install pips, and run a limited nose test:

```bash
pip install --upgrade pip setuptools virtualenv virtualenvwrapper virtualenv-clone wheel
pip install -r requirements.txt && pyenv rehash
bin/theano-nose theano/tests/test_config.py
```

I ran the limited and the full `bin/theano-nose` in Python 2.7.18, 3.8.5, and 3.9.0b5. (I tried to run it in Python 3.10-dev but `pip install numpy` failed.) The full test can take 1.5 - 3 hours.

I'm unsure how far to go in this PR on fixing other warnings, but Python 3.9 is stricter about regex patterns so I fixed some problems there.