### PR TITLE
Fix deprecation import nose test

### DIFF
--- a/theano/tests/main.py
+++ b/theano/tests/main.py
@@ -3,13 +3,13 @@ import os
 import unittest
 import sys
 
-from numpy.testing.nosetester import NoseTester
+from numpy.testing import nosetester 
 
 
 # This class contains code adapted from NumPy,
 # numpy/testing/nosetester.py,
 # Copyright (c) 2005-2011, NumPy Developers
-class TheanoNoseTester(NoseTester):
+class TheanoNoseTester(nosetester.NoseTester):
     """
     Nose test runner.
 

--- a/theano/tests/main.py
+++ b/theano/tests/main.py
@@ -3,13 +3,13 @@ import os
 import unittest
 import sys
 
-from numpy.testing import nosetester 
+from numpy.testing import Tester
 
 
 # This class contains code adapted from NumPy,
 # numpy/testing/nosetester.py,
 # Copyright (c) 2005-2011, NumPy Developers
-class TheanoNoseTester(nosetester.NoseTester):
+class TheanoNoseTester(Tester):
     """
     Nose test runner.
 


### PR DESCRIPTION
`theano/tests/main.py` now correctly imports NoseTester as recommended here: https://github.com/numpy/numpy/blob/v1.19.0/numpy/testing/_private/nosetester.py