### PR TITLE
Fix Overly Broad Regular Expression Ranges

### DIFF
--- a/theano/gof/cmodule.py
+++ b/theano/gof/cmodule.py
@@ -2392,7 +2392,7 @@ class GCC_compiler(Compiler):
             tf.write(compile_stderr)
             tf.close()
             print('\nYou can find the C code in this temporary file: ' + tf.name)
-            not_found_libraries = re.findall('-l["."-_a-zA-Z0-9]*', compile_stderr)
+            not_found_libraries = re.findall('-l[a-zA-Z0-9]*', compile_stderr)
             for nf_lib in not_found_libraries:
                 print('library ' + nf_lib[2:] + ' is not found.')
                 if re.search('-lPYTHON[".0-9]*', nf_lib, re.IGNORECASE):


### PR DESCRIPTION
Fixes #6797 

This Pull Request addresses an issue in the theano/gof/cmodule.py file, where some regular expressions had overly broad or overlapping character ranges, leading to potential unintended matches. The problem resides in the re.findall and re.search functions at line 2395.

The specific regular expressions causing the problem are:

    -l["."-_a-zA-Z0-9]* in the re.findall function

The proposed changes in this PR are:

    Change -l["."-_a-zA-Z0-9]* to -l[a-zA-Z0-9]* in the re.findall function

These changes make the regular expressions unambiguous and ensure that they match only the expected characters.

The regex I addressed is -l["."-_a-zA-Z0-9]*, used within a re.findall function. Originally, it had a character range of ["."-_a-zA-Z0-9] which was overly broad, including characters such as quotes and periods, among others. My proposed modification narrows down this range to [a-zA-Z0-9], which means the regex now matches any lowercase or uppercase alphanumeric character. This refines the regex's behavior, ensuring that it will only capture sequences that start with '-l' followed by alphanumeric characters.