### PR TITLE
Solving configparser compatibility issue for python>3.2 

### DIFF
--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -74,7 +74,7 @@ def config_files_from_theanorc():
 
 config_files = config_files_from_theanorc()
 theano_cfg = (ConfigParser.ConfigParser if PY3
-              else ConfigParser.SafeConfigParser)(
+              else ConfigParser.ConfigParser)(
     {'USER': os.getenv("USER", os.path.split(os.path.expanduser('~'))[-1]),
      'LSCRATCH': os.getenv("LSCRATCH", ""),
      'TMPDIR': os.getenv("TMPDIR", ""),

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
since python3.2
configparser no longer has a SafeConfigParser class. Use the shorter ConfigParser
configparser.ConfigParser no longer has a readfp method. Use read_file()
see https://docs.python.org/3/whatsnew/3.12.html

fixed this issue with updated versioneer.py and configparser.py