### PR TITLE
versioneer.py is not compatible with Python3

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -341,7 +341,7 @@ def get_config_from_root(root):
     setup_cfg = os.path.join(root, "setup.cfg")
     parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,7 +339,7 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
         parser.readfp(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory


### PR DESCRIPTION
Change "SafeConfigParser" to "ConfigParser" and  "readfp" to "read_file" for compatibility with Python3
